### PR TITLE
Feat/ll and beacon support

### DIFF
--- a/packages/mux-video/README.md
+++ b/packages/mux-video/README.md
@@ -73,6 +73,7 @@ Now you are free to use this web component in your HTML, just as you would with 
     env-key="mux-data-env-key"
     metadata-video-title="Big Buck Bunny"
     metadata-viewer-user-id="user-id-1234"
+    stream-type="vod"
     controls
   ></mux-video>
 </body>
@@ -88,6 +89,7 @@ Attributes:
 - `metadata-video-title`: This is an arbitrary title for your video that will be passed in as metadata into Mux Data. Adding a title will give you useful context in your Mux Data dashboard. (optional, but encouraged)
 - `metadata-viewer-user-id`: If you have a logged-in user this should be an anonymized ID value that maps back to the user in your database. Take care to not expose personal identifiable information like names, usernames or email addresses. (optional, but encouraged)
 - `metadata-video-id`: This is an arbitrary ID that should map back to a record of this video in your database. If not provided then the `playback-id` will be used for this value.
+- `stream-type`: Enum value: one of `"vod"` (video on demand), `"live"` (HLS live stream), `"ll-live"` (low latency live). Not strictly required, but preffered so that `<mux-video />` can make optimizations based on the type of stream.
 
 This is the bare bones of metadata that you should provide to the `<mux-video>` element.
 

--- a/packages/mux-video/examples/index.html
+++ b/packages/mux-video/examples/index.html
@@ -20,6 +20,7 @@
       metadata-video-title="Star Wars: Episode 3"
       metadata-viewer-user-id="user-id-6789"
       env-key="mux-data-env-key"
+      stream-type="vod"
       controls
       autoplay
       muted

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -19,7 +19,7 @@
     "build": "npm-run-all build:snowpack build:types"
   },
   "dependencies": {
-    "hls.js": "^1.0.9",
+    "hls.js": "1.0.11",
     "mux-embed": "^4.1.1"
   }
 }

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mux-elements/mux-video",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "A custom mux video element for the browser that Just Works™",
   "main": "dist/index.js",

--- a/packages/mux-video/src/customTypings/mux-embed.d.ts
+++ b/packages/mux-video/src/customTypings/mux-embed.d.ts
@@ -66,6 +66,7 @@ declare module "mux-embed" {
 
   export type Options<M extends Metadata = Metadata> = {
     debug?: boolean;
+    beaconDomain?: string;
     hlsjs?: Hls;
     Hls?: typeof Hls;
     data: M;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2669,6 +2669,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hls.js@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.0.11.tgz#8bc4adf7a80aaaa0378e5e3ad417bb9bb9bea3eb"
+  integrity sha512-KY6WUwtp7v+L4ec5hX6waNB3N0HOGkWfp3r7XcAZtUc6MT6TzbTsH5wYjQTQVQXQ6HVrDGqF2U5ovc+/R4E3lQ==
+
 hls.js@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.0.9.tgz#a3b92a0a2a4cdb3076c09639a8e06463b3a189f5"


### PR DESCRIPTION
* Adds support for stream-type & stream-type-specific hls.js config.
* Adds support for mux-data beaconDomain
* Upgrades to hls.js v1.0.11