### PR TITLE
add type: "module" in package.json

### DIFF
--- a/packages/mux-audio/package.json
+++ b/packages/mux-audio/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mux-elements/mux-audio",
   "version": "0.1.1",
+  "type": "module",
   "description": "A custom mux audio element for the browser that Just Works™",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mux-elements/mux-video",
   "version": "0.1.1",
+  "type": "module",
   "description": "A custom mux video element for the browser that Just Works™",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
From [the node.js docs](https://nodejs.org/api/packages.html#packages_package_json_and_file_extensions)

> A package.json "type" value of "module" tells Node.js to interpret .js files within that package as using ES module syntax.

Without this -- Next.js blows up

```
SyntaxError: Unexpected token 'export'
    at wrapSafe (internal/modules/cjs/loader.js:988:16)
    at Module._compile (internal/modules/cjs/loader.js:1036:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
```

With `type: "module"` in the package.json then Next.js correctly recognizes that these packages are exporting ES modules.