### PR TITLE
build/remove-deps: Remove dependencies on mux-embed and hls.js from e…

### DIFF
--- a/packages/mux-audio-react/package.json
+++ b/packages/mux-audio-react/package.json
@@ -35,8 +35,6 @@
   },
   "dependencies": {
     "@mux-elements/playback-core": "*",
-    "hls.js": "1.0.11",
-    "mux-embed": "^4.2.3",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -7,7 +7,7 @@ import {
   MuxMediaProps,
   StreamTypes,
   toMuxVideoURL,
-  Hls,
+  PlaybackEngine,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
 
@@ -42,7 +42,7 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
       toMuxVideoURL(playbackId) ?? outerSrc
     );
 
-    const hlsRef = useRef<Hls | undefined>(undefined);
+    const playbackEngineRef = useRef<PlaybackEngine | undefined>(undefined);
     const innerMediaElRef = useRef<HTMLAudioElement>(null);
 
     const mediaElRef = useCombinedRefs(innerMediaElRef, ref);
@@ -60,12 +60,12 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
         playerSoftwareName,
         playerSoftwareVersion,
       };
-      const nextHlsRef = initialize(
+      const nextPlaybackEngineRef = initialize(
         propsWithState,
         mediaElRef.current,
-        hlsRef.current
+        playbackEngineRef.current
       );
-      hlsRef.current = nextHlsRef;
+      playbackEngineRef.current = nextPlaybackEngineRef;
     }, [src]);
 
     return (

--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -1,4 +1,3 @@
-import Hls from "hls.js";
 import useCombinedRefs from "./use-combined-refs";
 import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
@@ -8,6 +7,7 @@ import {
   MuxMediaProps,
   StreamTypes,
   toMuxVideoURL,
+  Hls,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
 

--- a/packages/mux-audio/package.json
+++ b/packages/mux-audio/package.json
@@ -22,9 +22,7 @@
     "build": "npm-run-all --parallel build:types build:esm build:iife build:cjs"
   },
   "dependencies": {
-    "@mux-elements/playback-core": "*",
-    "hls.js": "1.0.11",
-    "mux-embed": "^4.2.3"
+    "@mux-elements/playback-core": "*"
   },
   "devDependencies": {
     "esbuild": "^0.13.13",

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -1,8 +1,5 @@
 import CustomAudioElement from "./CustomAudioElement";
-import * as mux from "mux-embed";
-import { Options } from "mux-embed";
 
-import Hls from "hls.js";
 import {
   initialize,
   MuxMediaProps,
@@ -11,10 +8,11 @@ import {
   ExtensionMimeTypeMap,
   toMuxVideoURL,
   teardown,
+  Hls,
+  Metadata,
+  mux,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
-
-type Metadata = Partial<Options["data"]>;
 
 /** @TODO make the relationship between name+value smarter and more deriveable (CJP) */
 type AttributeNames = {

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -8,7 +8,7 @@ import {
   ExtensionMimeTypeMap,
   toMuxVideoURL,
   teardown,
-  Hls,
+  PlaybackEngine,
   Metadata,
   mux,
 } from "@mux-elements/playback-core";
@@ -61,7 +61,8 @@ class MuxAudioElement
     ];
   }
 
-  protected __hls?: Hls;
+  // Keeping this named "__hls" since it's exposed for unadvertised "advanced usage" via getter that assumes specifically hls.js (CJP)
+  protected __hls?: PlaybackEngine;
   protected __muxPlayerInitTime: number;
   protected __metadata: Readonly<Metadata> = {};
 
@@ -293,6 +294,10 @@ if (!globalThis.customElements.get("mux-audio")) {
   globalThis.MuxAudioElement = MuxAudioElement;
 }
 
-export { Hls, ExtensionMimeTypeMap as MimeTypes };
+export {
+  PlaybackEngine,
+  PlaybackEngine as Hls,
+  ExtensionMimeTypeMap as MimeTypes,
+};
 
 export default MuxAudioElement;

--- a/packages/mux-video-react/package.json
+++ b/packages/mux-video-react/package.json
@@ -35,8 +35,6 @@
   },
   "dependencies": {
     "@mux-elements/playback-core": "*",
-    "hls.js": "1.0.11",
-    "mux-embed": "^4.2.3",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -7,7 +7,7 @@ import {
   MuxMediaProps,
   StreamTypes,
   toMuxVideoURL,
-  Hls,
+  PlaybackEngine,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
 
@@ -42,7 +42,7 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
       toMuxVideoURL(playbackId) ?? outerSrc
     );
 
-    const hlsRef = useRef<Hls | undefined>(undefined);
+    const playbackEngineRef = useRef<PlaybackEngine | undefined>(undefined);
     const innerMediaElRef = useRef<HTMLVideoElement>(null);
 
     const mediaElRef = useCombinedRefs(innerMediaElRef, ref);
@@ -60,12 +60,12 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
         playerSoftwareName,
         playerSoftwareVersion,
       };
-      const nextHlsRef = initialize(
+      const nextPlaybackEngineRef = initialize(
         propsWithState,
         mediaElRef.current,
-        hlsRef.current
+        playbackEngineRef.current
       );
-      hlsRef.current = nextHlsRef;
+      playbackEngineRef.current = nextPlaybackEngineRef;
     }, [src]);
 
     return (

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -1,4 +1,3 @@
-import Hls from "hls.js";
 import useCombinedRefs from "./use-combined-refs";
 import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
@@ -8,6 +7,7 @@ import {
   MuxMediaProps,
   StreamTypes,
   toMuxVideoURL,
+  Hls,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
 

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -23,9 +23,7 @@
     "build": "npm-run-all --parallel build:types build:esm build:iife build:cjs"
   },
   "dependencies": {
-    "@mux-elements/playback-core": "*",
-    "hls.js": "1.0.11",
-    "mux-embed": "^4.2.3"
+    "@mux-elements/playback-core": "*"
   },
   "devDependencies": {
     "esbuild": "^0.13.13",

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -9,7 +9,7 @@ import {
   toMuxVideoURL,
   teardown,
   Metadata,
-  Hls,
+  PlaybackEngine,
   mux,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
@@ -61,7 +61,8 @@ class MuxVideoElement
     ];
   }
 
-  protected __hls?: Hls;
+  // Keeping this named "__hls" since it's exposed for unadvertised "advanced usage" via getter that assumes specifically hls.js (CJP)
+  protected __hls?: PlaybackEngine;
   protected __muxPlayerInitTime: number;
   protected __metadata: Readonly<Metadata> = {};
 
@@ -310,6 +311,10 @@ if (!globalThis.customElements.get("mux-video")) {
   globalThis.MuxVideoElement = MuxVideoElement;
 }
 
-export { Hls, ExtensionMimeTypeMap as MimeTypes };
+export {
+  PlaybackEngine,
+  PlaybackEngine as Hls,
+  ExtensionMimeTypeMap as MimeTypes,
+};
 
 export default MuxVideoElement;

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -1,8 +1,5 @@
 import CustomVideoElement from "./CustomVideoElement";
-import * as mux from "mux-embed";
-import { Options } from "mux-embed";
 
-import Hls from "hls.js";
 import {
   initialize,
   MuxMediaProps,
@@ -11,10 +8,11 @@ import {
   ExtensionMimeTypeMap,
   toMuxVideoURL,
   teardown,
+  Metadata,
+  Hls,
+  mux,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
-
-type Metadata = Partial<Options["data"]>;
 
 /** @TODO make the relationship between name+value smarter and more deriveable (CJP) */
 type AttributeNames = {

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -5,6 +5,7 @@ import { isKeyOf } from "./util";
 export type ValueOf<T> = T[keyof T];
 
 export type Metadata = Partial<Options["data"]>;
+export type PlaybackEngine = Hls;
 export { mux };
 export { Hls };
 

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -4,6 +4,10 @@ import Hls, { HlsConfig } from "hls.js";
 import { isKeyOf } from "./util";
 export type ValueOf<T> = T[keyof T];
 
+export type Metadata = Partial<Options["data"]>;
+export { mux };
+export { Hls };
+
 export type StreamTypes = {
   VOD: "on-demand";
   LIVE: "live";


### PR DESCRIPTION
…lements. Provide relevant type exports from playback-core.

Per Dylan's callout, removing and refactoring to reduce cross-package dependency version management.

To test, you should be able to do a from scratch install and build of the workspace as a whole and then run any/all of our examples projects.