### PR TITLE
Make Lerna work in independent mode to publish pks

### DIFF
--- a/README_INTERNAL.md
+++ b/README_INTERNAL.md
@@ -1,5 +1,5 @@
 # Releasing
 
-1. `yarn release`
+1. From the workspace root directory, run `yarn release`
 2. `git push && git push origin --tags`
 3. Create a [new release in GitHub](https://github.com/muxinc/elements/releases) and write a description

--- a/README_INTERNAL.md
+++ b/README_INTERNAL.md
@@ -1,7 +1,5 @@
 # Releasing
 
-1. Bump version in the `package.json`
-1. Rebase and merge changes into `main`
-1. Tag `@mux-elements/{package-name}@{version}` -- for example: `git tag @mux-elements/mux-video@0.1.1 && git push origin --tags`
-1. From the package directory (For example: `packages/mux-video` run `yarn build && npm publish`
-1. Create a new release in GitHub and write a description
+1. `yarn release`
+2. `git push && git push origin --tags`
+3. Create a [new release in GitHub](https://github.com/muxinc/elements/releases) and write a description

--- a/examples/create-react-app-with-typescript/package.json
+++ b/examples/create-react-app-with-typescript/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@mux-elements/mux-video-react": "*",
-    "@mux-elements/mux-audio-react": "*",
+    "@mux-elements/mux-audio-react": "^0.1.0",
+    "@mux-elements/mux-video-react": "^0.2.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/examples/nextjs-with-typescript/package.json
+++ b/examples/nextjs-with-typescript/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mux-elements/mux-video-react": "*",
-    "@mux-elements/mux-audio-react": "*",
+    "@mux-elements/mux-audio-react": "^0.1.0",
+    "@mux-elements/mux-video-react": "^0.2.0",
     "next": "^12.0.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/examples/vanilla-ts-esm/package.json
+++ b/examples/vanilla-ts-esm/package.json
@@ -15,7 +15,7 @@
     "typescript": "^4.5.2"
   },
   "dependencies": {
-    "@mux-elements/mux-audio": "*",
-    "@mux-elements/mux-video": "*"
+    "@mux-elements/mux-audio": "^0.2.0",
+    "@mux-elements/mux-video": "^0.2.0"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
   "packages": ["packages/*", "examples/*"],
   "npmClient": "yarn",
+  "useWorkspaces": true,
   "version": "independent"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "packages": ["packages/*", "examples/*"],
   "npmClient": "yarn",
-  "version": "0.0.0"
+  "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "dev": "lerna run dev --parallel --ignore demo-*",
     "build": "lerna run build",
-    "prepare": "husky install && yarn build --ignore demo-*"
+    "prepare": "husky install && yarn build --ignore demo-*",
+    "release": "lerna publish"
   }
 }

--- a/packages/mux-audio-react/package.json
+++ b/packages/mux-audio-react/package.json
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "@mux-elements/playback-core": "*",
+    "@mux-elements/playback-core": "^0.1.0",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/packages/mux-audio-react/package.json
+++ b/packages/mux-audio-react/package.json
@@ -18,7 +18,8 @@
     "dev": "npm-run-all --parallel dev:types dev:cjs",
     "build:cjs": "esbuild src/index.tsx --target=es2019 --minify --bundle --sourcemap --format=cjs --outdir=dist --external:react --external:prop-types --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
-    "build": "npm-run-all --parallel build:types build:cjs"
+    "build": "npm-run-all --parallel build:types build:cjs",
+    "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
     "@types/react": "^16.8.6 || ^17.0.0",

--- a/packages/mux-audio/package.json
+++ b/packages/mux-audio/package.json
@@ -19,7 +19,8 @@
     "build:iife": "esbuild src/index.ts --target=es2019 --bundle --minify --sourcemap --format=iife --outdir=dist --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:cjs": "esbuild src/index.ts --target=es2019 --bundle --minify --sourcemap --format=cjs --outdir=dist --out-extension:.js=.cjs --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
-    "build": "npm-run-all --parallel build:types build:esm build:iife build:cjs"
+    "build": "npm-run-all --parallel build:types build:esm build:iife build:cjs",
+    "prepublishOnly": "yarn build"
   },
   "dependencies": {
     "@mux-elements/playback-core": "^0.1.0"

--- a/packages/mux-audio/package.json
+++ b/packages/mux-audio/package.json
@@ -22,7 +22,7 @@
     "build": "npm-run-all --parallel build:types build:esm build:iife build:cjs"
   },
   "dependencies": {
-    "@mux-elements/playback-core": "*"
+    "@mux-elements/playback-core": "^0.1.0"
   },
   "devDependencies": {
     "esbuild": "^0.13.13",

--- a/packages/mux-video-react/package.json
+++ b/packages/mux-video-react/package.json
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "@mux-elements/playback-core": "*",
+    "@mux-elements/playback-core": "^0.1.0",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/packages/mux-video-react/package.json
+++ b/packages/mux-video-react/package.json
@@ -18,7 +18,8 @@
     "dev": "npm-run-all --parallel dev:types dev:cjs",
     "build:cjs": "esbuild src/index.tsx --target=es2019 --minify --bundle --sourcemap --format=cjs --outdir=dist --external:react --external:prop-types --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
-    "build": "npm-run-all --parallel build:types build:cjs"
+    "build": "npm-run-all --parallel build:types build:cjs",
+    "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
     "@types/react": "^16.8.6 || ^17.0.0",

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -20,7 +20,8 @@
     "build:iife": "esbuild src/index.ts --target=es2019 --bundle --minify --sourcemap --format=iife --outdir=dist --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:cjs": "esbuild src/index.ts --target=es2019 --bundle --minify --sourcemap --format=cjs --outdir=dist --out-extension:.js=.cjs --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
-    "build": "npm-run-all --parallel build:types build:esm build:iife build:cjs"
+    "build": "npm-run-all --parallel build:types build:esm build:iife build:cjs",
+    "prepublishOnly": "yarn build"
   },
   "dependencies": {
     "@mux-elements/playback-core": "^0.1.0"

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -23,7 +23,7 @@
     "build": "npm-run-all --parallel build:types build:esm build:iife build:cjs"
   },
   "dependencies": {
-    "@mux-elements/playback-core": "*"
+    "@mux-elements/playback-core": "^0.1.0"
   },
   "devDependencies": {
     "esbuild": "^0.13.13",

--- a/packages/playback-core/package.json
+++ b/packages/playback-core/package.json
@@ -18,7 +18,8 @@
     "dev": "npm-run-all --parallel dev:types dev:cjs",
     "build:cjs": "esbuild src/index.ts --target=es2019 --minify --bundle --sourcemap --format=cjs --outdir=dist --external:mux-embed --external:hls.js",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
-    "build": "npm-run-all --parallel build:types build:cjs"
+    "build": "npm-run-all --parallel build:types build:cjs",
+    "prepublishOnly": "yarn build"
   },
   "dependencies": {
     "hls.js": "1.0.11",


### PR DESCRIPTION
This will make it easier to publish packages separately, each package will have its own version.
See https://github.com/lerna/lerna#independent-mode

Added 1 npm script in the root `yarn release`, this will call `lerna publish` internally 
https://github.com/lerna/lerna/tree/main/commands/publish#readme

Going from the release step list here
https://github.com/muxinc/elements/blob/main/README_INTERNAL.md

this becomes:

1. **yarn release**
   Lerna will detect changed files of the packages and prompt to cut a new release (patch,minor,major,etc) of that package
   *build* of package will automatically be done by the "prepublishOnly" script, *git tag* is also done automatically
2. **git push && git push --tags**
3. Edit the pushed git tag to release in GitHub and write a description