### PR TITLE
Ignore sublime project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+*.sublime-*


### PR DESCRIPTION
Adds Sublime text projects files to the `.gitignore` file.