### PR TITLE
Add prettier config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
-name: "🐛 Bug Report"
+name: '🐛 Bug Report'
 about: Report a reproducible bug or regression.
-title: "Bug: "
-labels: "bug, Status: Unconfirmed"
+title: 'Bug: '
+labels: 'bug, Status: Unconfirmed'
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/docs_request.md
+++ b/.github/ISSUE_TEMPLATE/docs_request.md
@@ -1,8 +1,8 @@
 ---
-name: "📄 Docs Request"
+name: '📄 Docs Request'
 about: Report a discrepancy in or an improvement to the docs.
-title: "Docs: "
-labels: "documentation"
+title: 'Docs: '
+labels: 'documentation'
 ---
 
 <!--
@@ -22,9 +22,9 @@ labels: "documentation"
 
 # Is this a discrepancy or an improvement?
 
-<!-- 
+<!--
   Uncomment all that apply
-  
+
 - discrepancy
 - improvement
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
-name: "🎥 Feature Request"
+name: '🎥 Feature Request'
 about: Create a feature request for one or more Mux Elements, or for a new Mux Element you'd like to see.
-title: "Feature: "
-labels: "enhancement"
+title: 'Feature: '
+labels: 'enhancement'
 ---
 
 <!--

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+build
+coverage
+dist
+node_modules
+examples

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@ coverage
 dist
 node_modules
 examples
+*.sublime-*
+*.vscode*

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,13 @@
 {
-  "trailingComma": "es5",
+  "printWidth": 120,
+  "singleQuote": true,
   "tabWidth": 2,
-  "singleQuote": true
+  "useTabs": false,
+  "semi": true,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "arrowParens": "always"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -8,6 +8,5 @@
   "jsxSingleQuote": false,
   "trailingComma": "es5",
   "bracketSpacing": true,
-  "jsxBracketSameLine": false,
   "arrowParens": "always"
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -35,7 +35,7 @@ coverage:
 
 # adding Flags to your `layout` configuration to show up in the PR comment
 comment:
-  layout: "reach, diff, flags, files"
+  layout: 'reach, diff, flags, files'
   behavior: default
   require_changes: false
   require_base: yes

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "shared/*"
   ],
   "scripts": {
+    "format": "prettier --write .",
     "lint": "lerna run lint --scope @mux-elements/*",
     "test": "lerna run test --scope @mux-elements/*",
     "dev": "lerna run dev --parallel --scope @mux-elements/*",

--- a/packages/mux-audio-react/README.md
+++ b/packages/mux-audio-react/README.md
@@ -30,13 +30,13 @@ npm i @mux-elements/mux-audio-react
 Then, import the library into your application with either `import` or `require`:
 
 ```js
-import "@mux-elements/mux-audio-react";
+import '@mux-elements/mux-audio-react';
 ```
 
 or
 
 ```js
-require("@mux-elements/mux-audio-react");
+require('@mux-elements/mux-audio-react');
 ```
 
 ## Features and benefits
@@ -59,12 +59,12 @@ const MuxAudioExample = () => {
     <div>
       <h1>Simple MuxAudio Example</h1>
       <MuxAudio
-        style={{ height: "100%", maxWidth: "100%" }}
+        style={{ height: '100%', maxWidth: '100%' }}
         playbackId="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
         metadata={{
-          video_id: "audio-id-123456",
-          video_title: "Super Interesting Audio",
-          viewer_user_id: "user-id-bc-789",
+          video_id: 'audio-id-123456',
+          video_title: 'Super Interesting Audio',
+          viewer_user_id: 'user-id-bc-789',
         }}
         envKey="YOUR_MUX_DATA_ENV_KEY"
         streamType="on-demand"
@@ -101,9 +101,9 @@ If you prefer to use the in-code MSE-based engine (currently hls.js) whenever po
 <MuxAudio
   playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
   metadata={{
-    video_id: "audio-id-123456",
-    video_title: "Super Interesting Audio",
-    viewer_user_id: "user-id-bc-789",
+    video_id: 'audio-id-123456',
+    video_title: 'Super Interesting Audio',
+    viewer_user_id: 'user-id-bc-789',
   }}
   envKey="YOUR_MUX_DATA_ENV_KEY"
   preferMse
@@ -119,9 +119,9 @@ By default `<MuxAudio/>` will try to figure out the type of media you're trying 
 <MuxAudio
   src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
   metadata={{
-    video_id: "audio-id-123456",
-    video_title: "Super Interesting Audio",
-    viewer_user_id: "user-id-bc-789",
+    video_id: 'audio-id-123456',
+    video_title: 'Super Interesting Audio',
+    viewer_user_id: 'user-id-bc-789',
   }}
   envKey="YOUR_MUX_DATA_ENV_KEY"
   controls
@@ -135,9 +135,9 @@ Sometimes, however, your `src` URL may not have an identifiable extension. In th
   src="https://stream.notmux.com/path/to/an/hls/source/playlist"
   type="application/vnd.apple.mpegurl"
   metadata={{
-    video_id: "video-id-123456",
-    video_title: "Super Interesting Video",
-    viewer_user_id: "user-id-bc-789",
+    video_id: 'video-id-123456',
+    video_title: 'Super Interesting Video',
+    viewer_user_id: 'user-id-bc-789',
   }}
   envKey="YOUR_MUX_DATA_ENV_KEY"
   controls
@@ -151,9 +151,9 @@ Or, for convenience, we also support the shorthand `type="hls`:
   src="https://stream.notmux.com/path/to/an/hls/source/playlist"
   type="hls"
   metadata={{
-    video_id: "audio-id-123456",
-    video_title: "Super Interesting Audio",
-    viewer_user_id: "user-id-bc-789",
+    video_id: 'audio-id-123456',
+    video_title: 'Super Interesting Audio',
+    viewer_user_id: 'user-id-bc-789',
   }}
   envKey="YOUR_MUX_DATA_ENV_KEY"
   controls

--- a/packages/mux-audio-react/src/env.ts
+++ b/packages/mux-audio-react/src/env.ts
@@ -1,13 +1,13 @@
-export const isMaybeBrowser = () => typeof window != "undefined";
+export const isMaybeBrowser = () => typeof window != 'undefined';
 // @ts-ignore
-export const isMaybeServer = () => typeof global != "undefined";
+export const isMaybeServer = () => typeof global != 'undefined';
 
 const getEnvPlayerVersion = () => {
   try {
     // @ts-ignore
     return PLAYER_VERSION as string;
   } catch {}
-  return "UNKNOWN";
+  return 'UNKNOWN';
 };
 
 const player_version: string = getEnvPlayerVersion();

--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -1,6 +1,6 @@
-import useCombinedRefs from "./use-combined-refs";
-import React, { useEffect, useRef, useState } from "react";
-import PropTypes from "prop-types";
+import useCombinedRefs from './use-combined-refs';
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
 import {
   allMediaTypes,
   initialize,
@@ -12,87 +12,74 @@ import {
   toMuxVideoURL,
   PlaybackEngine,
   generatePlayerInitTime,
-} from "@mux-elements/playback-core";
-import { getPlayerVersion } from "./env";
+} from '@mux-elements/playback-core';
+import { getPlayerVersion } from './env';
 
 export type Props = Omit<
-  React.DetailedHTMLProps<
-    React.AudioHTMLAttributes<HTMLAudioElement>,
-    HTMLAudioElement
-  >,
-  "autoPlay"
+  React.DetailedHTMLProps<React.AudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement>,
+  'autoPlay'
 > &
   MuxMediaProps;
 
 const playerSoftwareVersion = getPlayerVersion();
-const playerSoftwareName = "mux-audio-react";
+const playerSoftwareName = 'mux-audio-react';
 
-const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
-  (props, ref) => {
-    const {
-      envKey,
-      debug,
-      beaconDomain,
-      playbackId,
-      preferMse,
-      type,
-      streamType,
-      startTime,
-      src: outerSrc,
-      children,
-      autoPlay,
-      ...restProps
-    } = props;
+const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>((props, ref) => {
+  const {
+    envKey,
+    debug,
+    beaconDomain,
+    playbackId,
+    preferMse,
+    type,
+    streamType,
+    startTime,
+    src: outerSrc,
+    children,
+    autoPlay,
+    ...restProps
+  } = props;
 
-    const [playerInitTime] = useState(generatePlayerInitTime());
+  const [playerInitTime] = useState(generatePlayerInitTime());
 
-    const [src, setSrc] = useState<MuxMediaProps["src"]>(
-      toMuxVideoURL(playbackId) ?? outerSrc
-    );
+  const [src, setSrc] = useState<MuxMediaProps['src']>(toMuxVideoURL(playbackId) ?? outerSrc);
 
-    const playbackEngineRef = useRef<PlaybackEngine | undefined>(undefined);
-    const innerMediaElRef = useRef<HTMLAudioElement>(null);
+  const playbackEngineRef = useRef<PlaybackEngine | undefined>(undefined);
+  const innerMediaElRef = useRef<HTMLAudioElement>(null);
 
-    const mediaElRef = useCombinedRefs(innerMediaElRef, ref);
-    const updateAutoplayRef = useRef<UpdateAutoplay | undefined>(undefined);
-    const [updateAutoplay, setUpdateAutoplay] = useState(() => (x: any) => {});
+  const mediaElRef = useCombinedRefs(innerMediaElRef, ref);
+  const updateAutoplayRef = useRef<UpdateAutoplay | undefined>(undefined);
+  const [updateAutoplay, setUpdateAutoplay] = useState(() => (x: any) => {});
 
-    useEffect(() => {
-      const src = toMuxVideoURL(playbackId) ?? outerSrc;
-      setSrc(src);
-    }, [outerSrc, playbackId]);
+  useEffect(() => {
+    const src = toMuxVideoURL(playbackId) ?? outerSrc;
+    setSrc(src);
+  }, [outerSrc, playbackId]);
 
-    useEffect(() => {
-      const propsWithState = {
-        ...props,
-        src,
-        playerInitTime,
-        playerSoftwareName,
-        playerSoftwareVersion,
-        autoplay: autoPlay,
-      };
-      const nextPlaybackEngineRef = initialize(
-        propsWithState,
-        mediaElRef.current,
-        playbackEngineRef.current
-      );
-      playbackEngineRef.current = nextPlaybackEngineRef;
-      setUpdateAutoplay(() =>
-        setupAutoplay(mediaElRef.current, autoPlay, playbackEngineRef.current)
-      );
-    }, [src]);
+  useEffect(() => {
+    const propsWithState = {
+      ...props,
+      src,
+      playerInitTime,
+      playerSoftwareName,
+      playerSoftwareVersion,
+      autoplay: autoPlay,
+    };
+    const nextPlaybackEngineRef = initialize(propsWithState, mediaElRef.current, playbackEngineRef.current);
+    playbackEngineRef.current = nextPlaybackEngineRef;
+    setUpdateAutoplay(() => setupAutoplay(mediaElRef.current, autoPlay, playbackEngineRef.current));
+  }, [src]);
 
-    useEffect(() => {
-      updateAutoplay(autoPlay);
-    }, [autoPlay]);
+  useEffect(() => {
+    updateAutoplay(autoPlay);
+  }, [autoPlay]);
 
-    return (
-      <audio ref={mediaElRef} {...restProps}>
-        {children}
-      </audio>
-    );
-  }
-);
+  return (
+    <audio ref={mediaElRef} {...restProps}>
+      {children}
+    </audio>
+  );
+});
 
 MuxAudio.propTypes = {
   envKey: PropTypes.string,

--- a/packages/mux-audio-react/src/use-combined-refs.ts
+++ b/packages/mux-audio-react/src/use-combined-refs.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, MutableRefObject } from "react";
+import { useEffect, useRef, MutableRefObject } from 'react';
 
 type Maybe<T> = T | null | undefined;
 type RefCb<T> = (instance: Maybe<T>) => void;
@@ -15,7 +15,7 @@ export const useCombinedRefs: useCombinedRefs = (...refs) => {
     refs.forEach((ref) => {
       if (!ref) return;
 
-      if (typeof ref === "function") {
+      if (typeof ref === 'function') {
         ref(targetRef.current);
       } else {
         ref.current = targetRef.current;

--- a/packages/mux-audio/README.md
+++ b/packages/mux-audio/README.md
@@ -30,13 +30,13 @@ npm i @mux-elements/mux-audio
 Then, import the library into your application with either `import` or `require`:
 
 ```js
-import "@mux-elements/mux-audio";
+import '@mux-elements/mux-audio';
 ```
 
 or
 
 ```js
-require("@mux-elements/mux-audio");
+require('@mux-elements/mux-audio');
 ```
 
 ## CDN option
@@ -64,10 +64,7 @@ interface MuxAudioHTMLAttributes<T> extends React.AudioHTMLAttributes<T> {
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      "mux-audio": React.DetailedHTMLProps<
-        MuxAudioHTMLAttributes<HTMLAudioElement>,
-        HTMLAudioElement
-      >;
+      'mux-audio': React.DetailedHTMLProps<MuxAudioHTMLAttributes<HTMLAudioElement>, HTMLAudioElement>;
     }
   }
 }

--- a/packages/mux-audio/src/CustomAudioElement.d.ts
+++ b/packages/mux-audio/src/CustomAudioElement.d.ts
@@ -1,7 +1,5 @@
 /** @TODO Add type defs to custom-video-element directly */
-export default class CustomAudioElement<
-    V extends HTMLAudioElement = HTMLAudioElement
-  >
+export default class CustomAudioElement<V extends HTMLAudioElement = HTMLAudioElement>
   // NOTE: "lying" here since we programmatically merge props/methods from HTMLAudioElement into the CustomAudioElement's prototype in an attempt to make it "look like"
   // it extends an HTMLAudioElement.
   extends HTMLAudioElement
@@ -9,9 +7,5 @@ export default class CustomAudioElement<
 {
   static readonly observedAttributes: Array<string>;
   readonly nativeEl: V;
-  attributeChangedCallback(
-    attrName: string,
-    oldValue?: string | null,
-    newValue?: string | null
-  ): void;
+  attributeChangedCallback(attrName: string, oldValue?: string | null, newValue?: string | null): void;
 }

--- a/packages/mux-audio/src/CustomAudioElement.js
+++ b/packages/mux-audio/src/CustomAudioElement.js
@@ -1,4 +1,4 @@
-import "@mux-elements/polyfills/window";
+import '@mux-elements/polyfills/window';
 /**
  * Custom Video Element
  * The goal is to create an element that works just like the audio element
@@ -6,7 +6,7 @@ import "@mux-elements/polyfills/window";
  * extended today across browsers.
  */
 
-const template = document.createElement("template");
+const template = document.createElement('template');
 // Could you get styles to apply by passing a global button from global to shadow?
 
 template.innerHTML = `
@@ -41,9 +41,9 @@ class CustomAudioElement extends HTMLElement {
   constructor() {
     super();
 
-    this.attachShadow({ mode: "open" });
+    this.attachShadow({ mode: 'open' });
     this.shadowRoot.appendChild(template.content.cloneNode(true));
-    const nativeEl = (this.nativeEl = this.shadowRoot.querySelector("audio"));
+    const nativeEl = (this.nativeEl = this.shadowRoot.querySelector('audio'));
 
     // Initialize all the attribute properties
     Array.prototype.forEach.call(this.attributes, (attrNode) => {
@@ -59,8 +59,8 @@ class CustomAudioElement extends HTMLElement {
       nativeEl.muted = true;
     }
 
-    const slotEl = this.shadowRoot.querySelector("slot");
-    slotEl.addEventListener("slotchange", () => {
+    const slotEl = this.shadowRoot.querySelector('slot');
+    slotEl.addEventListener('slotchange', () => {
       slotEl.assignedElements().forEach((el) => {
         nativeEl.appendChild(el);
       });
@@ -80,7 +80,7 @@ class CustomAudioElement extends HTMLElement {
 
       // Non-func properties throw errors because it's not an instance
       try {
-        if (typeof this.prototype[propName] === "function") {
+        if (typeof this.prototype[propName] === 'function') {
           isFunc = true;
         }
       } catch (e) {}
@@ -109,16 +109,13 @@ class CustomAudioElement extends HTMLElement {
     const propName = arrayFindAnyCase(ownProps, attrName);
 
     // Check if this is the original custom native elemnt or a subclass
-    const isBaseElement =
-      Object.getPrototypeOf(this.constructor)
-        .toString()
-        .indexOf("function HTMLElement") === 0;
+    const isBaseElement = Object.getPrototypeOf(this.constructor).toString().indexOf('function HTMLElement') === 0;
 
     // If this is a subclass custom attribute we want to set the
     // matching property on the subclass
     if (propName && !isBaseElement) {
       // Boolean props should never start as null
-      if (typeof this[propName] == "boolean") {
+      if (typeof this[propName] == 'boolean') {
         // null is returned when attributes are removed i.e. boolean attrs
         if (newValue === null) {
           this[propName] = false;
@@ -138,7 +135,7 @@ class CustomAudioElement extends HTMLElement {
       } else {
         // Ignore a few that don't need to be passed through just in case
         // it creates unexpected behavior.
-        if (["id", "class"].indexOf(attrName) === -1) {
+        if (['id', 'class'].indexOf(attrName) === -1) {
           this.nativeEl.setAttribute(attrName, newValue);
         }
       }
@@ -160,13 +157,10 @@ let nativeElProps = [];
 // Can't check typeof directly on element prototypes without
 // throwing Illegal Invocation errors, so creating an element
 // to check on instead.
-const nativeElTest = document.createElement("audio");
+const nativeElTest = document.createElement('audio');
 
 // Deprecated props throw warnings if used, so exclude them
-const deprecatedProps = [
-  "webkitDisplayingFullscreen",
-  "webkitSupportsFullscreen",
-];
+const deprecatedProps = ['webkitDisplayingFullscreen', 'webkitSupportsFullscreen'];
 
 // Walk the prototype chain up to HTMLElement.
 // This will grab all super class props in between.
@@ -191,7 +185,7 @@ nativeElProps = nativeElProps.concat(Object.keys(EventTarget.prototype));
 nativeElProps.forEach((prop) => {
   const type = typeof nativeElTest[prop];
 
-  if (type == "function") {
+  if (type == 'function') {
     // Function
     CustomAudioElement.prototype[prop] = function () {
       return this.nativeEl[prop].apply(this.nativeEl, arguments);
@@ -227,8 +221,8 @@ function arrayFindAnyCase(arr, word) {
   return found;
 }
 
-if (!globalThis.customElements.get("custom-audio")) {
-  globalThis.customElements.define("custom-audio", CustomAudioElement);
+if (!globalThis.customElements.get('custom-audio')) {
+  globalThis.customElements.define('custom-audio', CustomAudioElement);
   globalThis.CustomAudioElement = CustomAudioElement;
 }
 

--- a/packages/mux-audio/src/env.ts
+++ b/packages/mux-audio/src/env.ts
@@ -1,13 +1,13 @@
-export const isMaybeBrowser = () => typeof window != "undefined";
+export const isMaybeBrowser = () => typeof window != 'undefined';
 // @ts-ignore
-export const isMaybeServer = () => typeof global != "undefined";
+export const isMaybeServer = () => typeof global != 'undefined';
 
 const getEnvPlayerVersion = () => {
   try {
     // @ts-ignore
     return PLAYER_VERSION as string;
   } catch {}
-  return "UNKNOWN";
+  return 'UNKNOWN';
 };
 
 const player_version: string = getEnvPlayerVersion();

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -1,4 +1,4 @@
-import CustomAudioElement from "./CustomAudioElement";
+import CustomAudioElement from './CustomAudioElement';
 
 import {
   initialize,
@@ -11,59 +11,49 @@ import {
   Metadata,
   mux,
   generatePlayerInitTime,
-} from "@mux-elements/playback-core";
-import type {
-  PlaybackEngine,
-  UpdateAutoplay,
-  ExtensionMimeTypeMap,
-} from "@mux-elements/playback-core";
-import { getPlayerVersion } from "./env";
+} from '@mux-elements/playback-core';
+import type { PlaybackEngine, UpdateAutoplay, ExtensionMimeTypeMap } from '@mux-elements/playback-core';
+import { getPlayerVersion } from './env';
 
 /** @TODO make the relationship between name+value smarter and more deriveable (CJP) */
 type AttributeNames = {
-  ENV_KEY: "env-key";
-  DEBUG: "debug";
-  METADATA_URL: "metadata-url";
-  METADATA_VIDEO_ID: "metadata-video-id";
-  METADATA_VIDEO_TITLE: "metadata-video-title";
-  METADATA_VIEWER_USER_ID: "metadata-viewer-user-id";
-  BEACON_DOMAIN: "beacon-domain";
-  PLAYBACK_ID: "playback-id";
-  PREFER_MSE: "prefer-mse";
-  TYPE: "type";
-  STREAM_TYPE: "stream-type";
-  START_TIME: "start-time";
+  ENV_KEY: 'env-key';
+  DEBUG: 'debug';
+  METADATA_URL: 'metadata-url';
+  METADATA_VIDEO_ID: 'metadata-video-id';
+  METADATA_VIDEO_TITLE: 'metadata-video-title';
+  METADATA_VIEWER_USER_ID: 'metadata-viewer-user-id';
+  BEACON_DOMAIN: 'beacon-domain';
+  PLAYBACK_ID: 'playback-id';
+  PREFER_MSE: 'prefer-mse';
+  TYPE: 'type';
+  STREAM_TYPE: 'stream-type';
+  START_TIME: 'start-time';
 };
 
 const Attributes: AttributeNames = {
-  ENV_KEY: "env-key",
-  DEBUG: "debug",
-  PLAYBACK_ID: "playback-id",
-  METADATA_URL: "metadata-url",
-  PREFER_MSE: "prefer-mse",
-  METADATA_VIDEO_ID: "metadata-video-id",
-  METADATA_VIDEO_TITLE: "metadata-video-title",
-  METADATA_VIEWER_USER_ID: "metadata-viewer-user-id",
-  BEACON_DOMAIN: "beacon-domain",
-  TYPE: "type",
-  STREAM_TYPE: "stream-type",
-  START_TIME: "start-time",
+  ENV_KEY: 'env-key',
+  DEBUG: 'debug',
+  PLAYBACK_ID: 'playback-id',
+  METADATA_URL: 'metadata-url',
+  PREFER_MSE: 'prefer-mse',
+  METADATA_VIDEO_ID: 'metadata-video-id',
+  METADATA_VIDEO_TITLE: 'metadata-video-title',
+  METADATA_VIEWER_USER_ID: 'metadata-viewer-user-id',
+  BEACON_DOMAIN: 'beacon-domain',
+  TYPE: 'type',
+  STREAM_TYPE: 'stream-type',
+  START_TIME: 'start-time',
 };
 
 const AttributeNameValues = Object.values(Attributes);
 
 const playerSoftwareVersion = getPlayerVersion();
-const playerSoftwareName = "mux-audio";
+const playerSoftwareName = 'mux-audio';
 
-class MuxAudioElement
-  extends CustomAudioElement<HTMLAudioElement>
-  implements Partial<MuxMediaProps>
-{
+class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Partial<MuxMediaProps> {
   static get observedAttributes() {
-    return [
-      ...AttributeNameValues,
-      ...(CustomAudioElement.observedAttributes ?? []),
-    ];
+    return [...AttributeNameValues, ...(CustomAudioElement.observedAttributes ?? [])];
   }
 
   // Keeping this named "__hls" since it's exposed for unadvertised "advanced usage" via getter that assumes specifically hls.js (CJP)
@@ -101,7 +91,7 @@ class MuxAudioElement
     // Use the attribute value as the source of truth.
     // No need to store it in two places.
     // This avoids needing a to read the attribute initially and update the src.
-    return this.getAttribute("src") as string;
+    return this.getAttribute('src') as string;
   }
 
   set src(val: string) {
@@ -110,9 +100,9 @@ class MuxAudioElement
     if (val === this.src) return;
 
     if (val == null) {
-      this.removeAttribute("src");
+      this.removeAttribute('src');
     } else {
-      this.setAttribute("src", val);
+      this.setAttribute('src', val);
     }
   }
 
@@ -126,7 +116,7 @@ class MuxAudioElement
     if (val === this.debug) return;
 
     if (val) {
-      this.setAttribute(Attributes.DEBUG, "");
+      this.setAttribute(Attributes.DEBUG, '');
     } else {
       this.removeAttribute(Attributes.DEBUG);
     }
@@ -197,10 +187,7 @@ class MuxAudioElement
 
   get streamType(): ValueOf<StreamTypes> | undefined {
     // getAttribute doesn't know that this attribute is well defined. Should explore extending for MuxVideo (CJP)
-    return (
-      (this.getAttribute(Attributes.STREAM_TYPE) as ValueOf<StreamTypes>) ??
-      undefined
-    );
+    return (this.getAttribute(Attributes.STREAM_TYPE) as ValueOf<StreamTypes>) ?? undefined;
   }
 
   set streamType(val: ValueOf<StreamTypes> | undefined) {
@@ -221,7 +208,7 @@ class MuxAudioElement
 
   set preferMse(val: boolean) {
     if (val) {
-      this.setAttribute(Attributes.PREFER_MSE, "");
+      this.setAttribute(Attributes.PREFER_MSE, '');
     } else {
       this.removeAttribute(Attributes.PREFER_MSE);
     }
@@ -236,24 +223,16 @@ class MuxAudioElement
     if (!!this.mux) {
       /** @TODO Link to docs for a more detailed discussion (CJP) */
       console.info(
-        "Some metadata values may not be overridable at this time. Make sure you set all metadata to override before setting the src."
+        'Some metadata values may not be overridable at this time. Make sure you set all metadata to override before setting the src.'
       );
-      this.mux.emit("hb", this.__metadata);
+      this.mux.emit('hb', this.__metadata);
     }
   }
 
   load() {
-    const nextHlsInstance = initialize(
-      this as Partial<MuxMediaProps>,
-      this.nativeEl,
-      this.__hls
-    );
+    const nextHlsInstance = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.__hls);
     this.__hls = nextHlsInstance;
-    const updateAutoplay = setupAutoplay(
-      this.nativeEl,
-      this.autoplay,
-      nextHlsInstance
-    );
+    const updateAutoplay = setupAutoplay(this.nativeEl, this.autoplay, nextHlsInstance);
     this.__updateAutoplay = updateAutoplay;
   }
 
@@ -262,13 +241,9 @@ class MuxAudioElement
     this.__hls = undefined;
   }
 
-  attributeChangedCallback(
-    attrName: string,
-    oldValue: string | null,
-    newValue: string | null
-  ) {
+  attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string | null) {
     switch (attrName) {
-      case "src":
+      case 'src':
         const hadSrc = !!oldValue;
         const hasSrc = !!newValue;
         if (!hadSrc && hasSrc) {
@@ -281,7 +256,7 @@ class MuxAudioElement
           this.load();
         }
         break;
-      case "autoplay":
+      case 'autoplay':
         this.__updateAutoplay?.(newValue);
         break;
       case Attributes.PLAYBACK_ID:
@@ -293,7 +268,7 @@ class MuxAudioElement
         if (!!this.mux) {
           /** @TODO Link to docs for a more detailed discussion (CJP) */
           console.info(
-            "Cannot toggle debug mode of mux data after initialization. Make sure you set all metadata to override before setting the src."
+            'Cannot toggle debug mode of mux data after initialization. Make sure you set all metadata to override before setting the src.'
           );
         }
         if (!!this.hls) {
@@ -305,11 +280,7 @@ class MuxAudioElement
           fetch(newValue)
             .then((resp) => resp.json())
             .then((json) => (this.metadata = json))
-            .catch((_err) =>
-              console.error(
-                `Unable to load or parse metadata JSON from metadata-url ${newValue}!`
-              )
-            );
+            .catch((_err) => console.error(`Unable to load or parse metadata JSON from metadata-url ${newValue}!`));
         }
         break;
       default:
@@ -337,16 +308,12 @@ declare global {
   var MuxAudioElement: MuxAudioElementType;
 }
 
-if (!globalThis.customElements.get("mux-audio")) {
-  globalThis.customElements.define("mux-audio", MuxAudioElement);
+if (!globalThis.customElements.get('mux-audio')) {
+  globalThis.customElements.define('mux-audio', MuxAudioElement);
   /** @TODO consider externalizing this (breaks standard modularity) */
   globalThis.MuxAudioElement = MuxAudioElement;
 }
 
-export {
-  PlaybackEngine,
-  PlaybackEngine as Hls,
-  ExtensionMimeTypeMap as MimeTypes,
-};
+export { PlaybackEngine, PlaybackEngine as Hls, ExtensionMimeTypeMap as MimeTypes };
 
 export default MuxAudioElement;

--- a/packages/mux-audio/test/player.test.js
+++ b/packages/mux-audio/test/player.test.js
@@ -1,8 +1,8 @@
-import { fixture, assert, aTimeout } from "@open-wc/testing";
-import "../src/index.ts";
+import { fixture, assert, aTimeout } from '@open-wc/testing';
+import '../src/index.ts';
 
-describe("<mux-audio>", () => {
-  it("has a Mux specific API", async function () {
+describe('<mux-audio>', () => {
+  it('has a Mux specific API', async function () {
     const player = await fixture(`<mux-audio
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
       env-key="ilc02s65tkrc2mk69b7q2qdkf"
@@ -13,19 +13,11 @@ describe("<mux-audio>", () => {
       muted
     ></mux-audio>`);
 
-    assert.equal(
-      player.playbackId,
-      "DS00Spx1CV902MCtPj5WknGlR102V5HFkDe",
-      "playback-id is reflected"
-    );
-    assert.equal(
-      player.envKey,
-      "ilc02s65tkrc2mk69b7q2qdkf",
-      "env-key is reflected"
-    );
-    assert.equal(player.startTime, 0, "startTime is set to 0");
-    assert.equal(player.streamType, "vod", "stream-type is vod");
-    assert.equal(player.preferMse, true, "prefer-mse is on");
-    assert.equal(player.debug, true, "debug is on");
+    assert.equal(player.playbackId, 'DS00Spx1CV902MCtPj5WknGlR102V5HFkDe', 'playback-id is reflected');
+    assert.equal(player.envKey, 'ilc02s65tkrc2mk69b7q2qdkf', 'env-key is reflected');
+    assert.equal(player.startTime, 0, 'startTime is set to 0');
+    assert.equal(player.streamType, 'vod', 'stream-type is vod');
+    assert.equal(player.preferMse, true, 'prefer-mse is on');
+    assert.equal(player.debug, true, 'debug is on');
   });
 });

--- a/packages/mux-audio/test/web-test-runner.config.mjs
+++ b/packages/mux-audio/test/web-test-runner.config.mjs
@@ -1,4 +1,4 @@
-import { esbuildPlugin } from "@web/dev-server-esbuild";
+import { esbuildPlugin } from '@web/dev-server-esbuild';
 
 export default {
   nodeResolve: true,
@@ -6,11 +6,11 @@ export default {
     esbuildPlugin({
       ts: true,
       json: true,
-      loaders: { ".css": "text", ".svg": "text" },
+      loaders: { '.css': 'text', '.svg': 'text' },
     }),
   ],
   coverageConfig: {
     report: true,
-    include: ["src/**/*"],
+    include: ['src/**/*'],
   },
 };

--- a/packages/mux-player-react/README.md
+++ b/packages/mux-player-react/README.md
@@ -28,13 +28,13 @@ npm i @mux-elements/mux-player-react
 Then, import the library into your application with either `import` or `require`:
 
 ```js
-import MuxPlayer from "@mux-elements/mux-player-react";
+import MuxPlayer from '@mux-elements/mux-player-react';
 ```
 
 or
 
 ```js
-const MuxPlayer = require("@mux-elements/mux-player-react");
+const MuxPlayer = require('@mux-elements/mux-player-react');
 ```
 
 ## Features and benefits
@@ -55,12 +55,12 @@ const MuxPlayerExample = () => {
     <div>
       <h1>Simple MuxPlayer Example</h1>
       <MuxPlayer
-        style={{ height: "100%", maxWidth: "100%" }}
+        style={{ height: '100%', maxWidth: '100%' }}
         playbackId="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
         metadata={{
-          video_id: "video-id-123456",
-          video_title: "Super Interesting Video",
-          viewer_user_id: "user-id-bc-789",
+          video_id: 'video-id-123456',
+          video_title: 'Super Interesting Video',
+          viewer_user_id: 'user-id-bc-789',
         }}
         envKey="YOUR_MUX_DATA_ENV_KEY"
         streamType="on-demand"
@@ -139,9 +139,9 @@ Example:
 <MuxPlayer
   playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
   metadata={{
-    video_id: "video-id-123456",
-    video_title: "Super Interesting Video",
-    viewer_user_id: "user-id-bc-789",
+    video_id: 'video-id-123456',
+    video_title: 'Super Interesting Video',
+    viewer_user_id: 'user-id-bc-789',
   }}
   envKey="YOUR_MUX_DATA_ENV_KEY"
 />
@@ -158,11 +158,11 @@ Example:
   playback-id="g65IqSFtWdpGR100c2W8VUHrfIVWTNRen"
   tokens={{
     playback:
-      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE2NDY0Mzg5NjEsImF1ZCI6InYiLCJzdWIiOiJiemVVNWZSQTQ3UzAxS0R6ck9iWWlpWnZ6ajAwajVFMDBkQ1ZidDNvUnptZkYwMCJ9.hWrdcJDa8FJCfVFP19oJ-9FSEVk9eB6DTOCRrucnzsrtUoZbb1OFe7swpQ38Fp3hZNNIt7-LWjdOl90TF4ucu7mhu42qyk3_i054RtmEZyQaj5Qjm3_H4sa2jLO-0QNSnOfp1A9x-fI8M_giGLg-byJPuu_eUqu1MW9bILLly_9gq8m0cNKghUa9xTMJgFmaya4XYudy5Mt2Fu72MiS3csUP3xhKlONVnGHlMRqB-dBVOgAJrayeUquAhaNY346oFBUWVM-EcAZ9G2ARtPakfy4Wpv5BsRKEGtR81P-k7EW8g27U0FKLlrvLkUz3Z-JYu53CRcJUvjkC9sDMrZLcTA",
+      'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE2NDY0Mzg5NjEsImF1ZCI6InYiLCJzdWIiOiJiemVVNWZSQTQ3UzAxS0R6ck9iWWlpWnZ6ajAwajVFMDBkQ1ZidDNvUnptZkYwMCJ9.hWrdcJDa8FJCfVFP19oJ-9FSEVk9eB6DTOCRrucnzsrtUoZbb1OFe7swpQ38Fp3hZNNIt7-LWjdOl90TF4ucu7mhu42qyk3_i054RtmEZyQaj5Qjm3_H4sa2jLO-0QNSnOfp1A9x-fI8M_giGLg-byJPuu_eUqu1MW9bILLly_9gq8m0cNKghUa9xTMJgFmaya4XYudy5Mt2Fu72MiS3csUP3xhKlONVnGHlMRqB-dBVOgAJrayeUquAhaNY346oFBUWVM-EcAZ9G2ARtPakfy4Wpv5BsRKEGtR81P-k7EW8g27U0FKLlrvLkUz3Z-JYu53CRcJUvjkC9sDMrZLcTA',
     thumbnail:
-      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE2NDY0OTMzMTksImF1ZCI6InQiLCJzdWIiOiJiemVVNWZSQTQ3UzAxS0R6ck9iWWlpWnZ6ajAwajVFMDBkQ1ZidDNvUnptZkYwMCJ9.hNBRo1-XDTT1CJMOxf90-8JPJzAygwm-3pVNBj31I7DEukSVRKVgUuhquEJbYXx1xg27xRMu8OVQxVob6jWHdjSwTyygAY040bqdyDxLsRtkDcVxwZ78iiZwtA1eTkxxY-410Ma3HbhNsG0Qjo5AWX46IhD9ARKHL-MPGaKda7FSx8J8jxa3hQ8_M1AKMsx7PrgJYOtW6n0mvkupEAFYRJlqIbkERSBeWChdrjCLYAcXRar5nfdNWlWST2pfllqz8pfJSTWjQRumTonC5BGB89jZUimHnuzkRXm_LeGyXbfZmBKb4d0j9YyGVnTPePqyVPsAQ-bzcfFDU0L67GDgyw",
+      'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE2NDY0OTMzMTksImF1ZCI6InQiLCJzdWIiOiJiemVVNWZSQTQ3UzAxS0R6ck9iWWlpWnZ6ajAwajVFMDBkQ1ZidDNvUnptZkYwMCJ9.hNBRo1-XDTT1CJMOxf90-8JPJzAygwm-3pVNBj31I7DEukSVRKVgUuhquEJbYXx1xg27xRMu8OVQxVob6jWHdjSwTyygAY040bqdyDxLsRtkDcVxwZ78iiZwtA1eTkxxY-410Ma3HbhNsG0Qjo5AWX46IhD9ARKHL-MPGaKda7FSx8J8jxa3hQ8_M1AKMsx7PrgJYOtW6n0mvkupEAFYRJlqIbkERSBeWChdrjCLYAcXRar5nfdNWlWST2pfllqz8pfJSTWjQRumTonC5BGB89jZUimHnuzkRXm_LeGyXbfZmBKb4d0j9YyGVnTPePqyVPsAQ-bzcfFDU0L67GDgyw',
     storyboard:
-      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE2NDY0OTM0OTgsImF1ZCI6InMiLCJzdWIiOiJiemVVNWZSQTQ3UzAxS0R6ck9iWWlpWnZ6ajAwajVFMDBkQ1ZidDNvUnptZkYwMCJ9.PKEybohVK0JyJGX_3iubRnHZx1ve5OmPmyfZdaKb17N2wVMQCYNltTc-gCUTU7EIKGeTtVOIITCSsIeTgXcI667B2GWJ5juDIErz1h-NQsPIfB-FsUeuWx2rYOap4G3FdwEIjaGc29HPncw-mG0JLcqkMB7jtDxjBY_-YlpjFYJF_z7r-1yIJM7mF3rl8YqeWstojC8oh2Iv2VRkuTyPE31QVI6fQcet5PIRWHudUIGWcNiWM56vwZskJ6qod8UvYpha7K5rhshh0Xdhnvq3Y9b6PXl3fy6VKCZIyszlPVje0IR2bR9iHDXnGbawivUsI65IDm-ZEoJrOzmZctMWAQ",
+      'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE2NDY0OTM0OTgsImF1ZCI6InMiLCJzdWIiOiJiemVVNWZSQTQ3UzAxS0R6ck9iWWlpWnZ6ajAwajVFMDBkQ1ZidDNvUnptZkYwMCJ9.PKEybohVK0JyJGX_3iubRnHZx1ve5OmPmyfZdaKb17N2wVMQCYNltTc-gCUTU7EIKGeTtVOIITCSsIeTgXcI667B2GWJ5juDIErz1h-NQsPIfB-FsUeuWx2rYOap4G3FdwEIjaGc29HPncw-mG0JLcqkMB7jtDxjBY_-YlpjFYJF_z7r-1yIJM7mF3rl8YqeWstojC8oh2Iv2VRkuTyPE31QVI6fQcet5PIRWHudUIGWcNiWM56vwZskJ6qod8UvYpha7K5rhshh0Xdhnvq3Y9b6PXl3fy6VKCZIyszlPVje0IR2bR9iHDXnGbawivUsI65IDm-ZEoJrOzmZctMWAQ',
   }}
 />
 ```
@@ -179,9 +179,9 @@ Example:
 <MuxPlayer
   playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
   metadata={{
-    video_id: "video-id-123456",
-    video_title: "Super Interesting Video",
-    viewer_user_id: "user-id-bc-789",
+    video_id: 'video-id-123456',
+    video_title: 'Super Interesting Video',
+    viewer_user_id: 'user-id-bc-789',
   }}
   envKey="YOUR_MUX_DATA_ENV_KEY"
   preferMse

--- a/packages/mux-player-react/src/common/utils.ts
+++ b/packages/mux-player-react/src/common/utils.ts
@@ -3,13 +3,13 @@
 // and provide a mechanism for passing in per-component overrides for
 // e.g. kebab cases, as that's the way React/Preact handles these. (CJP)
 const ReactPropToAttrNameMap = {
-  className: "class",
-  classname: "class",
-  htmlFor: "for",
-  crossOrigin: "crossorigin",
-  viewBox: "viewBox",
-  playsInline: "playsinline",
-  autoPlay: "autoplay",
+  className: 'class',
+  classname: 'class',
+  htmlFor: 'for',
+  crossOrigin: 'crossorigin',
+  viewBox: 'viewBox',
+  playsInline: 'playsinline',
+  autoPlay: 'autoplay',
 };
 
 type KeyTypes = string | number | symbol;
@@ -22,16 +22,11 @@ export const isKeyOf = <T = unknown>(k: KeyTypes, o: T): k is keyof T => {
   return k in o;
 };
 
-const toKebabCase = (string: string) =>
-  string.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+const toKebabCase = (string: string) => string.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
 
-export const toNativeAttrName = (
-  propName: string,
-  propValue: any
-): string | undefined => {
-  if (typeof propValue === "boolean" && !propValue) return undefined;
-  if (isKeyOf(propName, ReactPropToAttrNameMap))
-    return ReactPropToAttrNameMap[propName];
+export const toNativeAttrName = (propName: string, propValue: any): string | undefined => {
+  if (typeof propValue === 'boolean' && !propValue) return undefined;
+  if (isKeyOf(propName, ReactPropToAttrNameMap)) return ReactPropToAttrNameMap[propName];
   if (typeof propValue == undefined) return undefined;
   if (/[A-Z]/.test(propName)) return toKebabCase(propName);
   return propName;
@@ -39,24 +34,21 @@ export const toNativeAttrName = (
 export const toStyleAttr = <T>(x: T) => x;
 
 export const toNativeAttrValue = (propValue: any, propName: string) => {
-  if (typeof propValue === "boolean") return "";
+  if (typeof propValue === 'boolean') return '';
   return propValue;
 };
 
 export const toNativeProps = (props = {}) => {
-  return Object.entries(props).reduce<{ [k: string]: string }>(
-    (transformedProps, [propName, propValue]) => {
-      const attrName = toNativeAttrName(propName, propValue);
+  return Object.entries(props).reduce<{ [k: string]: string }>((transformedProps, [propName, propValue]) => {
+    const attrName = toNativeAttrName(propName, propValue);
 
-      // prop was stripped. Don't add.
-      if (!attrName) {
-        return transformedProps;
-      }
-
-      const attrValue = toNativeAttrValue(propValue, propName);
-      transformedProps[attrName] = attrValue;
+    // prop was stripped. Don't add.
+    if (!attrName) {
       return transformedProps;
-    },
-    {}
-  );
+    }
+
+    const attrValue = toNativeAttrValue(propValue, propName);
+    transformedProps[attrName] = attrValue;
+    return transformedProps;
+  }, {});
 };

--- a/packages/mux-player-react/src/env.ts
+++ b/packages/mux-player-react/src/env.ts
@@ -3,7 +3,7 @@ const getEnvPlayerVersion = () => {
     // @ts-ignore
     return PLAYER_VERSION as string;
   } catch {}
-  return "UNKNOWN";
+  return 'UNKNOWN';
 };
 
 const player_version: string = getEnvPlayerVersion();

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -1,13 +1,13 @@
-import React, { useEffect } from "react";
-import type { CSSProperties } from "react";
-import "@mux-elements/mux-player";
-import type MuxPlayerElement from "@mux-elements/mux-player";
-import type { Tokens } from "@mux-elements/mux-player";
-import { toNativeProps } from "./common/utils";
-import { useRef } from "react";
-import { useCombinedRefs } from "./useCombinedRefs";
-import useObjectPropEffect, { defaultHasChanged } from "./useObjectPropEffect";
-import { getPlayerVersion } from "./env";
+import React, { useEffect } from 'react';
+import type { CSSProperties } from 'react';
+import '@mux-elements/mux-player';
+import type MuxPlayerElement from '@mux-elements/mux-player';
+import type { Tokens } from '@mux-elements/mux-player';
+import { toNativeProps } from './common/utils';
+import { useRef } from 'react';
+import { useCombinedRefs } from './useCombinedRefs';
+import useObjectPropEffect, { defaultHasChanged } from './useObjectPropEffect';
+import { getPlayerVersion } from './env';
 
 type ValueOf<T> = T[keyof T];
 
@@ -28,9 +28,9 @@ type VideoApiAttributes = {
   style: CSSProperties;
 };
 type StreamTypes = {
-  VOD: "on-demand";
-  LIVE: "live";
-  LL_LIVE: "ll-live";
+  VOD: 'on-demand';
+  LIVE: 'live';
+  LL_LIVE: 'll-live';
 };
 
 type MuxMediaPropTypes = {
@@ -43,7 +43,7 @@ type MuxMediaPropTypes = {
   beaconDomain: string;
   playbackId: string;
   preferMse: boolean;
-  streamType: ValueOf<StreamTypes> | "vod";
+  streamType: ValueOf<StreamTypes> | 'vod';
   startTime: number;
   children: never[];
 };
@@ -81,15 +81,8 @@ export type MuxPlayerProps = {
 } & Partial<MuxMediaPropTypes> &
   Partial<VideoApiAttributes>;
 
-const MuxPlayerInternal = React.forwardRef<
-  MuxPlayerRefAttributes,
-  MuxPlayerProps
->(({ children, ...props }, ref) => {
-  return React.createElement(
-    "mux-player",
-    toNativeProps({ ...props, ref }),
-    children
-  );
+const MuxPlayerInternal = React.forwardRef<MuxPlayerRefAttributes, MuxPlayerProps>(({ children, ...props }, ref) => {
+  return React.createElement('mux-player', toNativeProps({ ...props, ref }), children);
 });
 
 const useEventCallbackEffect = (
@@ -137,11 +130,11 @@ const usePlayer = (
     playbackId,
     ...remainingProps
   } = props;
-  useObjectPropEffect("metadata", metadata, ref);
-  useObjectPropEffect("tokens", tokens, ref);
-  useObjectPropEffect("playbackId", playbackId, ref);
+  useObjectPropEffect('metadata', metadata, ref);
+  useObjectPropEffect('tokens', tokens, ref);
+  useObjectPropEffect('playbackId', playbackId, ref);
   useObjectPropEffect(
-    "paused",
+    'paused',
     paused,
     ref,
     (playerEl: HTMLMediaElement, pausedVal?: boolean) => {
@@ -153,38 +146,38 @@ const usePlayer = (
       }
     },
     (playerEl, value, propName) => {
-      if (playerEl.hasAttribute("autoplay") && !playerEl.hasPlayed) {
+      if (playerEl.hasAttribute('autoplay') && !playerEl.hasPlayed) {
         return false;
       }
       return defaultHasChanged(playerEl, value, propName);
     }
   );
-  useEventCallbackEffect("loadstart", ref, onLoadStart);
-  useEventCallbackEffect("loadedmetadata", ref, onLoadedMetadata);
-  useEventCallbackEffect("progress", ref, onProgress);
-  useEventCallbackEffect("durationchange", ref, onDurationChange);
-  useEventCallbackEffect("volumechange", ref, onVolumeChange);
-  useEventCallbackEffect("ratechange", ref, onRateChange);
-  useEventCallbackEffect("resize", ref, onResize);
-  useEventCallbackEffect("waiting", ref, onWaiting);
-  useEventCallbackEffect("play", ref, onPlay);
-  useEventCallbackEffect("playing", ref, onPlaying);
-  useEventCallbackEffect("timeupdate", ref, onTimeUpdate);
-  useEventCallbackEffect("pause", ref, onPause);
-  useEventCallbackEffect("seeking", ref, onSeeking);
-  useEventCallbackEffect("seeked", ref, onSeeked);
-  useEventCallbackEffect("ended", ref, onEnded);
-  useEventCallbackEffect("error", ref, onError);
-  useEventCallbackEffect("playerready", ref, onPlayerReady);
+  useEventCallbackEffect('loadstart', ref, onLoadStart);
+  useEventCallbackEffect('loadedmetadata', ref, onLoadedMetadata);
+  useEventCallbackEffect('progress', ref, onProgress);
+  useEventCallbackEffect('durationchange', ref, onDurationChange);
+  useEventCallbackEffect('volumechange', ref, onVolumeChange);
+  useEventCallbackEffect('ratechange', ref, onRateChange);
+  useEventCallbackEffect('resize', ref, onResize);
+  useEventCallbackEffect('waiting', ref, onWaiting);
+  useEventCallbackEffect('play', ref, onPlay);
+  useEventCallbackEffect('playing', ref, onPlaying);
+  useEventCallbackEffect('timeupdate', ref, onTimeUpdate);
+  useEventCallbackEffect('pause', ref, onPause);
+  useEventCallbackEffect('seeking', ref, onSeeking);
+  useEventCallbackEffect('seeked', ref, onSeeked);
+  useEventCallbackEffect('ended', ref, onEnded);
+  useEventCallbackEffect('error', ref, onError);
+  useEventCallbackEffect('playerready', ref, onPlayerReady);
   return [remainingProps];
 };
 
 const playerSoftwareVersion = getPlayerVersion();
-const playerSoftwareName = "mux-player-react";
+const playerSoftwareName = 'mux-player-react';
 
 const MuxPlayer = React.forwardRef<
   MuxPlayerRefAttributes,
-  Omit<MuxPlayerProps, "playerSoftwareVersion" | "playerSoftwareName">
+  Omit<MuxPlayerProps, 'playerSoftwareVersion' | 'playerSoftwareName'>
 >((props, ref) => {
   const {
     /** @TODO Remove these once defaults are added to mux-player (CJP) */

--- a/packages/mux-player-react/src/useCombinedRefs.ts
+++ b/packages/mux-player-react/src/useCombinedRefs.ts
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
-import type { MutableRefObject, ForwardedRef } from "react";
+import { useEffect, useRef } from 'react';
+import type { MutableRefObject, ForwardedRef } from 'react';
 
 type Maybe<T> = T | null | undefined;
 type RefCb<T> = (instance: Maybe<T>) => void;
@@ -16,7 +16,7 @@ export const useCombinedRefs: useCombinedRefs = (...refs) => {
     refs.forEach((ref) => {
       if (!ref) return;
 
-      if (typeof ref === "function") {
+      if (typeof ref === 'function') {
         ref(targetRef.current);
       } else {
         ref.current = targetRef.current;

--- a/packages/mux-player-react/src/useObjectPropEffect.ts
+++ b/packages/mux-player-react/src/useObjectPropEffect.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect } from 'react';
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -12,12 +12,7 @@ const shallowEqual = (objA: any, objB: any): boolean => {
     return true;
   }
 
-  if (
-    typeof objA !== "object" ||
-    objA === null ||
-    typeof objB !== "object" ||
-    objB === null
-  ) {
+  if (typeof objA !== 'object' || objA === null || typeof objB !== 'object' || objB === null) {
     return false;
   }
 
@@ -37,10 +32,7 @@ const shallowEqual = (objA: any, objB: any): boolean => {
 
   // Test for A's keys different from B.
   for (let i = 0; i < keysA.length; i++) {
-    if (
-      !hasOwnProperty.call(objB, keysA[i]) ||
-      !Object.is(objA[keysA[i]], objB[keysA[i]])
-    ) {
+    if (!hasOwnProperty.call(objB, keysA[i]) || !Object.is(objA[keysA[i]], objB[keysA[i]])) {
       return false;
     }
   }

--- a/packages/mux-player/README.md
+++ b/packages/mux-player/README.md
@@ -30,13 +30,13 @@ npm i @mux-elements/mux-player
 Then, import the library into your application with either `import` or `require`:
 
 ```js
-import "@mux-elements/mux-player";
+import '@mux-elements/mux-player';
 ```
 
 or
 
 ```js
-require("@mux-elements/mux-player");
+require('@mux-elements/mux-player');
 ```
 
 ## CDN option
@@ -182,11 +182,11 @@ To set other available metadata fields use the `metadata` property on the `<mux-
 </mux-player>
 
 <script>
-  const muxVideo = document.querySelector("mux-player");
+  const muxVideo = document.querySelector('mux-player');
   muxVideo.metadata = {
-    experiment_name: "landing_page_v3",
-    video_content_type: "clip",
-    video_series: "season 1",
+    experiment_name: 'landing_page_v3',
+    video_content_type: 'clip',
+    video_series: 'season 1',
   };
 </script>
 ```

--- a/packages/mux-player/src/dialog.ts
+++ b/packages/mux-player/src/dialog.ts
@@ -1,6 +1,6 @@
-import MediaDialog from "./media-chrome/dialog";
+import MediaDialog from './media-chrome/dialog';
 
-const template = document.createElement("template");
+const template = document.createElement('template');
 template.innerHTML = `
   <style>
     ${MediaDialog.styles}
@@ -40,14 +40,14 @@ class MxpDialog extends MediaDialog {
   constructor() {
     super();
 
-    this.shadowRoot?.querySelector(".close")?.addEventListener("click", () => {
+    this.shadowRoot?.querySelector('.close')?.addEventListener('click', () => {
       this.close();
     });
   }
 }
 
-if (!globalThis.customElements.get("mxp-dialog")) {
-  globalThis.customElements.define("mxp-dialog", MxpDialog);
+if (!globalThis.customElements.get('mxp-dialog')) {
+  globalThis.customElements.define('mxp-dialog', MxpDialog);
   (globalThis as any).MxpDialog = MxpDialog;
 }
 

--- a/packages/mux-player/src/dom-polyfills.ts
+++ b/packages/mux-player/src/dom-polyfills.ts
@@ -1,4 +1,4 @@
-if (typeof DocumentFragment === "undefined") {
+if (typeof DocumentFragment === 'undefined') {
   class DocumentFragment {}
   // @ts-ignore
   globalThis.DocumentFragment = DocumentFragment;

--- a/packages/mux-player/src/helpers.ts
+++ b/packages/mux-player/src/helpers.ts
@@ -1,5 +1,5 @@
-import { stylePropsToString, toQuery, camelCase } from "./utils";
-import type MuxPlayerElement from ".";
+import { stylePropsToString, toQuery, camelCase } from './utils';
+import type MuxPlayerElement from '.';
 
 /* eslint-disable */
 const getEnvPlayerVersion = () => {
@@ -7,7 +7,7 @@ const getEnvPlayerVersion = () => {
     // @ts-ignore
     return PLAYER_VERSION;
   } catch {}
-  return "UNKNOWN";
+  return 'UNKNOWN';
 };
 
 const player_version = getEnvPlayerVersion();
@@ -17,27 +17,21 @@ export const getSrcFromPlaybackId = (playbackId?: string, token?: string) => {
   return `https://stream.mux.com/${playbackId}.m3u8${toQuery({ token })}`;
 };
 
-export const getPosterURLFromPlaybackId = (
-  playbackId?: string,
-  token?: string
-) => {
+export const getPosterURLFromPlaybackId = (playbackId?: string, token?: string) => {
   return `https://image.mux.com/${playbackId}/thumbnail.jpg${toQuery({
     token,
   })}`;
 };
 
-export const getStoryboardURLFromPlaybackId = (
-  playbackId?: string,
-  token?: string
-) => {
+export const getStoryboardURLFromPlaybackId = (playbackId?: string, token?: string) => {
   return `https://image.mux.com/${playbackId}/storyboard.vtt${toQuery({
     token,
   })}`;
 };
 
 const attrToPropNameMap: Record<string, string> = {
-  crossorigin: "crossOrigin",
-  playsinline: "playsInline",
+  crossorigin: 'crossOrigin',
+  playsinline: 'playsInline',
 };
 
 export function toPropName(attrName: string) {
@@ -45,17 +39,15 @@ export function toPropName(attrName: string) {
 }
 
 let testMediaEl: HTMLMediaElement | undefined;
-export const getTestMediaEl = (nodeName = "video") => {
+export const getTestMediaEl = (nodeName = 'video') => {
   if (testMediaEl) return testMediaEl;
-  if (typeof window !== "undefined") {
-    testMediaEl = document.createElement(nodeName as "video" | "audio");
+  if (typeof window !== 'undefined') {
+    testMediaEl = document.createElement(nodeName as 'video' | 'audio');
   }
   return testMediaEl;
 };
 
-export const hasVolumeSupportAsync = async (
-  mediaEl: HTMLMediaElement | undefined = getTestMediaEl()
-) => {
+export const hasVolumeSupportAsync = async (mediaEl: HTMLMediaElement | undefined = getTestMediaEl()) => {
   if (!mediaEl) return false;
   const prevVolume = mediaEl.volume;
   mediaEl.volume = prevVolume / 2 + 0.1;
@@ -67,9 +59,7 @@ export const hasVolumeSupportAsync = async (
 };
 
 export function getCcSubTracks(el: MuxPlayerElement) {
-  return Array.from(el.video?.textTracks ?? []).filter(
-    ({ kind }) => kind === "subtitles" || kind === "captions"
-  );
+  return Array.from(el.video?.textTracks ?? []).filter(({ kind }) => kind === 'subtitles' || kind === 'captions');
 }
 
 export function getChromeStylesFromProps(props: any) {
@@ -77,18 +67,18 @@ export function getChromeStylesFromProps(props: any) {
 
   const primaryColorStyles = primaryColor
     ? {
-        "--media-icon-color": primaryColor,
-        "--media-range-thumb-background": primaryColor,
-        "--media-range-bar-color": primaryColor,
+        '--media-icon-color': primaryColor,
+        '--media-range-thumb-background': primaryColor,
+        '--media-range-bar-color': primaryColor,
         color: primaryColor,
       }
     : {};
 
   const secondaryColorStyles = secondaryColor
     ? {
-        "--media-background-color": secondaryColor,
-        "--media-control-background": secondaryColor,
-        "--media-control-hover-background": secondaryColor,
+        '--media-background-color': secondaryColor,
+        '--media-control-background': secondaryColor,
+        '--media-control-hover-background': secondaryColor,
       }
     : {};
 

--- a/packages/mux-player/src/icons.ts
+++ b/packages/mux-player/src/icons.ts
@@ -1,20 +1,20 @@
 // @ts-nocheck
-import { html, createTemplateInstance } from "./html";
-import airplayIcon from "./icons/airplay.svg";
-import captionsOffIcon from "./icons/captions-off.svg";
-import captionsOnIcon from "./icons/captions-on.svg";
-import fullscreenEnter from "./icons/fullscreen-enter.svg";
-import fullscreenExit from "./icons/fullscreen-exit.svg";
-import pause from "./icons/pause.svg";
-import pipEnter from "./icons/pip-enter.svg";
-import pipExit from "./icons/pip-exit.svg";
-import play from "./icons/play.svg";
-import seekBackward from "./icons/seek-backward.svg";
-import seekForward from "./icons/seek-forward.svg";
-import volumeHigh from "./icons/volume-high.svg";
-import volumeLow from "./icons/volume-low.svg";
-import volumeMedium from "./icons/volume-medium.svg";
-import volumeOff from "./icons/volume-off.svg";
+import { html, createTemplateInstance } from './html';
+import airplayIcon from './icons/airplay.svg';
+import captionsOffIcon from './icons/captions-off.svg';
+import captionsOnIcon from './icons/captions-on.svg';
+import fullscreenEnter from './icons/fullscreen-enter.svg';
+import fullscreenExit from './icons/fullscreen-exit.svg';
+import pause from './icons/pause.svg';
+import pipEnter from './icons/pip-enter.svg';
+import pipExit from './icons/pip-exit.svg';
+import play from './icons/play.svg';
+import seekBackward from './icons/seek-backward.svg';
+import seekForward from './icons/seek-forward.svg';
+import volumeHigh from './icons/volume-high.svg';
+import volumeLow from './icons/volume-low.svg';
+import volumeMedium from './icons/volume-medium.svg';
+import volumeOff from './icons/volume-off.svg';
 
 export const Airplay = () => createTemplateInstance(airplayIcon);
 export const CaptionsOff = () => createTemplateInstance(captionsOffIcon);

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -1,18 +1,13 @@
-import "media-chrome";
-import { MediaError } from "@mux-elements/mux-video";
-import VideoApiElement from "./video-api";
-import {
-  getCcSubTracks,
-  getPlayerVersion,
-  hasVolumeSupportAsync,
-  toPropName,
-} from "./helpers";
-import { template } from "./template";
-import { render } from "./html";
-import { toNumberOrUndefined, i18n } from "./utils";
+import 'media-chrome';
+import { MediaError } from '@mux-elements/mux-video';
+import VideoApiElement from './video-api';
+import { getCcSubTracks, getPlayerVersion, hasVolumeSupportAsync, toPropName } from './helpers';
+import { template } from './template';
+import { render } from './html';
+import { toNumberOrUndefined, i18n } from './utils';
 
-import type { MuxTemplateProps } from "./types";
-import type { Metadata } from "@mux-elements/playback-core";
+import type { MuxTemplateProps } from './types';
+import type { Metadata } from '@mux-elements/playback-core';
 
 export type Tokens = {
   playback?: string;
@@ -23,9 +18,9 @@ export type Tokens = {
 const SMALL_BREAKPOINT = 700;
 const XSMALL_BREAKPOINT = 300;
 const MediaChromeSizes = {
-  LG: "large",
-  SM: "small",
-  XS: "extra-small",
+  LG: 'large',
+  SM: 'small',
+  XS: 'extra-small',
 };
 
 function getPlayerSize(el: Element) {
@@ -38,31 +33,31 @@ function getPlayerSize(el: Element) {
 }
 
 const MuxVideoAttributes = {
-  ENV_KEY: "env-key",
-  DEBUG: "debug",
-  PLAYBACK_ID: "playback-id",
-  METADATA_URL: "metadata-url",
-  PREFER_MSE: "prefer-mse",
-  PLAYER_SOFTWARE_VERSION: "player-software-version",
-  PLAYER_SOFTWARE_NAME: "player-software-name",
-  METADATA_VIDEO_ID: "metadata-video-id",
-  METADATA_VIDEO_TITLE: "metadata-video-title",
-  METADATA_VIEWER_USER_ID: "metadata-viewer-user-id",
-  BEACON_DOMAIN: "beacon-domain",
-  TYPE: "type",
-  STREAM_TYPE: "stream-type",
-  START_TIME: "start-time",
+  ENV_KEY: 'env-key',
+  DEBUG: 'debug',
+  PLAYBACK_ID: 'playback-id',
+  METADATA_URL: 'metadata-url',
+  PREFER_MSE: 'prefer-mse',
+  PLAYER_SOFTWARE_VERSION: 'player-software-version',
+  PLAYER_SOFTWARE_NAME: 'player-software-name',
+  METADATA_VIDEO_ID: 'metadata-video-id',
+  METADATA_VIDEO_TITLE: 'metadata-video-title',
+  METADATA_VIEWER_USER_ID: 'metadata-viewer-user-id',
+  BEACON_DOMAIN: 'beacon-domain',
+  TYPE: 'type',
+  STREAM_TYPE: 'stream-type',
+  START_TIME: 'start-time',
 };
 
 const PlayerAttributes = {
-  DEFAULT_HIDDEN_CAPTIONS: "default-hidden-captions",
-  PRIMARY_COLOR: "primary-color",
-  SECONDARY_COLOR: "secondary-color",
-  FORWARD_SEEK_OFFSET: "forward-seek-offset",
-  BACKWARD_SEEK_OFFSET: "backward-seek-offset",
-  PLAYBACK_TOKEN: "playback-token",
-  THUMBNAIL_TOKEN: "thumbnail-token",
-  STORYBOARD_TOKEN: "storyboard-token",
+  DEFAULT_HIDDEN_CAPTIONS: 'default-hidden-captions',
+  PRIMARY_COLOR: 'primary-color',
+  SECONDARY_COLOR: 'secondary-color',
+  FORWARD_SEEK_OFFSET: 'forward-seek-offset',
+  BACKWARD_SEEK_OFFSET: 'backward-seek-offset',
+  PLAYBACK_TOKEN: 'playback-token',
+  THUMBNAIL_TOKEN: 'thumbnail-token',
+  STORYBOARD_TOKEN: 'storyboard-token',
 };
 
 function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
@@ -100,7 +95,7 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
 const MuxVideoAttributeNames = Object.values(MuxVideoAttributes);
 const PlayerAttributeNames = Object.values(PlayerAttributes);
 const playerSoftwareVersion = getPlayerVersion();
-const playerSoftwareName = "mux-player";
+const playerSoftwareName = 'mux-player';
 
 class MuxPlayerElement extends VideoApiElement {
   #tokens = {};
@@ -109,25 +104,20 @@ class MuxPlayerElement extends VideoApiElement {
     isDialogOpen: false,
     supportsAirPlay: false,
     supportsVolume: false,
-    onCloseErrorDialog: () =>
-      this.#setState({ dialog: undefined, isDialogOpen: false }),
+    onCloseErrorDialog: () => this.#setState({ dialog: undefined, isDialogOpen: false }),
   };
 
   static get observedAttributes() {
-    return [
-      ...(VideoApiElement.observedAttributes ?? []),
-      ...MuxVideoAttributeNames,
-      ...PlayerAttributeNames,
-    ];
+    return [...(VideoApiElement.observedAttributes ?? []), ...MuxVideoAttributeNames, ...PlayerAttributeNames];
   }
 
   constructor() {
     super();
 
-    this.attachShadow({ mode: "open" });
+    this.attachShadow({ mode: 'open' });
     this.#setState({ playerSize: getPlayerSize(this) });
 
-    this.querySelectorAll(":scope > track").forEach((track) => {
+    this.querySelectorAll(':scope > track').forEach((track) => {
       this.video?.append(track.cloneNode());
     });
 
@@ -168,10 +158,7 @@ class MuxPlayerElement extends VideoApiElement {
   }
 
   #render(props: Record<string, any> = {}) {
-    render(
-      template(getProps(this, { ...this.#state, ...props })),
-      this.shadowRoot as Node
-    );
+    render(template(getProps(this, { ...this.#state, ...props })), this.shadowRoot as Node);
   }
 
   #renderChrome() {
@@ -278,16 +265,16 @@ class MuxPlayerElement extends VideoApiElement {
       this.#setState({ isDialogOpen: true, dialog });
     };
 
-    this.addEventListener("error", onError);
+    this.addEventListener('error', onError);
 
-    this.video?.addEventListener("error", (event: Event) => {
+    this.video?.addEventListener('error', (event: Event) => {
       let { detail: error }: { detail: any } = event as CustomEvent;
       if (!error) {
         const { message, code } = this.video?.error ?? {};
         error = new MediaError(message, code);
       }
       this.dispatchEvent(
-        new CustomEvent("error", {
+        new CustomEvent('error', {
           detail: error,
         })
       );
@@ -296,21 +283,18 @@ class MuxPlayerElement extends VideoApiElement {
 
   #setUpCaptionsButton() {
     const onTrackCountChange = () => this.#render();
-    this.video?.textTracks?.addEventListener("addtrack", onTrackCountChange);
-    this.video?.textTracks?.addEventListener("removetrack", onTrackCountChange);
+    this.video?.textTracks?.addEventListener('addtrack', onTrackCountChange);
+    this.video?.textTracks?.addEventListener('removetrack', onTrackCountChange);
   }
 
   #setUpAirplayButton() {
     if (!!(globalThis as any).WebKitPlaybackTargetAvailabilityEvent) {
       const onPlaybackTargetAvailability = (evt: any) => {
-        const supportsAirPlay = evt.availability === "available";
+        const supportsAirPlay = evt.availability === 'available';
         this.#setState({ supportsAirPlay });
       };
 
-      this.video?.addEventListener(
-        "webkitplaybacktargetavailabilitychanged",
-        onPlaybackTargetAvailability
-      );
+      this.video?.addEventListener('webkitplaybacktargetavailabilitychanged', onPlaybackTargetAvailability);
     }
   }
 
@@ -319,11 +303,7 @@ class MuxPlayerElement extends VideoApiElement {
     this.#setState({ supportsVolume });
   }
 
-  attributeChangedCallback(
-    attrName: string,
-    oldValue: string | null,
-    newValue: string
-  ) {
+  attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string) {
     super.attributeChangedCallback(attrName, oldValue, newValue);
     this.#render({ [toPropName(attrName)]: newValue });
   }
@@ -368,11 +348,7 @@ class MuxPlayerElement extends VideoApiElement {
    * Get the offset applied to the forward seek button.
    */
   get forwardSeekOffset() {
-    return (
-      toNumberOrUndefined(
-        this.getAttribute(PlayerAttributes.FORWARD_SEEK_OFFSET)
-      ) ?? 10
-    );
+    return toNumberOrUndefined(this.getAttribute(PlayerAttributes.FORWARD_SEEK_OFFSET)) ?? 10;
   }
 
   /**
@@ -386,11 +362,7 @@ class MuxPlayerElement extends VideoApiElement {
    * Get the offset applied to the backward seek button.
    */
   get backwardSeekOffset() {
-    return (
-      toNumberOrUndefined(
-        this.getAttribute(PlayerAttributes.BACKWARD_SEEK_OFFSET)
-      ) ?? 10
-    );
+    return toNumberOrUndefined(this.getAttribute(PlayerAttributes.BACKWARD_SEEK_OFFSET)) ?? 10;
   }
 
   /**
@@ -412,20 +384,14 @@ class MuxPlayerElement extends VideoApiElement {
    * Get the player software name. Used by Mux Data.
    */
   get playerSoftwareName() {
-    return (
-      this.getAttribute(MuxVideoAttributes.PLAYER_SOFTWARE_NAME) ??
-      playerSoftwareName
-    );
+    return this.getAttribute(MuxVideoAttributes.PLAYER_SOFTWARE_NAME) ?? playerSoftwareName;
   }
 
   /**
    * Get the player software version. Used by Mux Data.
    */
   get playerSoftwareVersion() {
-    return (
-      this.getAttribute(MuxVideoAttributes.PLAYER_SOFTWARE_VERSION) ??
-      playerSoftwareVersion
-    );
+    return this.getAttribute(MuxVideoAttributes.PLAYER_SOFTWARE_VERSION) ?? playerSoftwareVersion;
   }
 
   /**
@@ -470,7 +436,7 @@ class MuxPlayerElement extends VideoApiElement {
    */
   set debug(val) {
     if (val) {
-      this.setAttribute(MuxVideoAttributes.DEBUG, "");
+      this.setAttribute(MuxVideoAttributes.DEBUG, '');
     } else {
       this.removeAttribute(MuxVideoAttributes.DEBUG);
     }
@@ -494,9 +460,7 @@ class MuxPlayerElement extends VideoApiElement {
    * Get the start time.
    */
   get startTime() {
-    return toNumberOrUndefined(
-      getVideoAttribute(this, MuxVideoAttributes.START_TIME)
-    );
+    return toNumberOrUndefined(getVideoAttribute(this, MuxVideoAttributes.START_TIME));
   }
 
   /**
@@ -518,7 +482,7 @@ class MuxPlayerElement extends VideoApiElement {
    */
   set preferMse(val) {
     if (val) {
-      this.setAttribute(MuxVideoAttributes.PREFER_MSE, "");
+      this.setAttribute(MuxVideoAttributes.PREFER_MSE, '');
     } else {
       this.removeAttribute(MuxVideoAttributes.PREFER_MSE);
     }
@@ -608,8 +572,8 @@ export function getVideoAttribute(el: MuxPlayerElement, name: string) {
 }
 
 /** @TODO Refactor once using `globalThis` polyfills */
-if (!globalThis.customElements.get("mux-player")) {
-  globalThis.customElements.define("mux-player", MuxPlayerElement);
+if (!globalThis.customElements.get('mux-player')) {
+  globalThis.customElements.define('mux-player', MuxPlayerElement);
   /** @TODO consider externalizing this (breaks standard modularity) */
   (globalThis as any).MuxPlayerElement = MuxPlayerElement;
 }

--- a/packages/mux-player/src/media-chrome/dialog.ts
+++ b/packages/mux-player/src/media-chrome/dialog.ts
@@ -61,7 +61,7 @@ const styles = `
   }
 `;
 
-const template = document.createElement("template");
+const template = document.createElement('template');
 template.innerHTML = `
   <style>
     ${styles}
@@ -75,50 +75,42 @@ template.innerHTML = `
 class MediaDialog extends HTMLElement {
   static styles: string = styles;
   static template: HTMLTemplateElement = template;
-  static observedAttributes = ["open"];
+  static observedAttributes = ['open'];
 
   _previouslyFocusedElement?: Element | null;
 
   constructor() {
     super();
 
-    this.attachShadow({ mode: "open" });
-    this.shadowRoot?.appendChild(
-      (this.constructor as any).template.content.cloneNode(true)
-    );
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot?.appendChild((this.constructor as any).template.content.cloneNode(true));
   }
 
   show() {
-    this.setAttribute("open", "");
+    this.setAttribute('open', '');
     focus(this);
   }
 
   close() {
     // If already closed, don't re-emit value (circular due to attributeChangedCallback()) (CJP)
-    if (!this.hasAttribute("open")) return;
-    this.removeAttribute("open");
-    this.dispatchEvent(
-      new CustomEvent("close", { composed: true, bubbles: true })
-    );
+    if (!this.hasAttribute('open')) return;
+    this.removeAttribute('open');
+    this.dispatchEvent(new CustomEvent('close', { composed: true, bubbles: true }));
     restoreFocus(this);
   }
 
-  attributeChangedCallback(
-    attrName: string,
-    oldValue: string | null,
-    newValue: string
-  ) {
-    if (attrName === "open" && oldValue !== newValue) {
+  attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string) {
+    if (attrName === 'open' && oldValue !== newValue) {
       newValue != null ? this.show() : this.close();
     }
   }
 
   connectedCallback() {
-    if (!this.hasAttribute("role")) {
-      this.setAttribute("role", "dialog");
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'dialog');
     }
 
-    if (this.hasAttribute("open")) {
+    if (this.hasAttribute('open')) {
       focus(this);
     }
   }
@@ -126,9 +118,7 @@ class MediaDialog extends HTMLElement {
 
 function focus(el: MediaDialog) {
   // Find element with `autofocus` attribute, or fall back to the first form/tabindex control.
-  let target: Element | null | undefined = el.querySelector(
-    "[autofocus]:not([disabled])"
-  );
+  let target: Element | null | undefined = el.querySelector('[autofocus]:not([disabled])');
   if (!target && (el as HTMLElement).tabIndex >= 0) {
     target = el;
   }
@@ -146,24 +136,22 @@ function focus(el: MediaDialog) {
   }
 }
 
-function findFocusableElementWithin(
-  hostElement: Element | ShadowRoot | null | undefined
-): Element | null | undefined {
+function findFocusableElementWithin(hostElement: Element | ShadowRoot | null | undefined): Element | null | undefined {
   // Note that this is 'any focusable area'. This list is probably not exhaustive, but the
   // alternative involves stepping through and trying to focus everything.
-  const opts = ["button", "input", "keygen", "select", "textarea"];
+  const opts = ['button', 'input', 'keygen', 'select', 'textarea'];
   const query = opts.map(function (el) {
-    return el + ":not([disabled])";
+    return el + ':not([disabled])';
   });
   // TODO(samthor): tabindex values that are not numeric are not focusable.
   query.push('[tabindex]:not([disabled]):not([tabindex=""])'); // tabindex != "", not disabled
-  let target = hostElement?.querySelector(query.join(", "));
+  let target = hostElement?.querySelector(query.join(', '));
 
-  if (!target && "attachShadow" in Element.prototype) {
+  if (!target && 'attachShadow' in Element.prototype) {
     // If we haven't found a focusable target, see if the host element contains an element
     // which has a shadowRoot.
     // Recursively search for the first focusable item in shadow roots.
-    const elems = hostElement?.querySelectorAll("*") || [];
+    const elems = hostElement?.querySelectorAll('*') || [];
     for (let i = 0; i < elems.length; i++) {
       if (elems[i].tagName && elems[i].shadowRoot) {
         target = findFocusableElementWithin(elems[i].shadowRoot);
@@ -183,8 +171,8 @@ function restoreFocus(el: MediaDialog) {
   }
 }
 
-if (!globalThis.customElements.get("media-dialog")) {
-  globalThis.customElements.define("media-dialog", MediaDialog);
+if (!globalThis.customElements.get('media-dialog')) {
+  globalThis.customElements.define('media-dialog', MediaDialog);
   (globalThis as any).MediaDialog = MediaDialog;
 }
 

--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -31,13 +31,13 @@ media-control-bar {
   --media-button-icon-width: 18px;
 }
 
-media-control-bar [role="button"],
-media-control-bar [role="switch"] {
+media-control-bar [role='button'],
+media-control-bar [role='switch'] {
   height: 44px;
 }
 
-.size-extra-small media-control-bar [role="button"],
-.size-extra-small media-control-bar [role="switch"] {
+.size-extra-small media-control-bar [role='button'],
+.size-extra-small media-control-bar [role='switch'] {
   height: auto;
   padding: 4.4% 3.2%;
 }
@@ -118,7 +118,7 @@ media-time-display {
 }
 
 .mxp-live-indicator::before {
-  content: "● ";
+  content: '● ';
   color: #fb3c4d;
   padding-right: 5px;
 }

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -1,29 +1,29 @@
-import "./dialog";
-import "./time-display";
+import './dialog';
+import './time-display';
 import {
   getChromeStylesFromProps,
   getSrcFromPlaybackId,
   getPosterURLFromPlaybackId,
   getStoryboardURLFromPlaybackId,
-} from "./helpers";
-import { html } from "./html";
-import * as icons from "./icons";
+} from './helpers';
+import { html } from './html';
+import * as icons from './icons';
 // @ts-ignore
-import cssStr from "./styles.css";
-import { i18n } from "./utils";
+import cssStr from './styles.css';
+import { i18n } from './utils';
 
-import type { MuxTemplateProps } from "./types";
+import type { MuxTemplateProps } from './types';
 
 export const StreamTypes = {
-  VOD: "on-demand",
-  LIVE: "live",
-  LL_LIVE: "ll-live",
+  VOD: 'on-demand',
+  LIVE: 'live',
+  LL_LIVE: 'll-live',
 };
 
 const MediaChromeSizes = {
-  LG: "large",
-  SM: "small",
-  XS: "extra-small",
+  LG: 'large',
+  SM: 'small',
+  XS: 'extra-small',
 };
 
 const Spacer = () => html`<div class="mxp-spacer"></div>`;
@@ -32,10 +32,7 @@ export const template = (props: MuxTemplateProps) => html`
   <style>
     ${cssStr}
   </style>
-  <media-controller
-    style="${getChromeStylesFromProps(props) ?? false}"
-    class="size-${props.playerSize}"
-  >
+  <media-controller style="${getChromeStylesFromProps(props) ?? false}" class="size-${props.playerSize}">
     <mux-video
       slot="media"
       crossorigin
@@ -65,31 +62,18 @@ export const template = (props: MuxTemplateProps) => html`
       metadata-video-title="${props.metadata?.video_title ?? false}"
       metadata-viewer-user-id="${props.metadata?.viewer_user_id ?? false}"
     >
-      ${props.playbackId &&
-      props.streamType !== StreamTypes.LIVE &&
-      props.streamType !== StreamTypes.LL_LIVE
+      ${props.playbackId && props.streamType !== StreamTypes.LIVE && props.streamType !== StreamTypes.LL_LIVE
         ? html`<track
             label="thumbnails"
             default
             kind="metadata"
-            src="${getStoryboardURLFromPlaybackId(
-              props.playbackId,
-              props.tokens.storyboard
-            )}"
+            src="${getStoryboardURLFromPlaybackId(props.playbackId, props.tokens.storyboard)}"
           />`
-        : ""}
+        : ''}
     </mux-video>
-    <media-loading-indicator
-      slot="centered-chrome"
-      no-auto-hide
-    ></media-loading-indicator>
+    <media-loading-indicator slot="centered-chrome" no-auto-hide></media-loading-indicator>
     ${ChromeRenderer(props)}
-    <mxp-dialog
-      slot="centered-chrome"
-      no-auto-hide
-      open="${props.isDialogOpen}"
-      onclose="${props.onCloseErrorDialog}"
-    >
+    <mxp-dialog slot="centered-chrome" no-auto-hide open="${props.isDialogOpen}" onclose="${props.onCloseErrorDialog}">
       ${props.dialog?.title && html`<h3>${props.dialog.title}</h3>`}
       <p>
         ${props.dialog?.message}
@@ -98,8 +82,7 @@ export const template = (props: MuxTemplateProps) => html`
           href="${props.dialog.linkUrl}"
           target="_blank"
           rel="external noopener"
-          aria-label="${props.dialog.linkText ??
-          ""} ${i18n`(opens in a new window)`}"
+          aria-label="${props.dialog.linkText ?? ''} ${i18n`(opens in a new window)`}"
           >${props.dialog.linkText ?? props.dialog.linkUrl}</a
         >`}
       </p>

--- a/packages/mux-player/src/time-display.ts
+++ b/packages/mux-player/src/time-display.ts
@@ -4,7 +4,7 @@ const styles = `
   }
 `;
 
-const template = document.createElement("template");
+const template = document.createElement('template');
 template.innerHTML = `
   <style>
     ${styles}
@@ -12,7 +12,7 @@ template.innerHTML = `
   <media-time-display show-duration></media-time-display>
 `;
 
-const ButtonPressedKeys = ["Enter", " "];
+const ButtonPressedKeys = ['Enter', ' '];
 
 class MxpTimeDisplay extends HTMLElement {
   static styles: string = styles;
@@ -22,18 +22,16 @@ class MxpTimeDisplay extends HTMLElement {
   constructor() {
     super();
 
-    this.attachShadow({ mode: "open" });
-    this.shadowRoot?.appendChild(
-      (this.constructor as any).template.content.cloneNode(true)
-    );
-    this.timeDisplayEl = this.shadowRoot?.querySelector("media-time-display");
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot?.appendChild((this.constructor as any).template.content.cloneNode(true));
+    this.timeDisplayEl = this.shadowRoot?.querySelector('media-time-display');
   }
 
   toggleTimeDisplay() {
-    if (this.timeDisplayEl?.hasAttribute("remaining")) {
-      this.timeDisplayEl?.removeAttribute("remaining");
+    if (this.timeDisplayEl?.hasAttribute('remaining')) {
+      this.timeDisplayEl?.removeAttribute('remaining');
     } else {
-      this.timeDisplayEl?.setAttribute("remaining", "");
+      this.timeDisplayEl?.setAttribute('remaining', '');
     }
   }
 
@@ -41,28 +39,28 @@ class MxpTimeDisplay extends HTMLElement {
     const keyUpHandler = (e: KeyboardEvent) => {
       const { key } = e;
       if (!ButtonPressedKeys.includes(key)) {
-        this.removeEventListener("keyup", keyUpHandler);
+        this.removeEventListener('keyup', keyUpHandler);
         return;
       }
 
       this.toggleTimeDisplay();
     };
 
-    this.addEventListener("keydown", (e) => {
+    this.addEventListener('keydown', (e) => {
       const { metaKey, altKey, key } = e;
       if (metaKey || altKey || !ButtonPressedKeys.includes(key)) {
-        this.removeEventListener("keyup", keyUpHandler);
+        this.removeEventListener('keyup', keyUpHandler);
         return;
       }
-      this.addEventListener("keyup", keyUpHandler);
+      this.addEventListener('keyup', keyUpHandler);
     });
 
-    this.addEventListener("click", this.toggleTimeDisplay);
+    this.addEventListener('click', this.toggleTimeDisplay);
   }
 }
 
-if (!globalThis.customElements.get("mxp-time-display")) {
-  globalThis.customElements.define("mxp-time-display", MxpTimeDisplay);
+if (!globalThis.customElements.get('mxp-time-display')) {
+  globalThis.customElements.define('mxp-time-display', MxpTimeDisplay);
   (globalThis as any).MxpTimeDisplay = MxpTimeDisplay;
 }
 

--- a/packages/mux-player/src/types.d.ts
+++ b/packages/mux-player/src/types.d.ts
@@ -1,4 +1,4 @@
-import type MuxVideoElement from "@mux-elements/mux-video";
+import type MuxVideoElement from '@mux-elements/mux-video';
 
 export type MuxPlayerProps = Partial<MuxVideoElement> & {
   preferMse?: boolean;

--- a/packages/mux-player/src/utils.ts
+++ b/packages/mux-player/src/utils.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import lang from "../lang/en.json";
+import lang from '../lang/en.json';
 
 // NL example
 // lang = {
@@ -18,14 +18,14 @@ class IntlMessageFormat {
   message: string;
   locale: string;
 
-  constructor(message: string, locale = "en-US") {
+  constructor(message: string, locale = 'en-US') {
     this.message = message;
     this.locale = locale;
   }
 
   format(values: Record<string, any>): string {
     return this.message.replace(/\{(\w+)\}/g, (match, key) => {
-      return values[key] ?? "";
+      return values[key] ?? '';
     });
   }
 
@@ -35,7 +35,7 @@ class IntlMessageFormat {
 }
 
 export function stylePropsToString(props: any) {
-  let style = "";
+  let style = '';
   Object.entries(props).forEach(([key, value]) => {
     style += `${kebabCase(key)}: ${value}; `;
   });
@@ -43,7 +43,7 @@ export function stylePropsToString(props: any) {
 }
 
 export function kebabCase(name: string) {
-  return name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+  return name.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
 }
 
 export function camelCase(name: string) {
@@ -64,7 +64,7 @@ export function toNumberOrUndefined(val: any) {
 
 export function toQuery(obj: Record<string, any>) {
   const params = toParams(obj).toString();
-  return params ? "?" + params : "";
+  return params ? '?' + params : '';
 }
 
 export function toParams(obj: Record<string, any>) {

--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -1,47 +1,47 @@
-import type MuxVideoElement from "@mux-elements/mux-video";
+import type MuxVideoElement from '@mux-elements/mux-video';
 
 const AllowedVideoAttributes = {
-  AUTOPLAY: "autoplay",
-  CROSSORIGIN: "crossorigin",
-  LOOP: "loop",
-  MUTED: "muted",
-  PLAYSINLINE: "playsinline",
-  SRC: "src",
-  POSTER: "poster",
-  PRELOAD: "preload",
+  AUTOPLAY: 'autoplay',
+  CROSSORIGIN: 'crossorigin',
+  LOOP: 'loop',
+  MUTED: 'muted',
+  PLAYSINLINE: 'playsinline',
+  SRC: 'src',
+  POSTER: 'poster',
+  PRELOAD: 'preload',
 };
 
 const CustomVideoAttributes = {
-  VOLUME: "volume",
-  PLAYBACKRATE: "playbackrate",
+  VOLUME: 'volume',
+  PLAYBACKRATE: 'playbackrate',
   // This muted attribute also reflects to the muted property while the muted
   // attribute on a native video element reflects only to video.defaultMuted.
-  MUTED: "muted",
+  MUTED: 'muted',
 };
 
 const AllowedVideoEvents = [
-  "abort",
-  "canplay",
-  "canplaythrough",
-  "emptied",
-  "loadstart",
-  "loadedmetadata",
-  "loadeddata",
-  "progress",
-  "durationchange",
-  "volumechange",
-  "ratechange",
-  "resize",
-  "stalled",
-  "suspend",
-  "waiting",
-  "play",
-  "playing",
-  "timeupdate",
-  "pause",
-  "seeking",
-  "seeked",
-  "ended",
+  'abort',
+  'canplay',
+  'canplaythrough',
+  'emptied',
+  'loadstart',
+  'loadedmetadata',
+  'loadeddata',
+  'progress',
+  'durationchange',
+  'volumechange',
+  'ratechange',
+  'resize',
+  'stalled',
+  'suspend',
+  'waiting',
+  'play',
+  'playing',
+  'timeupdate',
+  'pause',
+  'seeking',
+  'seeked',
+  'ended',
 ];
 
 const AllowedVideoAttributeNames = Object.values(AllowedVideoAttributes);
@@ -60,7 +60,7 @@ class VideoApiElement extends HTMLElement {
   constructor() {
     super();
 
-    this.querySelectorAll(":scope > track").forEach((track) => {
+    this.querySelectorAll(':scope > track').forEach((track) => {
       this.video?.append(track.cloneNode());
     });
 
@@ -68,12 +68,10 @@ class VideoApiElement extends HTMLElement {
     /** @type {(mutationList: MutationRecord[]) => void} */
     const mutationCallback = (mutationsList: MutationRecord[]) => {
       for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
+        if (mutation.type === 'childList') {
           // Child being removed
           mutation.removedNodes.forEach((node) => {
-            const track = this.video?.querySelector(
-              `track[src="${(node as HTMLTrackElement).src}"]`
-            );
+            const track = this.video?.querySelector(`track[src="${(node as HTMLTrackElement).src}"]`);
             if (track) this.video?.removeChild(track);
           });
 
@@ -88,11 +86,7 @@ class VideoApiElement extends HTMLElement {
     observer.observe(this, { childList: true, subtree: true });
   }
 
-  attributeChangedCallback(
-    attrName: string,
-    oldValue: string | null,
-    newValue: string
-  ) {
+  attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string) {
     switch (attrName) {
       case CustomVideoAttributes.MUTED: {
         if (this.video) {
@@ -150,14 +144,14 @@ class VideoApiElement extends HTMLElement {
   }
 
   get video(): MuxVideoElement | null | undefined {
-    return this.shadowRoot?.querySelector("mux-video");
+    return this.shadowRoot?.querySelector('mux-video');
   }
 
   get hasPlayed() {
-    const mc = this.shadowRoot?.querySelector("media-controller");
+    const mc = this.shadowRoot?.querySelector('media-controller');
 
     if (mc) {
-      return mc.hasAttribute("media-has-played");
+      return mc.hasAttribute('media-has-played');
     }
 
     return false;
@@ -220,7 +214,7 @@ class VideoApiElement extends HTMLElement {
   }
 
   get poster() {
-    return getVideoAttribute(this, AllowedVideoAttributes.POSTER) ?? "";
+    return getVideoAttribute(this, AllowedVideoAttributes.POSTER) ?? '';
   }
 
   set poster(val) {
@@ -251,10 +245,7 @@ class VideoApiElement extends HTMLElement {
 
   set autoplay(val) {
     if (val) {
-      this.setAttribute(
-        AllowedVideoAttributes.AUTOPLAY,
-        typeof val === "string" ? val : ""
-      );
+      this.setAttribute(AllowedVideoAttributes.AUTOPLAY, typeof val === 'string' ? val : '');
     } else {
       // Remove boolean attribute if false, 0, '', null, undefined.
       this.removeAttribute(AllowedVideoAttributes.AUTOPLAY);
@@ -267,7 +258,7 @@ class VideoApiElement extends HTMLElement {
 
   set loop(val) {
     if (val) {
-      this.setAttribute(AllowedVideoAttributes.LOOP, "");
+      this.setAttribute(AllowedVideoAttributes.LOOP, '');
     } else {
       // Remove boolean attribute if false, 0, '', null, undefined.
       this.removeAttribute(AllowedVideoAttributes.LOOP);
@@ -280,7 +271,7 @@ class VideoApiElement extends HTMLElement {
 
   set muted(val) {
     if (val) {
-      this.setAttribute(AllowedVideoAttributes.MUTED, "");
+      this.setAttribute(AllowedVideoAttributes.MUTED, '');
     } else {
       // Remove boolean attribute if false, 0, '', null, undefined.
       this.removeAttribute(AllowedVideoAttributes.MUTED);
@@ -293,7 +284,7 @@ class VideoApiElement extends HTMLElement {
 
   set playsInline(val) {
     if (val) {
-      this.setAttribute(AllowedVideoAttributes.PLAYSINLINE, "");
+      this.setAttribute(AllowedVideoAttributes.PLAYSINLINE, '');
     } else {
       // Remove boolean attribute if false, 0, '', null, undefined.
       this.removeAttribute(AllowedVideoAttributes.PLAYSINLINE);

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -1,8 +1,8 @@
-import { fixture, assert, aTimeout } from "@open-wc/testing";
-import "../src/index.ts";
+import { fixture, assert, aTimeout } from '@open-wc/testing';
+import '../src/index.ts';
 
-describe("<mux-player>", () => {
-  it("has a Mux specific API", async function () {
+describe('<mux-player>', () => {
+  it('has a Mux specific API', async function () {
     const player = await fixture(`<mux-player
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
       env-key="ilc02s65tkrc2mk69b7q2qdkf"
@@ -13,23 +13,15 @@ describe("<mux-player>", () => {
       muted
     ></mux-player>`);
 
-    assert.equal(
-      player.playbackId,
-      "DS00Spx1CV902MCtPj5WknGlR102V5HFkDe",
-      "playback-id is reflected"
-    );
-    assert.equal(
-      player.envKey,
-      "ilc02s65tkrc2mk69b7q2qdkf",
-      "env-key is reflected"
-    );
-    assert.equal(player.startTime, 0, "startTime is set to 0");
-    assert.equal(player.streamType, "vod", "stream-type is vod");
-    assert.equal(player.preferMse, true, "prefer-mse is on");
-    assert.equal(player.debug, true, "debug is on");
+    assert.equal(player.playbackId, 'DS00Spx1CV902MCtPj5WknGlR102V5HFkDe', 'playback-id is reflected');
+    assert.equal(player.envKey, 'ilc02s65tkrc2mk69b7q2qdkf', 'env-key is reflected');
+    assert.equal(player.startTime, 0, 'startTime is set to 0');
+    assert.equal(player.streamType, 'vod', 'stream-type is vod');
+    assert.equal(player.preferMse, true, 'prefer-mse is on');
+    assert.equal(player.debug, true, 'debug is on');
   });
 
-  it("has a video like API", async function () {
+  it('has a video like API', async function () {
     this.timeout(10000);
 
     const player = await fixture(`<mux-player
@@ -37,19 +29,19 @@ describe("<mux-player>", () => {
       muted
     ></mux-player>`);
 
-    assert(player.paused, "is paused on initialization");
-    assert(!player.ended, "is not ended");
+    assert(player.paused, 'is paused on initialization');
+    assert(!player.ended, 'is not ended');
 
-    assert(!player.loop, "loop is false by default");
+    assert(!player.loop, 'loop is false by default');
     player.loop = true;
-    assert(player.loop, "loop is true");
+    assert(player.loop, 'loop is true');
 
-    assert.equal(player.volume, 1, "is all turned up");
+    assert.equal(player.volume, 1, 'is all turned up');
     player.volume = 0.5;
-    assert.equal(player.volume, 0.5, "is half volume");
+    assert.equal(player.volume, 0.5, 'is half volume');
 
     player.muted = true;
-    assert(player.muted, "is muted");
+    assert(player.muted, 'is muted');
 
     try {
       await player.play();
@@ -57,29 +49,29 @@ describe("<mux-player>", () => {
       console.warn(error);
     }
 
-    assert(!player.paused, "is playing after player.play()");
+    assert(!player.paused, 'is playing after player.play()');
     assert.equal(Math.round(player.duration), 134, `is 134s long`);
 
     await aTimeout(1000);
 
-    assert.equal(String(Math.round(player.currentTime)), 1, "is about 1s in");
+    assert.equal(String(Math.round(player.currentTime)), 1, 'is about 1s in');
 
     player.playbackRate = 2;
     await aTimeout(1000);
 
-    assert.equal(String(Math.round(player.currentTime)), 3, "is about 3s in");
+    assert.equal(String(Math.round(player.currentTime)), 3, 'is about 3s in');
   });
 
-  it("playbackId is forwarded to the media element", async function () {
+  it('playbackId is forwarded to the media element', async function () {
     const player = await fixture(`<mux-player
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
       muted
     ></mux-player>`);
 
-    assert.equal(player.playbackId, "DS00Spx1CV902MCtPj5WknGlR102V5HFkDe");
+    assert.equal(player.playbackId, 'DS00Spx1CV902MCtPj5WknGlR102V5HFkDe');
   });
 
-  it("autoplay is forwarded to the media element", async function () {
+  it('autoplay is forwarded to the media element', async function () {
     const player = await fixture(`<mux-player
       autoplay
     ></mux-player>`);
@@ -88,19 +80,15 @@ describe("<mux-player>", () => {
     assert.equal(player.autoplay, true);
     assert.equal(muxVideo.autoplay, true);
 
-    player.removeAttribute("autoplay");
-    assert(!muxVideo.hasAttribute("autoplay"), `has autoplay attr removed`);
+    player.removeAttribute('autoplay');
+    assert(!muxVideo.hasAttribute('autoplay'), `has autoplay attr removed`);
 
-    player.setAttribute("autoplay", "");
-    assert.equal(
-      muxVideo.getAttribute("autoplay"),
-      "",
-      `has autoplay attr added`
-    );
+    player.setAttribute('autoplay', '');
+    assert.equal(muxVideo.getAttribute('autoplay'), '', `has autoplay attr added`);
     assert.equal(muxVideo.autoplay, true, `has autoplay enabled`);
   });
 
-  it("muted is forwarded to the media element", async function () {
+  it('muted is forwarded to the media element', async function () {
     const player = await fixture(`<mux-player
       muted
     ></mux-player>`);
@@ -109,11 +97,11 @@ describe("<mux-player>", () => {
     assert.equal(player.muted, true);
     assert.equal(muxVideo.muted, true);
 
-    player.removeAttribute("muted");
-    assert(!muxVideo.hasAttribute("muted"), `has muted attr removed`);
+    player.removeAttribute('muted');
+    assert(!muxVideo.hasAttribute('muted'), `has muted attr removed`);
 
-    player.setAttribute("muted", "");
-    assert.equal(muxVideo.getAttribute("muted"), "", `has muted attr added`);
+    player.setAttribute('muted', '');
+    assert.equal(muxVideo.getAttribute('muted'), '', `has muted attr added`);
     assert.equal(muxVideo.muted, true, `has muted enabled`);
   });
 
@@ -141,7 +129,7 @@ describe("<mux-player>", () => {
   //   assert.equal(muxVideo.playsInline, true, `has playsInline enabled`);
   // });
 
-  it("loop is forwarded to the media element", async function () {
+  it('loop is forwarded to the media element', async function () {
     const player = await fixture(`<mux-player
       loop
     ></mux-player>`);
@@ -150,11 +138,11 @@ describe("<mux-player>", () => {
     assert.equal(player.loop, true);
     assert.equal(muxVideo.loop, true);
 
-    player.removeAttribute("loop");
-    assert(!muxVideo.hasAttribute("loop"), `has loop attr removed`);
+    player.removeAttribute('loop');
+    assert(!muxVideo.hasAttribute('loop'), `has loop attr removed`);
 
-    player.setAttribute("loop", "");
-    assert.equal(muxVideo.getAttribute("loop"), "", `has loop attr added`);
+    player.setAttribute('loop', '');
+    assert.equal(muxVideo.getAttribute('loop'), '', `has loop attr added`);
     assert.equal(muxVideo.loop, true, `has loop enabled`);
   });
 
@@ -186,28 +174,24 @@ describe("<mux-player>", () => {
   //   );
   // });
 
-  it("preload is forwarded to the media element", async function () {
+  it('preload is forwarded to the media element', async function () {
     const player = await fixture(`<mux-player
       preload="metadata"
     ></mux-player>`);
     const muxVideo = player.video;
 
-    assert.equal(player.preload, "metadata");
-    assert.equal(muxVideo.preload, "metadata");
+    assert.equal(player.preload, 'metadata');
+    assert.equal(muxVideo.preload, 'metadata');
 
-    player.removeAttribute("preload");
-    assert(!muxVideo.hasAttribute("preload"), `has preload attr removed`);
+    player.removeAttribute('preload');
+    assert(!muxVideo.hasAttribute('preload'), `has preload attr removed`);
 
-    player.setAttribute("preload", "auto");
-    assert.equal(
-      muxVideo.getAttribute("preload"),
-      "auto",
-      `has preload attr added`
-    );
-    assert.equal(muxVideo.preload, "auto", `has preload enabled`);
+    player.setAttribute('preload', 'auto');
+    assert.equal(muxVideo.getAttribute('preload'), 'auto', `has preload attr added`);
+    assert.equal(muxVideo.preload, 'auto', `has preload enabled`);
   });
 
-  it("poster is forwarded to the media element", async function () {
+  it('poster is forwarded to the media element', async function () {
     const player = await fixture(`<mux-player
       poster="https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=0"
     ></mux-player>`);
@@ -215,138 +199,125 @@ describe("<mux-player>", () => {
 
     assert.equal(
       player.poster,
-      "https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=0"
+      'https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=0'
     );
     assert.equal(
       muxVideo.poster,
-      "https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=0"
+      'https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=0'
     );
 
-    player.removeAttribute("poster");
-    assert(!muxVideo.hasAttribute("poster"), `has poster attr removed`);
+    player.removeAttribute('poster');
+    assert(!muxVideo.hasAttribute('poster'), `has poster attr removed`);
 
     player.setAttribute(
-      "poster",
-      "https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=1"
+      'poster',
+      'https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=1'
     );
     assert.equal(
-      muxVideo.getAttribute("poster"),
-      "https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=1",
+      muxVideo.getAttribute('poster'),
+      'https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=1',
       `has poster attr added`
     );
     assert.equal(
       muxVideo.poster,
-      "https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=1",
+      'https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=1',
       `has poster enabled`
     );
   });
 
-  it("src is forwarded to the media element", async function () {
+  it('src is forwarded to the media element', async function () {
     const player = await fixture(`<mux-player
       src="https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8"
     ></mux-player>`);
     const muxVideo = player.video;
 
-    assert.equal(
-      player.src,
-      "https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8"
-    );
-    assert.equal(
-      muxVideo.src,
-      "https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8"
-    );
+    assert.equal(player.src, 'https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8');
+    assert.equal(muxVideo.src, 'https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8');
 
-    player.removeAttribute("src");
-    assert(!muxVideo.hasAttribute("src"), `has src attr removed`);
+    player.removeAttribute('src');
+    assert(!muxVideo.hasAttribute('src'), `has src attr removed`);
 
-    player.setAttribute(
-      "src",
-      "https://stream.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE.m3u8"
-    );
+    player.setAttribute('src', 'https://stream.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE.m3u8');
     assert.equal(
-      muxVideo.getAttribute("src"),
-      "https://stream.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE.m3u8",
+      muxVideo.getAttribute('src'),
+      'https://stream.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE.m3u8',
       `has src attr added`
     );
     assert.equal(
       muxVideo.src,
-      "https://stream.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE.m3u8",
+      'https://stream.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE.m3u8',
       `has src enabled`
     );
   });
 
-  it("muted attribute behaves like expected", async function () {
+  it('muted attribute behaves like expected', async function () {
     const player = await fixture(`<mux-player
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
       muted
     ></mux-player>`);
 
     const muxVideo = player.video;
-    const nativeVideo = muxVideo.shadowRoot.querySelector("video");
+    const nativeVideo = muxVideo.shadowRoot.querySelector('video');
 
-    assert(player.muted, "player.muted is true");
-    assert(muxVideo.muted, "muxVideo.muted is true");
-    assert(nativeVideo.muted, "nativeVideo.muted is true");
+    assert(player.muted, 'player.muted is true');
+    assert(muxVideo.muted, 'muxVideo.muted is true');
+    assert(nativeVideo.muted, 'nativeVideo.muted is true');
 
-    player.removeAttribute("muted");
+    player.removeAttribute('muted');
 
-    assert(!player.muted, "player.muted is false");
-    assert(!muxVideo.muted, "muxVideo.muted is false");
-    assert(!nativeVideo.muted, "nativeVideo.muted is false");
+    assert(!player.muted, 'player.muted is false');
+    assert(!muxVideo.muted, 'muxVideo.muted is false');
+    assert(!nativeVideo.muted, 'nativeVideo.muted is false');
 
-    player.setAttribute("muted", "");
+    player.setAttribute('muted', '');
 
-    assert(player.muted, "player.muted is true");
-    assert(muxVideo.muted, "muxVideo.muted is true");
-    assert(nativeVideo.muted, "nativeVideo.muted is true");
+    assert(player.muted, 'player.muted is true');
+    assert(muxVideo.muted, 'muxVideo.muted is true');
+    assert(nativeVideo.muted, 'nativeVideo.muted is true');
   });
 
-  it("volume attribute behaves like expected", async function () {
+  it('volume attribute behaves like expected', async function () {
     const player = await fixture(`<mux-player
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
       volume="0.4"
     ></mux-player>`);
 
-    assert.equal(player.getAttribute("volume"), "0.4");
+    assert.equal(player.getAttribute('volume'), '0.4');
 
     const muxVideo = player.video;
-    const nativeVideo = muxVideo.shadowRoot.querySelector("video");
+    const nativeVideo = muxVideo.shadowRoot.querySelector('video');
 
-    assert.equal(player.volume, 0.4, "player.volume is 0.4");
-    assert.equal(muxVideo.volume, 0.4, "muxVideo.volume is 0.4");
-    assert.equal(nativeVideo.volume, 0.4, "nativeVideo.volume is 0.4");
+    assert.equal(player.volume, 0.4, 'player.volume is 0.4');
+    assert.equal(muxVideo.volume, 0.4, 'muxVideo.volume is 0.4');
+    assert.equal(nativeVideo.volume, 0.4, 'nativeVideo.volume is 0.4');
 
-    player.setAttribute("volume", "0.9");
+    player.setAttribute('volume', '0.9');
 
-    assert.equal(player.volume, 0.9, "player.volume is 0.9");
-    assert.equal(muxVideo.volume, 0.9, "muxVideo.volume is 0.9");
-    assert.equal(nativeVideo.volume, 0.9, "nativeVideo.volume is 0.9");
+    assert.equal(player.volume, 0.9, 'player.volume is 0.9');
+    assert.equal(muxVideo.volume, 0.9, 'muxVideo.volume is 0.9');
+    assert.equal(nativeVideo.volume, 0.9, 'nativeVideo.volume is 0.9');
   });
 
-  it("playbackrate attribute behaves like expected", async function () {
+  it('playbackrate attribute behaves like expected', async function () {
     const player = await fixture(`<mux-player
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
       playbackrate="2"
     ></mux-player>`);
 
-    assert.equal(player.getAttribute("playbackrate"), "2");
+    assert.equal(player.getAttribute('playbackrate'), '2');
 
     const muxVideo = player.video;
-    const nativeVideo = muxVideo.shadowRoot.querySelector("video");
+    const nativeVideo = muxVideo.shadowRoot.querySelector('video');
 
-    assert.equal(player.playbackRate, 2, "player.playbackRate is 2");
-    assert.equal(muxVideo.playbackRate, 2, "muxVideo.playbackRate is 2");
-    assert.equal(nativeVideo.playbackRate, 2, "nativeVideo.playbackRate is 2");
+    assert.equal(player.playbackRate, 2, 'player.playbackRate is 2');
+    assert.equal(muxVideo.playbackRate, 2, 'muxVideo.playbackRate is 2');
+    assert.equal(nativeVideo.playbackRate, 2, 'nativeVideo.playbackRate is 2');
 
-    player.setAttribute("playbackrate", "0.7");
+    player.setAttribute('playbackrate', '0.7');
 
-    assert.equal(player.playbackRate, 0.7, "player.playbackRate is 0.7");
-    assert.equal(muxVideo.playbackRate, 0.7, "muxVideo.playbackRate is 0.7");
-    assert.equal(
-      nativeVideo.playbackRate,
-      0.7,
-      "nativeVideo.playbackRate is 0.7"
-    );
+    assert.equal(player.playbackRate, 0.7, 'player.playbackRate is 0.7');
+    assert.equal(muxVideo.playbackRate, 0.7, 'muxVideo.playbackRate is 0.7');
+    assert.equal(nativeVideo.playbackRate, 0.7, 'nativeVideo.playbackRate is 0.7');
   });
 
   it("signing tokens generate correct asset URL's", async function () {
@@ -359,23 +330,21 @@ describe("<mux-player>", () => {
     ></mux-player>`);
 
     const muxVideo = player.video;
-    const storyboardTrack = muxVideo.shadowRoot.querySelector(
-      "track[label='thumbnails']"
+    const storyboardTrack = muxVideo.shadowRoot.querySelector("track[label='thumbnails']");
+
+    assert.equal(
+      muxVideo.getAttribute('src'),
+      'https://stream.mux.com/bos2bPV3qbFgpVPaQ900Xd5UcdM6WXTmz02WZSz01nJ00tY.m3u8?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE5NjE2MDE2MjgsImF1ZCI6InYiLCJzdWIiOiJib3MyYlBWM3FiRmdwVlBhUTkwMFhkNVVjZE02V1hUbXowMldaU3owMW5KMDB0WSJ9.OUegJAmrlvD9BhzUhogrup_mYRBYNG2ocqmJZK2lKPLFmP1jLKi99Lj_9ZQqIXgmoYeXo2jKr3WFMO8nbGwtZFKU2_szq1EWlj4mBgdWXfAP5amC92qkm87nIuNFM2WVANGlBksmj8uOmYNIuPh1Ctti1qiJEYkf-JthWFFpaR_2TlQJ7g0bmRPzk3nOPDtqZnJBfTVm3n4Kp7Cr27a_VBA6zpoW6DwjJ6_uPkm6TAxXjw7VWNd3YVLs7S_jgs8q3t9DPpAN57q94syVQtEUkRh4tlDX-gdIrJDi9nFB1fIBh45pD01PvrAWzZXKKE9YSW7dnktqSUy81kcu2F_gXA'
     );
 
     assert.equal(
-      muxVideo.getAttribute("src"),
-      "https://stream.mux.com/bos2bPV3qbFgpVPaQ900Xd5UcdM6WXTmz02WZSz01nJ00tY.m3u8?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE5NjE2MDE2MjgsImF1ZCI6InYiLCJzdWIiOiJib3MyYlBWM3FiRmdwVlBhUTkwMFhkNVVjZE02V1hUbXowMldaU3owMW5KMDB0WSJ9.OUegJAmrlvD9BhzUhogrup_mYRBYNG2ocqmJZK2lKPLFmP1jLKi99Lj_9ZQqIXgmoYeXo2jKr3WFMO8nbGwtZFKU2_szq1EWlj4mBgdWXfAP5amC92qkm87nIuNFM2WVANGlBksmj8uOmYNIuPh1Ctti1qiJEYkf-JthWFFpaR_2TlQJ7g0bmRPzk3nOPDtqZnJBfTVm3n4Kp7Cr27a_VBA6zpoW6DwjJ6_uPkm6TAxXjw7VWNd3YVLs7S_jgs8q3t9DPpAN57q94syVQtEUkRh4tlDX-gdIrJDi9nFB1fIBh45pD01PvrAWzZXKKE9YSW7dnktqSUy81kcu2F_gXA"
+      muxVideo.getAttribute('poster'),
+      'https://image.mux.com/bos2bPV3qbFgpVPaQ900Xd5UcdM6WXTmz02WZSz01nJ00tY/thumbnail.jpg?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE5NjE2MDE3MzYsImF1ZCI6InQiLCJzdWIiOiJib3MyYlBWM3FiRmdwVlBhUTkwMFhkNVVjZE02V1hUbXowMldaU3owMW5KMDB0WSJ9.gDe_efqmRB5E3e4ag6in8MfMK-Vn3c_3B4M-BiWw6lg2aaf2BOTv7ltxhn2cvg4G0iFi-esRjhDlHbMRTxwTGavsx8TRLFtJ8vyBzToaFQbQMrn9OZztq_XrCEwqkD8bUAVtdOT1YB606OZyy6XO-CxdMRrKMUsM-cGrfv0TxvzJjThJBY4SzFv_whtYRxqAypZojROU7IiTbqcsk_cSrRMjB7WyAOAvyPNKnr6RkVEuMJtlCtaf_e4DIJHebZUZb3JmVTG4jIWrD1QkN7uLUwCPPRvGhXwhet9JaJPyC5lmkcb9YmH-15V6GOpwSg7sDMGC3YS4aIb_RtVkan0t-w'
     );
 
     assert.equal(
-      muxVideo.getAttribute("poster"),
-      "https://image.mux.com/bos2bPV3qbFgpVPaQ900Xd5UcdM6WXTmz02WZSz01nJ00tY/thumbnail.jpg?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE5NjE2MDE3MzYsImF1ZCI6InQiLCJzdWIiOiJib3MyYlBWM3FiRmdwVlBhUTkwMFhkNVVjZE02V1hUbXowMldaU3owMW5KMDB0WSJ9.gDe_efqmRB5E3e4ag6in8MfMK-Vn3c_3B4M-BiWw6lg2aaf2BOTv7ltxhn2cvg4G0iFi-esRjhDlHbMRTxwTGavsx8TRLFtJ8vyBzToaFQbQMrn9OZztq_XrCEwqkD8bUAVtdOT1YB606OZyy6XO-CxdMRrKMUsM-cGrfv0TxvzJjThJBY4SzFv_whtYRxqAypZojROU7IiTbqcsk_cSrRMjB7WyAOAvyPNKnr6RkVEuMJtlCtaf_e4DIJHebZUZb3JmVTG4jIWrD1QkN7uLUwCPPRvGhXwhet9JaJPyC5lmkcb9YmH-15V6GOpwSg7sDMGC3YS4aIb_RtVkan0t-w"
-    );
-
-    assert.equal(
-      storyboardTrack.getAttribute("src"),
-      "https://image.mux.com/bos2bPV3qbFgpVPaQ900Xd5UcdM6WXTmz02WZSz01nJ00tY/storyboard.vtt?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE5NjE2MDE3NzcsImF1ZCI6InMiLCJzdWIiOiJib3MyYlBWM3FiRmdwVlBhUTkwMFhkNVVjZE02V1hUbXowMldaU3owMW5KMDB0WSJ9.aVd0dsOJUVeQko3BWd9YEhL41Eytf_ZfaBeNzHSSUqU_gREa_jJEVTlRfuiE4g71cKJLSiVTKP7f-F7Txh6DlL8E2SkonfIPB2H0f_3DQxYLso2E8qI4zuJkyxKORbQFLAEB_vSE-2lMbrHXfdpQhv6SrVyu6di9ku0LpFpoyz-_7fVJICr8nhlsqOGt66AYcaa99TXoZ582FWzBaePmWw-WWKYsLvtNjLS9UoxbdVaBRwNylohvhh-i1Y9dNilyNooJ7O8Cj4GuMjeh1pCj0BOrGagxrWrswm3HjUVNUqFq5JCWnJCxgjjwiV4RLZg_4z7gkBXyX7H2-i1dKA3Cpw"
+      storyboardTrack.getAttribute('src'),
+      'https://image.mux.com/bos2bPV3qbFgpVPaQ900Xd5UcdM6WXTmz02WZSz01nJ00tY/storyboard.vtt?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE5NjE2MDE3NzcsImF1ZCI6InMiLCJzdWIiOiJib3MyYlBWM3FiRmdwVlBhUTkwMFhkNVVjZE02V1hUbXowMldaU3owMW5KMDB0WSJ9.aVd0dsOJUVeQko3BWd9YEhL41Eytf_ZfaBeNzHSSUqU_gREa_jJEVTlRfuiE4g71cKJLSiVTKP7f-F7Txh6DlL8E2SkonfIPB2H0f_3DQxYLso2E8qI4zuJkyxKORbQFLAEB_vSE-2lMbrHXfdpQhv6SrVyu6di9ku0LpFpoyz-_7fVJICr8nhlsqOGt66AYcaa99TXoZ582FWzBaePmWw-WWKYsLvtNjLS9UoxbdVaBRwNylohvhh-i1Y9dNilyNooJ7O8Cj4GuMjeh1pCj0BOrGagxrWrswm3HjUVNUqFq5JCWnJCxgjjwiV4RLZg_4z7gkBXyX7H2-i1dKA3Cpw'
     );
   });
 });

--- a/packages/mux-player/test/utils.test.js
+++ b/packages/mux-player/test/utils.test.js
@@ -1,21 +1,21 @@
-import { assert } from "@open-wc/testing";
-import { stylePropsToString, uniqueId } from "../src/utils.ts";
+import { assert } from '@open-wc/testing';
+import { stylePropsToString, uniqueId } from '../src/utils.ts';
 
-describe("utils", () => {
-  it("stylePropsToString", function () {
+describe('utils', () => {
+  it('stylePropsToString', function () {
     assert.equal(
       stylePropsToString({
-        fontSize: "12px",
-        color: "#fff",
+        fontSize: '12px',
+        color: '#fff',
       }),
-      "font-size: 12px; color: #fff;"
+      'font-size: 12px; color: #fff;'
     );
   });
 
-  it("uniqueId", function () {
-    let id = uniqueId("uid");
-    assert.equal(id, "uid1");
+  it('uniqueId', function () {
+    let id = uniqueId('uid');
+    assert.equal(id, 'uid1');
 
-    assert.notEqual(uniqueId("uid"), id);
+    assert.notEqual(uniqueId('uid'), id);
   });
 });

--- a/packages/mux-player/test/web-test-runner.config.mjs
+++ b/packages/mux-player/test/web-test-runner.config.mjs
@@ -1,4 +1,4 @@
-import { esbuildPlugin } from "@web/dev-server-esbuild";
+import { esbuildPlugin } from '@web/dev-server-esbuild';
 
 export default {
   nodeResolve: true,
@@ -6,11 +6,11 @@ export default {
     esbuildPlugin({
       ts: true,
       json: true,
-      loaders: { ".css": "text", ".svg": "text" },
+      loaders: { '.css': 'text', '.svg': 'text' },
     }),
   ],
   coverageConfig: {
     report: true,
-    include: ["src/**/*"],
+    include: ['src/**/*'],
   },
 };

--- a/packages/mux-video-react/README.md
+++ b/packages/mux-video-react/README.md
@@ -30,13 +30,13 @@ npm i @mux-elements/mux-video-react
 Then, import the library into your application with either `import` or `require`:
 
 ```js
-import MuxVideo from "@mux-elements/mux-video-react";
+import MuxVideo from '@mux-elements/mux-video-react';
 ```
 
 or
 
 ```js
-const MuxVideo = require("@mux-elements/mux-video-react");
+const MuxVideo = require('@mux-elements/mux-video-react');
 ```
 
 ## Features and benefits
@@ -59,12 +59,12 @@ const MuxVideoExample = () => {
     <div>
       <h1>Simple MuxVideo Example</h1>
       <MuxVideo
-        style={{ height: "100%", maxWidth: "100%" }}
+        style={{ height: '100%', maxWidth: '100%' }}
         playbackId="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
         metadata={{
-          video_id: "video-id-123456",
-          video_title: "Super Interesting Video",
-          viewer_user_id: "user-id-bc-789",
+          video_id: 'video-id-123456',
+          video_title: 'Super Interesting Video',
+          viewer_user_id: 'user-id-bc-789',
         }}
         envKey="YOUR_MUX_DATA_ENV_KEY"
         streamType="on-demand"
@@ -101,9 +101,9 @@ If you prefer to use the in-code MSE-based engine (currently hls.js) whenever po
 <MuxVideo
   playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
   metadata={{
-    video_id: "video-id-123456",
-    video_title: "Super Interesting Video",
-    viewer_user_id: "user-id-bc-789",
+    video_id: 'video-id-123456',
+    video_title: 'Super Interesting Video',
+    viewer_user_id: 'user-id-bc-789',
   }}
   envKey="YOUR_MUX_DATA_ENV_KEY"
   preferMse
@@ -119,9 +119,9 @@ By default `<MuxVideo/>` will try to figure out the type of media you're trying 
 <MuxVideo
   src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe/high.mp4"
   metadata={{
-    video_id: "video-id-123456",
-    video_title: "Super Interesting Video",
-    viewer_user_id: "user-id-bc-789",
+    video_id: 'video-id-123456',
+    video_title: 'Super Interesting Video',
+    viewer_user_id: 'user-id-bc-789',
   }}
   envKey="YOUR_MUX_DATA_ENV_KEY"
   controls
@@ -135,9 +135,9 @@ Sometimes, however, your `src` URL may not have an identifiable extension. In th
   src="https://stream.notmux.com/path/to/an/hls/source/playlist"
   type="application/vnd.apple.mpegurl"
   metadata={{
-    video_id: "video-id-123456",
-    video_title: "Super Interesting Video",
-    viewer_user_id: "user-id-bc-789",
+    video_id: 'video-id-123456',
+    video_title: 'Super Interesting Video',
+    viewer_user_id: 'user-id-bc-789',
   }}
   envKey="YOUR_MUX_DATA_ENV_KEY"
   controls
@@ -151,9 +151,9 @@ Or, for convenience, we also support the shorthand `type="hls`:
   src="https://stream.notmux.com/path/to/an/hls/source/playlist"
   type="hls"
   metadata={{
-    video_id: "video-id-123456",
-    video_title: "Super Interesting Video",
-    viewer_user_id: "user-id-bc-789",
+    video_id: 'video-id-123456',
+    video_title: 'Super Interesting Video',
+    viewer_user_id: 'user-id-bc-789',
   }}
   envKey="YOUR_MUX_DATA_ENV_KEY"
   controls

--- a/packages/mux-video-react/src/env.ts
+++ b/packages/mux-video-react/src/env.ts
@@ -1,13 +1,13 @@
-export const isMaybeBrowser = () => typeof window != "undefined";
+export const isMaybeBrowser = () => typeof window != 'undefined';
 // @ts-ignore
-export const isMaybeServer = () => typeof global != "undefined";
+export const isMaybeServer = () => typeof global != 'undefined';
 
 const getEnvPlayerVersion = () => {
   try {
     // @ts-ignore
     return PLAYER_VERSION as string;
   } catch {}
-  return "UNKNOWN";
+  return 'UNKNOWN';
 };
 
 const player_version: string = getEnvPlayerVersion();

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -1,6 +1,6 @@
-import useCombinedRefs from "./use-combined-refs";
-import React, { useEffect, useRef, useState } from "react";
-import PropTypes from "prop-types";
+import useCombinedRefs from './use-combined-refs';
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
 import {
   allMediaTypes,
   initialize,
@@ -10,86 +10,73 @@ import {
   toMuxVideoURL,
   PlaybackEngine,
   generatePlayerInitTime,
-} from "@mux-elements/playback-core";
-import { getPlayerVersion } from "./env";
+} from '@mux-elements/playback-core';
+import { getPlayerVersion } from './env';
 
 export type Props = Omit<
-  React.DetailedHTMLProps<
-    React.VideoHTMLAttributes<HTMLVideoElement>,
-    HTMLVideoElement
-  >,
-  "autoPlay"
+  React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>,
+  'autoPlay'
 > &
   MuxMediaProps;
 
 const playerSoftwareVersion = getPlayerVersion();
-const playerSoftwareName = "mux-video-react";
+const playerSoftwareName = 'mux-video-react';
 
-const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
-  (props, ref) => {
-    const {
-      envKey,
-      debug,
-      beaconDomain,
-      playbackId,
-      preferMse,
-      type,
-      streamType,
-      startTime,
-      src: outerSrc,
-      children,
-      autoPlay,
-      ...restProps
-    } = props;
+const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>((props, ref) => {
+  const {
+    envKey,
+    debug,
+    beaconDomain,
+    playbackId,
+    preferMse,
+    type,
+    streamType,
+    startTime,
+    src: outerSrc,
+    children,
+    autoPlay,
+    ...restProps
+  } = props;
 
-    const [playerInitTime] = useState(generatePlayerInitTime());
+  const [playerInitTime] = useState(generatePlayerInitTime());
 
-    const [src, setSrc] = useState<MuxMediaProps["src"]>(
-      toMuxVideoURL(playbackId) ?? outerSrc
-    );
+  const [src, setSrc] = useState<MuxMediaProps['src']>(toMuxVideoURL(playbackId) ?? outerSrc);
 
-    const playbackEngineRef = useRef<PlaybackEngine | undefined>(undefined);
-    const innerMediaElRef = useRef<HTMLVideoElement>(null);
-    const [updateAutoplay, setUpdateAutoplay] = useState(() => (x: any) => {});
+  const playbackEngineRef = useRef<PlaybackEngine | undefined>(undefined);
+  const innerMediaElRef = useRef<HTMLVideoElement>(null);
+  const [updateAutoplay, setUpdateAutoplay] = useState(() => (x: any) => {});
 
-    const mediaElRef = useCombinedRefs(innerMediaElRef, ref);
+  const mediaElRef = useCombinedRefs(innerMediaElRef, ref);
 
-    useEffect(() => {
-      const src = toMuxVideoURL(playbackId) ?? outerSrc;
-      setSrc(src);
-    }, [outerSrc, playbackId]);
+  useEffect(() => {
+    const src = toMuxVideoURL(playbackId) ?? outerSrc;
+    setSrc(src);
+  }, [outerSrc, playbackId]);
 
-    useEffect(() => {
-      const propsWithState = {
-        ...props,
-        src,
-        playerInitTime,
-        playerSoftwareName,
-        playerSoftwareVersion,
-        autoplay: autoPlay,
-      };
-      const nextPlaybackEngineRef = initialize(
-        propsWithState,
-        mediaElRef.current,
-        playbackEngineRef.current
-      );
-      playbackEngineRef.current = nextPlaybackEngineRef;
-      setUpdateAutoplay(() =>
-        setupAutoplay(mediaElRef.current, autoPlay, playbackEngineRef.current)
-      );
-    }, [src]);
+  useEffect(() => {
+    const propsWithState = {
+      ...props,
+      src,
+      playerInitTime,
+      playerSoftwareName,
+      playerSoftwareVersion,
+      autoplay: autoPlay,
+    };
+    const nextPlaybackEngineRef = initialize(propsWithState, mediaElRef.current, playbackEngineRef.current);
+    playbackEngineRef.current = nextPlaybackEngineRef;
+    setUpdateAutoplay(() => setupAutoplay(mediaElRef.current, autoPlay, playbackEngineRef.current));
+  }, [src]);
 
-    useEffect(() => {
-      updateAutoplay(autoPlay);
-    }, [autoPlay]);
+  useEffect(() => {
+    updateAutoplay(autoPlay);
+  }, [autoPlay]);
 
-    return (
-      <video ref={mediaElRef} {...restProps}>
-        {children}
-      </video>
-    );
-  }
-);
+  return (
+    <video ref={mediaElRef} {...restProps}>
+      {children}
+    </video>
+  );
+});
 
 MuxVideo.propTypes = {
   envKey: PropTypes.string,

--- a/packages/mux-video-react/src/use-combined-refs.ts
+++ b/packages/mux-video-react/src/use-combined-refs.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, MutableRefObject } from "react";
+import { useEffect, useRef, MutableRefObject } from 'react';
 
 type Maybe<T> = T | null | undefined;
 type RefCb<T> = (instance: Maybe<T>) => void;
@@ -15,7 +15,7 @@ export const useCombinedRefs: useCombinedRefs = (...refs) => {
     refs.forEach((ref) => {
       if (!ref) return;
 
-      if (typeof ref === "function") {
+      if (typeof ref === 'function') {
         ref(targetRef.current);
       } else {
         ref.current = targetRef.current;

--- a/packages/mux-video/README.md
+++ b/packages/mux-video/README.md
@@ -30,13 +30,13 @@ npm i @mux-elements/mux-video
 Then, import the library into your application with either `import` or `require`:
 
 ```js
-import "@mux-elements/mux-video";
+import '@mux-elements/mux-video';
 ```
 
 or
 
 ```js
-require("@mux-elements/mux-video");
+require('@mux-elements/mux-video');
 ```
 
 ## CDN option
@@ -110,11 +110,11 @@ To set other available metadata fields use the `metadata` property on the `<mux-
 </mux-video>
 
 <script>
-  const muxVideo = document.querySelector("mux-video");
+  const muxVideo = document.querySelector('mux-video');
   muxVideo.metadata = {
-    experiment_name: "landing_page_v3",
-    video_content_type: "clip",
-    video_series: "season 1",
+    experiment_name: 'landing_page_v3',
+    video_content_type: 'clip',
+    video_series: 'season 1',
   };
 </script>
 ```
@@ -232,10 +232,7 @@ interface MuxVideoHTMLAttributes<T> extends React.VideoHTMLAttributes<T> {
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      "mux-video": React.DetailedHTMLProps<
-        MuxVideoHTMLAttributes<HTMLVideoElement>,
-        HTMLVideoElement
-      >;
+      'mux-video': React.DetailedHTMLProps<MuxVideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>;
     }
   }
 }

--- a/packages/mux-video/src/CustomVideoElement.d.ts
+++ b/packages/mux-video/src/CustomVideoElement.d.ts
@@ -1,7 +1,5 @@
 /** @TODO Add type defs to custom-video-element directly */
-export default class CustomVideoElement<
-    V extends HTMLVideoElement = HTMLVideoElement
-  >
+export default class CustomVideoElement<V extends HTMLVideoElement = HTMLVideoElement>
   // NOTE: "lying" here since we programmatically merge props/methods from HTMLVideoElement into the CustomVideoElement's prototype in an attempt to make it "look like"
   // it extends an HTMLVideoElement.
   extends HTMLVideoElement
@@ -9,9 +7,5 @@ export default class CustomVideoElement<
 {
   static readonly observedAttributes: Array<string>;
   readonly nativeEl: V;
-  attributeChangedCallback(
-    attrName: string,
-    oldValue?: string | null,
-    newValue?: string | null
-  ): void;
+  attributeChangedCallback(attrName: string, oldValue?: string | null, newValue?: string | null): void;
 }

--- a/packages/mux-video/src/CustomVideoElement.js
+++ b/packages/mux-video/src/CustomVideoElement.js
@@ -1,4 +1,4 @@
-import "@mux-elements/polyfills/window";
+import '@mux-elements/polyfills/window';
 
 /**
  * Custom Video Element
@@ -7,7 +7,7 @@ import "@mux-elements/polyfills/window";
  * extended today across browsers.
  */
 
-const template = document.createElement("template");
+const template = document.createElement('template');
 // Could you get styles to apply by passing a global button from global to shadow?
 
 template.innerHTML = `
@@ -42,10 +42,10 @@ class CustomVideoElement extends HTMLElement {
   constructor() {
     super();
 
-    this.attachShadow({ mode: "open" });
+    this.attachShadow({ mode: 'open' });
     this.shadowRoot.appendChild(template.content.cloneNode(true));
 
-    const nativeEl = (this.nativeEl = this.shadowRoot.querySelector("video"));
+    const nativeEl = (this.nativeEl = this.shadowRoot.querySelector('video'));
 
     // Initialize all the attribute properties
     Array.prototype.forEach.call(this.attributes, (attrNode) => {
@@ -61,8 +61,8 @@ class CustomVideoElement extends HTMLElement {
       nativeEl.muted = true;
     }
 
-    const slotEl = this.shadowRoot.querySelector("slot");
-    slotEl.addEventListener("slotchange", () => {
+    const slotEl = this.shadowRoot.querySelector('slot');
+    slotEl.addEventListener('slotchange', () => {
       slotEl.assignedElements().forEach((el) => {
         nativeEl.appendChild(el);
       });
@@ -82,7 +82,7 @@ class CustomVideoElement extends HTMLElement {
 
       // Non-func properties throw errors because it's not an instance
       try {
-        if (typeof this.prototype[propName] === "function") {
+        if (typeof this.prototype[propName] === 'function') {
           isFunc = true;
         }
       } catch (e) {}
@@ -111,16 +111,13 @@ class CustomVideoElement extends HTMLElement {
     const propName = arrayFindAnyCase(ownProps, attrName);
 
     // Check if this is the original custom native elemnt or a subclass
-    const isBaseElement =
-      Object.getPrototypeOf(this.constructor)
-        .toString()
-        .indexOf("function HTMLElement") === 0;
+    const isBaseElement = Object.getPrototypeOf(this.constructor).toString().indexOf('function HTMLElement') === 0;
 
     // If this is a subclass custom attribute we want to set the
     // matching property on the subclass
     if (propName && !isBaseElement) {
       // Boolean props should never start as null
-      if (typeof this[propName] == "boolean") {
+      if (typeof this[propName] == 'boolean') {
         // null is returned when attributes are removed i.e. boolean attrs
         if (newValue === null) {
           this[propName] = false;
@@ -140,7 +137,7 @@ class CustomVideoElement extends HTMLElement {
       } else {
         // Ignore a few that don't need to be passed through just in case
         // it creates unexpected behavior.
-        if (["id", "class"].indexOf(attrName) === -1) {
+        if (['id', 'class'].indexOf(attrName) === -1) {
           this.nativeEl.setAttribute(attrName, newValue);
         }
       }
@@ -162,13 +159,10 @@ let nativeElProps = [];
 // Can't check typeof directly on element prototypes without
 // throwing Illegal Invocation errors, so creating an element
 // to check on instead.
-const nativeElTest = document.createElement("video");
+const nativeElTest = document.createElement('video');
 
 // Deprecated props throw warnings if used, so exclude them
-const deprecatedProps = [
-  "webkitDisplayingFullscreen",
-  "webkitSupportsFullscreen",
-];
+const deprecatedProps = ['webkitDisplayingFullscreen', 'webkitSupportsFullscreen'];
 
 // Walk the prototype chain up to HTMLElement.
 // This will grab all super class props in between.
@@ -193,7 +187,7 @@ nativeElProps = nativeElProps.concat(Object.keys(EventTarget.prototype));
 nativeElProps.forEach((prop) => {
   const type = typeof nativeElTest[prop];
 
-  if (type == "function") {
+  if (type == 'function') {
     // Function
     CustomVideoElement.prototype[prop] = function () {
       return this.nativeEl[prop].apply(this.nativeEl, arguments);
@@ -229,8 +223,8 @@ function arrayFindAnyCase(arr, word) {
   return found;
 }
 
-if (!globalThis.customElements.get("custom-video")) {
-  globalThis.customElements.define("custom-video", CustomVideoElement);
+if (!globalThis.customElements.get('custom-video')) {
+  globalThis.customElements.define('custom-video', CustomVideoElement);
   globalThis.CustomVideoElement = CustomVideoElement;
 }
 

--- a/packages/mux-video/src/env.ts
+++ b/packages/mux-video/src/env.ts
@@ -1,13 +1,13 @@
-export const isMaybeBrowser = () => typeof window != "undefined";
+export const isMaybeBrowser = () => typeof window != 'undefined';
 // @ts-ignore
-export const isMaybeServer = () => typeof global != "undefined";
+export const isMaybeServer = () => typeof global != 'undefined';
 
 const getEnvPlayerVersion = () => {
   try {
     // @ts-ignore
     return PLAYER_VERSION as string;
   } catch {}
-  return "UNKNOWN";
+  return 'UNKNOWN';
 };
 
 const player_version: string = getEnvPlayerVersion();

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -1,4 +1,4 @@
-import CustomVideoElement from "./CustomVideoElement";
+import CustomVideoElement from './CustomVideoElement';
 
 import {
   initialize,
@@ -12,63 +12,53 @@ import {
   Metadata,
   mux,
   MediaError,
-} from "@mux-elements/playback-core";
-import type {
-  PlaybackEngine,
-  UpdateAutoplay,
-  ExtensionMimeTypeMap,
-} from "@mux-elements/playback-core";
-import { getPlayerVersion } from "./env";
+} from '@mux-elements/playback-core';
+import type { PlaybackEngine, UpdateAutoplay, ExtensionMimeTypeMap } from '@mux-elements/playback-core';
+import { getPlayerVersion } from './env';
 
 /** @TODO make the relationship between name+value smarter and more deriveable (CJP) */
 type AttributeNames = {
-  ENV_KEY: "env-key";
-  DEBUG: "debug";
-  METADATA_URL: "metadata-url";
-  PLAYER_SOFTWARE_VERSION: "player-software-version";
-  PLAYER_SOFTWARE_NAME: "player-software-name";
-  METADATA_VIDEO_ID: "metadata-video-id";
-  METADATA_VIDEO_TITLE: "metadata-video-title";
-  METADATA_VIEWER_USER_ID: "metadata-viewer-user-id";
-  BEACON_DOMAIN: "beacon-domain";
-  PLAYBACK_ID: "playback-id";
-  PREFER_MSE: "prefer-mse";
-  TYPE: "type";
-  STREAM_TYPE: "stream-type";
-  START_TIME: "start-time";
+  ENV_KEY: 'env-key';
+  DEBUG: 'debug';
+  METADATA_URL: 'metadata-url';
+  PLAYER_SOFTWARE_VERSION: 'player-software-version';
+  PLAYER_SOFTWARE_NAME: 'player-software-name';
+  METADATA_VIDEO_ID: 'metadata-video-id';
+  METADATA_VIDEO_TITLE: 'metadata-video-title';
+  METADATA_VIEWER_USER_ID: 'metadata-viewer-user-id';
+  BEACON_DOMAIN: 'beacon-domain';
+  PLAYBACK_ID: 'playback-id';
+  PREFER_MSE: 'prefer-mse';
+  TYPE: 'type';
+  STREAM_TYPE: 'stream-type';
+  START_TIME: 'start-time';
 };
 
 const Attributes: AttributeNames = {
-  ENV_KEY: "env-key",
-  DEBUG: "debug",
-  PLAYBACK_ID: "playback-id",
-  METADATA_URL: "metadata-url",
-  PREFER_MSE: "prefer-mse",
-  PLAYER_SOFTWARE_VERSION: "player-software-version",
-  PLAYER_SOFTWARE_NAME: "player-software-name",
-  METADATA_VIDEO_ID: "metadata-video-id",
-  METADATA_VIDEO_TITLE: "metadata-video-title",
-  METADATA_VIEWER_USER_ID: "metadata-viewer-user-id",
-  BEACON_DOMAIN: "beacon-domain",
-  TYPE: "type",
-  STREAM_TYPE: "stream-type",
-  START_TIME: "start-time",
+  ENV_KEY: 'env-key',
+  DEBUG: 'debug',
+  PLAYBACK_ID: 'playback-id',
+  METADATA_URL: 'metadata-url',
+  PREFER_MSE: 'prefer-mse',
+  PLAYER_SOFTWARE_VERSION: 'player-software-version',
+  PLAYER_SOFTWARE_NAME: 'player-software-name',
+  METADATA_VIDEO_ID: 'metadata-video-id',
+  METADATA_VIDEO_TITLE: 'metadata-video-title',
+  METADATA_VIEWER_USER_ID: 'metadata-viewer-user-id',
+  BEACON_DOMAIN: 'beacon-domain',
+  TYPE: 'type',
+  STREAM_TYPE: 'stream-type',
+  START_TIME: 'start-time',
 };
 
 const AttributeNameValues = Object.values(Attributes);
 
 const playerSoftwareVersion = getPlayerVersion();
-const playerSoftwareName = "mux-video";
+const playerSoftwareName = 'mux-video';
 
-class MuxVideoElement
-  extends CustomVideoElement<HTMLVideoElement>
-  implements Partial<MuxMediaProps>
-{
+class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Partial<MuxMediaProps> {
   static get observedAttributes() {
-    return [
-      ...AttributeNameValues,
-      ...(CustomVideoElement.observedAttributes ?? []),
-    ];
+    return [...AttributeNameValues, ...(CustomVideoElement.observedAttributes ?? [])];
   }
 
   // Keeping this named "__hls" since it's exposed for unadvertised "advanced usage" via getter that assumes specifically hls.js (CJP)
@@ -116,7 +106,7 @@ class MuxVideoElement
     // Use the attribute value as the source of truth.
     // No need to store it in two places.
     // This avoids needing a to read the attribute initially and update the src.
-    return this.getAttribute("src") as string;
+    return this.getAttribute('src') as string;
   }
 
   set src(val: string) {
@@ -125,17 +115,14 @@ class MuxVideoElement
     if (val === this.src) return;
 
     if (val == null) {
-      this.removeAttribute("src");
+      this.removeAttribute('src');
     } else {
-      this.setAttribute("src", val);
+      this.setAttribute('src', val);
     }
   }
 
   get type(): ValueOf<ExtensionMimeTypeMap> | undefined {
-    return (
-      (this.getAttribute(Attributes.TYPE) as ValueOf<ExtensionMimeTypeMap>) ??
-      undefined
-    );
+    return (this.getAttribute(Attributes.TYPE) as ValueOf<ExtensionMimeTypeMap>) ?? undefined;
   }
 
   set type(val: ValueOf<ExtensionMimeTypeMap> | undefined) {
@@ -159,7 +146,7 @@ class MuxVideoElement
     if (val === this.debug) return;
 
     if (val) {
-      this.setAttribute(Attributes.DEBUG, "");
+      this.setAttribute(Attributes.DEBUG, '');
     } else {
       this.removeAttribute(Attributes.DEBUG);
     }
@@ -230,10 +217,7 @@ class MuxVideoElement
 
   get streamType(): ValueOf<StreamTypes> | undefined {
     // getAttribute doesn't know that this attribute is well defined. Should explore extending for MuxVideo (CJP)
-    return (
-      (this.getAttribute(Attributes.STREAM_TYPE) as ValueOf<StreamTypes>) ??
-      undefined
-    );
+    return (this.getAttribute(Attributes.STREAM_TYPE) as ValueOf<StreamTypes>) ?? undefined;
   }
 
   set streamType(val: ValueOf<StreamTypes> | undefined) {
@@ -254,7 +238,7 @@ class MuxVideoElement
 
   set preferMse(val: boolean) {
     if (val) {
-      this.setAttribute(Attributes.PREFER_MSE, "");
+      this.setAttribute(Attributes.PREFER_MSE, '');
     } else {
       this.removeAttribute(Attributes.PREFER_MSE);
     }
@@ -263,9 +247,7 @@ class MuxVideoElement
   get metadata() {
     const video_id = this.getAttribute(Attributes.METADATA_VIDEO_ID);
     const video_title = this.getAttribute(Attributes.METADATA_VIDEO_TITLE);
-    const viewer_user_id = this.getAttribute(
-      Attributes.METADATA_VIEWER_USER_ID
-    );
+    const viewer_user_id = this.getAttribute(Attributes.METADATA_VIEWER_USER_ID);
     return {
       ...this.__metadata,
       ...(video_id != null ? { video_id } : {}),
@@ -277,22 +259,14 @@ class MuxVideoElement
   set metadata(val: Readonly<Metadata> | undefined) {
     this.__metadata = val ?? {};
     if (!!this.mux) {
-      this.mux.emit("hb", this.__metadata);
+      this.mux.emit('hb', this.__metadata);
     }
   }
 
   load() {
-    const nextHlsInstance = initialize(
-      this as Partial<MuxMediaProps>,
-      this.nativeEl,
-      this.__hls
-    );
+    const nextHlsInstance = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.__hls);
     this.__hls = nextHlsInstance;
-    const updateAutoplay = setupAutoplay(
-      this.nativeEl,
-      this.autoplay,
-      nextHlsInstance
-    );
+    const updateAutoplay = setupAutoplay(this.nativeEl, this.autoplay, nextHlsInstance);
     this.__updateAutoplay = updateAutoplay;
   }
 
@@ -312,11 +286,7 @@ class MuxVideoElement
   //   }
   // }
 
-  attributeChangedCallback(
-    attrName: string,
-    oldValue: string | null,
-    newValue: string | null
-  ) {
+  attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string | null) {
     switch (attrName) {
       case Attributes.PLAYER_SOFTWARE_NAME:
         this.playerSoftwareName = newValue ?? undefined;
@@ -324,7 +294,7 @@ class MuxVideoElement
       case Attributes.PLAYER_SOFTWARE_VERSION:
         this.playerSoftwareVersion = newValue ?? undefined;
         break;
-      case "src":
+      case 'src':
         const hadSrc = !!oldValue;
         const hasSrc = !!newValue;
         if (!hadSrc && hasSrc) {
@@ -337,7 +307,7 @@ class MuxVideoElement
           this.load();
         }
         break;
-      case "autoplay":
+      case 'autoplay':
         this.__updateAutoplay?.(newValue);
         break;
       case Attributes.PLAYBACK_ID:
@@ -349,7 +319,7 @@ class MuxVideoElement
         if (!!this.mux) {
           /** @TODO Link to docs for a more detailed discussion (CJP) */
           console.info(
-            "Cannot toggle debug mode of mux data after initialization. Make sure you set all metadata to override before setting the src."
+            'Cannot toggle debug mode of mux data after initialization. Make sure you set all metadata to override before setting the src.'
           );
         }
         if (!!this.hls) {
@@ -361,11 +331,7 @@ class MuxVideoElement
           fetch(newValue)
             .then((resp) => resp.json())
             .then((json) => (this.metadata = json))
-            .catch((_err) =>
-              console.error(
-                `Unable to load or parse metadata JSON from metadata-url ${newValue}!`
-              )
-            );
+            .catch((_err) => console.error(`Unable to load or parse metadata JSON from metadata-url ${newValue}!`));
         }
         break;
       default:
@@ -403,17 +369,12 @@ declare global {
 }
 
 /** @TODO Refactor once using `globalThis` polyfills */
-if (!globalThis.customElements.get("mux-video")) {
-  globalThis.customElements.define("mux-video", MuxVideoElement);
+if (!globalThis.customElements.get('mux-video')) {
+  globalThis.customElements.define('mux-video', MuxVideoElement);
   /** @TODO consider externalizing this (breaks standard modularity) */
   globalThis.MuxVideoElement = MuxVideoElement;
 }
 
-export {
-  PlaybackEngine,
-  PlaybackEngine as Hls,
-  ExtensionMimeTypeMap as MimeTypes,
-  MediaError,
-};
+export { PlaybackEngine, PlaybackEngine as Hls, ExtensionMimeTypeMap as MimeTypes, MediaError };
 
 export default MuxVideoElement;

--- a/packages/mux-video/test/player.test.js
+++ b/packages/mux-video/test/player.test.js
@@ -1,8 +1,8 @@
-import { fixture, assert, aTimeout } from "@open-wc/testing";
-import "../src/index.ts";
+import { fixture, assert, aTimeout } from '@open-wc/testing';
+import '../src/index.ts';
 
-describe("<mux-video>", () => {
-  it("has a Mux specific API", async function () {
+describe('<mux-video>', () => {
+  it('has a Mux specific API', async function () {
     const player = await fixture(`<mux-video
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
       env-key="ilc02s65tkrc2mk69b7q2qdkf"
@@ -13,19 +13,11 @@ describe("<mux-video>", () => {
       muted
     ></mux-video>`);
 
-    assert.equal(
-      player.playbackId,
-      "DS00Spx1CV902MCtPj5WknGlR102V5HFkDe",
-      "playback-id is reflected"
-    );
-    assert.equal(
-      player.envKey,
-      "ilc02s65tkrc2mk69b7q2qdkf",
-      "env-key is reflected"
-    );
-    assert.equal(player.startTime, 0, "startTime is set to 0");
-    assert.equal(player.streamType, "vod", "stream-type is vod");
-    assert.equal(player.preferMse, true, "prefer-mse is on");
-    assert.equal(player.debug, true, "debug is on");
+    assert.equal(player.playbackId, 'DS00Spx1CV902MCtPj5WknGlR102V5HFkDe', 'playback-id is reflected');
+    assert.equal(player.envKey, 'ilc02s65tkrc2mk69b7q2qdkf', 'env-key is reflected');
+    assert.equal(player.startTime, 0, 'startTime is set to 0');
+    assert.equal(player.streamType, 'vod', 'stream-type is vod');
+    assert.equal(player.preferMse, true, 'prefer-mse is on');
+    assert.equal(player.debug, true, 'debug is on');
   });
 });

--- a/packages/mux-video/test/web-test-runner.config.mjs
+++ b/packages/mux-video/test/web-test-runner.config.mjs
@@ -1,4 +1,4 @@
-import { esbuildPlugin } from "@web/dev-server-esbuild";
+import { esbuildPlugin } from '@web/dev-server-esbuild';
 
 export default {
   nodeResolve: true,
@@ -6,11 +6,11 @@ export default {
     esbuildPlugin({
       ts: true,
       json: true,
-      loaders: { ".css": "text", ".svg": "text" },
+      loaders: { '.css': 'text', '.svg': 'text' },
     }),
   ],
   coverageConfig: {
     report: true,
-    include: ["src/**/*"],
+    include: ['src/**/*'],
   },
 };

--- a/packages/playback-core/src/autoplay.ts
+++ b/packages/playback-core/src/autoplay.ts
@@ -1,16 +1,16 @@
-import Hls from "hls.js";
+import Hls from 'hls.js';
 
 type PlaybackEngine = Hls;
 
 // TODO add INVIEW_MUTED, INVIEW_ANY
 export type AutoplayTypes = {
-  ANY: "any";
-  MUTED: "muted";
+  ANY: 'any';
+  MUTED: 'muted';
 };
 
 export const AutoplayTypes: AutoplayTypes = {
-  ANY: "any",
-  MUTED: "muted",
+  ANY: 'any',
+  MUTED: 'muted',
 };
 
 type ValueOf<T> = T[keyof T];
@@ -21,9 +21,8 @@ export type UpdateAutoplay = (newAutoplay: Maybe<string | boolean>) => void;
 const AutoplayTypeValues = Object.values(AutoplayTypes);
 export const isAutoplayValue = (value: unknown): value is Autoplay => {
   return (
-    typeof value === "boolean" ||
-    (typeof value === "string" &&
-      AutoplayTypeValues.includes(value as ValueOf<AutoplayTypes>))
+    typeof value === 'boolean' ||
+    (typeof value === 'string' && AutoplayTypeValues.includes(value as ValueOf<AutoplayTypes>))
   );
 };
 
@@ -40,14 +39,12 @@ export const setupAutoplay = (
 ) => {
   let hasPlayed = false;
   let isLive = false;
-  let autoplay: Autoplay = isAutoplayValue(maybeAutoplay)
-    ? maybeAutoplay
-    : !!maybeAutoplay;
+  let autoplay: Autoplay = isAutoplayValue(maybeAutoplay) ? maybeAutoplay : !!maybeAutoplay;
 
   const updateHasPlayed = () => {
     // hasPlayed
     mediaEl.addEventListener(
-      "playing",
+      'playing',
       () => {
         hasPlayed = true;
       },
@@ -61,7 +58,7 @@ export const setupAutoplay = (
   // hasPlayed should default to false
   // we should try and autoplay
   mediaEl.addEventListener(
-    "loadstart",
+    'loadstart',
     () => {
       hasPlayed = false;
       updateHasPlayed();
@@ -72,7 +69,7 @@ export const setupAutoplay = (
 
   // on `loadedmetadata` we can check whether we're live in the case of native playback
   mediaEl.addEventListener(
-    "loadedmetadata",
+    'loadedmetadata',
     () => {
       // only update isLive here if we're using native playback
       if (!hls) {
@@ -95,7 +92,7 @@ export const setupAutoplay = (
   // which probably shouldn't seek
   if (!autoplay) {
     mediaEl.addEventListener(
-      "play",
+      'play',
       () => {
         // don't seek if we're not live
         if (!isLive) {
@@ -124,10 +121,7 @@ export const setupAutoplay = (
   return updateAutoplay;
 };
 
-export const handleAutoplay = (
-  mediaEl: HTMLMediaElement,
-  autoplay: Autoplay
-) => {
+export const handleAutoplay = (mediaEl: HTMLMediaElement, autoplay: Autoplay) => {
   if (!autoplay) {
     return;
   }

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -1,13 +1,13 @@
-import "@mux-elements/polyfills/window";
-import mux, { Options } from "mux-embed";
+import '@mux-elements/polyfills/window';
+import mux, { Options } from 'mux-embed';
 
-import Hls, { HlsConfig } from "hls.js";
-import { AutoplayTypes, setupAutoplay } from "./autoplay";
-import { isKeyOf } from "./util";
-import type { Autoplay, UpdateAutoplay } from "./autoplay";
+import Hls, { HlsConfig } from 'hls.js';
+import { AutoplayTypes, setupAutoplay } from './autoplay';
+import { isKeyOf } from './util';
+import type { Autoplay, UpdateAutoplay } from './autoplay';
 
 export type ValueOf<T> = T[keyof T];
-export type Metadata = Partial<Options["data"]>;
+export type Metadata = Partial<Options['data']>;
 export type PlaybackEngine = Hls;
 export { mux };
 export { Hls };
@@ -18,29 +18,29 @@ export const generatePlayerInitTime = () => {
 };
 
 export type StreamTypes = {
-  VOD: "on-demand";
-  LIVE: "live";
-  LL_LIVE: "ll-live";
+  VOD: 'on-demand';
+  LIVE: 'live';
+  LL_LIVE: 'll-live';
 };
 
 export const StreamTypes: StreamTypes = {
-  VOD: "on-demand",
-  LIVE: "live",
-  LL_LIVE: "ll-live",
+  VOD: 'on-demand',
+  LIVE: 'live',
+  LL_LIVE: 'll-live',
 };
 
 export type ExtensionMimeTypeMap = {
-  M3U8: "application/vnd.apple.mpegurl";
-  MP4: "video/mp4";
+  M3U8: 'application/vnd.apple.mpegurl';
+  MP4: 'video/mp4';
 };
 
 export const ExtensionMimeTypeMap: ExtensionMimeTypeMap = {
-  M3U8: "application/vnd.apple.mpegurl",
-  MP4: "video/mp4",
+  M3U8: 'application/vnd.apple.mpegurl',
+  MP4: 'video/mp4',
 };
 
 export type MimeTypeShorthandMap = {
-  HLS: ExtensionMimeTypeMap["M3U8"];
+  HLS: ExtensionMimeTypeMap['M3U8'];
 };
 
 export const MimeTypeShorthandMap: MimeTypeShorthandMap = {
@@ -51,21 +51,17 @@ export const shorthandKeys = Object.keys(MimeTypeShorthandMap);
 export const allMediaTypes = [
   ...(Object.values(ExtensionMimeTypeMap) as ValueOf<ExtensionMimeTypeMap>[]),
   ...(shorthandKeys as (keyof MimeTypeShorthandMap)[]),
-  ...(shorthandKeys.map((k) => k.toUpperCase()) as `${Uppercase<
-    keyof MimeTypeShorthandMap
-  >}`[]),
-  ...(shorthandKeys.map((k) => k.toLowerCase()) as `${Lowercase<
-    keyof MimeTypeShorthandMap
-  >}`[]),
+  ...(shorthandKeys.map((k) => k.toUpperCase()) as `${Uppercase<keyof MimeTypeShorthandMap>}`[]),
+  ...(shorthandKeys.map((k) => k.toLowerCase()) as `${Lowercase<keyof MimeTypeShorthandMap>}`[]),
 ];
 
 export type MuxMediaPropTypes = {
-  envKey: Options["data"]["env_key"];
-  debug: Options["debug"] & Hls["config"]["debug"];
-  metadata: Partial<Options["data"]>;
-  beaconDomain: Options["beaconDomain"];
+  envKey: Options['data']['env_key'];
+  debug: Options['debug'] & Hls['config']['debug'];
+  metadata: Partial<Options['data']>;
+  beaconDomain: Options['beaconDomain'];
   playbackId: string;
-  playerInitTime: Options["data"]["player_init_time"];
+  playerInitTime: Options['data']['player_init_time'];
   preferMse: boolean;
   type:
     | ValueOf<ExtensionMimeTypeMap>
@@ -73,7 +69,7 @@ export type MuxMediaPropTypes = {
     | `${Lowercase<keyof MimeTypeShorthandMap>}`
     | `${Uppercase<keyof MimeTypeShorthandMap>}`;
   streamType: ValueOf<StreamTypes>;
-  startTime: HlsConfig["startPosition"];
+  startTime: HlsConfig['startPosition'];
   autoPlay: boolean | ValueOf<AutoplayTypes>;
   autoplay: boolean | ValueOf<AutoplayTypes>;
 };
@@ -84,18 +80,16 @@ declare global {
   }
 }
 
-export type HTMLMediaElementProps = Partial<Pick<HTMLMediaElement, "src">>;
+export type HTMLMediaElementProps = Partial<Pick<HTMLMediaElement, 'src'>>;
 
 export type MuxMediaProps = HTMLMediaElementProps & MuxMediaPropTypes;
 export type MuxMediaPropsInternal = MuxMediaProps & {
-  playerSoftwareName: Options["data"]["player_software_name"];
-  playerSoftwareVersion: Options["data"]["player_software_version"];
+  playerSoftwareName: Options['data']['player_software_name'];
+  playerSoftwareVersion: Options['data']['player_software_version'];
 };
 
-export const toPlaybackIdParts = (
-  playbackIdWithOptionalParams: string
-): [string, string?] => {
-  const qIndex = playbackIdWithOptionalParams.indexOf("?");
+export const toPlaybackIdParts = (playbackIdWithOptionalParams: string): [string, string?] => {
+  const qIndex = playbackIdWithOptionalParams.indexOf('?');
   if (qIndex < 0) return [playbackIdWithOptionalParams];
   const idPart = playbackIdWithOptionalParams.slice(0, qIndex);
   const queryPart = playbackIdWithOptionalParams.slice(qIndex);
@@ -104,45 +98,39 @@ export const toPlaybackIdParts = (
 
 export const toMuxVideoURL = (playbackId?: string) => {
   if (!playbackId) return undefined;
-  const [idPart, queryPart = ""] = toPlaybackIdParts(playbackId);
+  const [idPart, queryPart = ''] = toPlaybackIdParts(playbackId);
   return `https://stream.mux.com/${idPart}.m3u8${queryPart}`;
 };
 
 export const inferMimeTypeFromURL = (url: string) => {
-  let pathname = "";
+  let pathname = '';
   try {
     pathname = new URL(url).pathname;
   } catch (e) {
-    console.error("invalid url");
+    console.error('invalid url');
   }
 
-  const extDelimIdx = pathname.lastIndexOf(".");
-  if (extDelimIdx < 0) return "";
+  const extDelimIdx = pathname.lastIndexOf('.');
+  if (extDelimIdx < 0) return '';
 
   const ext = pathname.slice(extDelimIdx + 1);
   const upperExt = ext.toUpperCase();
 
-  return isKeyOf(upperExt, ExtensionMimeTypeMap)
-    ? ExtensionMimeTypeMap[upperExt]
-    : "";
+  return isKeyOf(upperExt, ExtensionMimeTypeMap) ? ExtensionMimeTypeMap[upperExt] : '';
 };
 
-export const getType = (
-  props: Partial<Pick<MuxMediaProps, "type" | "src">>
-) => {
+export const getType = (props: Partial<Pick<MuxMediaProps, 'type' | 'src'>>) => {
   const type = props.type;
 
   if (type) {
     const upperType = type.toUpperCase();
 
-    return isKeyOf(upperType, MimeTypeShorthandMap)
-      ? MimeTypeShorthandMap[upperType]
-      : type;
+    return isKeyOf(upperType, MimeTypeShorthandMap) ? MimeTypeShorthandMap[upperType] : type;
   }
 
   const { src } = props;
 
-  if (!src) return "";
+  if (!src) return '';
 
   return inferMimeTypeFromURL(src);
 };
@@ -157,8 +145,8 @@ export const getStreamTypeConfig = (streamType?: ValueOf<StreamTypes>) => {
 };
 
 export const teardown = (
-  mediaEl?: Pick<HTMLMediaElement, "mux"> | null,
-  hls?: Pick<Hls, "detachMedia" | "destroy">
+  mediaEl?: Pick<HTMLMediaElement, 'mux'> | null,
+  hls?: Pick<Hls, 'detachMedia' | 'destroy'>
 ) => {
   if (hls) {
     hls.detachMedia();
@@ -171,13 +159,8 @@ export const teardown = (
 };
 
 export const setupHls = (
-  props: Partial<
-    Pick<
-      MuxMediaProps,
-      "debug" | "preferMse" | "streamType" | "type" | "src" | "startTime"
-    >
-  >,
-  mediaEl?: Pick<HTMLMediaElement, "canPlayType"> | null
+  props: Partial<Pick<MuxMediaProps, 'debug' | 'preferMse' | 'streamType' | 'type' | 'src' | 'startTime'>>,
+  mediaEl?: Pick<HTMLMediaElement, 'canPlayType'> | null
 ) => {
   const { debug, preferMse, streamType, startTime: startPosition = -1 } = props;
   const type = getType(props);
@@ -187,14 +170,12 @@ export const setupHls = (
   const hlsSupported = Hls.isSupported();
   // NOTE: Native HLS playback on Android for LL-HLS has been flaky, so we're prefering
   // MSE for those conditions for now. (CJP)
-  const userAgentStr = window?.navigator?.userAgent ?? "";
-  const isAndroid = userAgentStr.toLowerCase().indexOf("android") !== -1;
+  const userAgentStr = window?.navigator?.userAgent ?? '';
+  const isAndroid = userAgentStr.toLowerCase().indexOf('android') !== -1;
   const defaultPreferMse = isAndroid && streamType === StreamTypes.LL_LIVE;
 
   // We should use native playback for hls media sources if we a) can use native playback and don't also b) prefer to use MSE/hls.js if/when it's supported
-  const shouldUseNative =
-    !hlsType ||
-    (canUseNative && !((preferMse || defaultPreferMse) && hlsSupported));
+  const shouldUseNative = !hlsType || (canUseNative && !((preferMse || defaultPreferMse) && hlsSupported));
 
   // 1. if we are trying to play an hls media source create hls if we should be using it "under the hood"
   if (hlsType && !shouldUseNative && hlsSupported) {
@@ -212,33 +193,28 @@ export const setupHls = (
   return undefined;
 };
 
-const MUX_VIDEO_DOMAIN = "mux.com";
+const MUX_VIDEO_DOMAIN = 'mux.com';
 
 export const setupMux = (
   props: Partial<
     Pick<
       MuxMediaPropsInternal,
-      | "envKey"
-      | "playerInitTime"
-      | "beaconDomain"
-      | "metadata"
-      | "debug"
-      | "playerSoftwareName"
-      | "playerSoftwareVersion"
-      | "playbackId"
-      | "src"
+      | 'envKey'
+      | 'playerInitTime'
+      | 'beaconDomain'
+      | 'metadata'
+      | 'debug'
+      | 'playerSoftwareName'
+      | 'playerSoftwareVersion'
+      | 'playbackId'
+      | 'src'
     >
   >,
   mediaEl?: HTMLMediaElement | null,
   hlsjs?: Hls
 ) => {
   const { envKey: env_key, playbackId, src } = props;
-  const inferredEnv =
-    !!playbackId ||
-    !!(
-      typeof src === "string" &&
-      new URL(src).hostname.includes(MUX_VIDEO_DOMAIN)
-    );
+  const inferredEnv = !!playbackId || !!(typeof src === 'string' && new URL(src).hostname.includes(MUX_VIDEO_DOMAIN));
   if ((env_key || inferredEnv) && mediaEl) {
     const {
       playerInitTime: player_init_time,
@@ -268,27 +244,15 @@ export const setupMux = (
 };
 
 export const loadMedia = (
-  props: Partial<
-    Pick<
-      MuxMediaProps,
-      "preferMse" | "src" | "type" | "startTime" | "streamType" | "autoplay"
-    >
-  >,
+  props: Partial<Pick<MuxMediaProps, 'preferMse' | 'src' | 'type' | 'startTime' | 'streamType' | 'autoplay'>>,
   mediaEl?: HTMLMediaElement | null,
   hls?: Pick<
     Hls,
-    | "on"
-    | "once"
-    | "startLoad"
-    | "recoverMediaError"
-    | "destroy"
-    | "loadSource"
-    | "attachMedia"
-    | "liveSyncPosition"
+    'on' | 'once' | 'startLoad' | 'recoverMediaError' | 'destroy' | 'loadSource' | 'attachMedia' | 'liveSyncPosition'
   >
 ) => {
   if (!mediaEl) {
-    console.warn("attempting to load media before mediaEl exists");
+    console.warn('attempting to load media before mediaEl exists');
     return;
   }
   const { preferMse, streamType } = props;
@@ -297,37 +261,30 @@ export const loadMedia = (
 
   const canUseNative = !type || (mediaEl?.canPlayType(type) ?? true);
   const hlsSupported = Hls.isSupported();
-  const userAgentStr = window?.navigator?.userAgent ?? "";
+  const userAgentStr = window?.navigator?.userAgent ?? '';
   // NOTE: Native HLS playback on Android for LL-HLS has been flaky, so we're prefering
   // MSE for those conditions for now. (CJP)
-  const isAndroid = userAgentStr.toLowerCase().indexOf("android") !== -1;
+  const isAndroid = userAgentStr.toLowerCase().indexOf('android') !== -1;
   const defaultPreferMse = isAndroid && streamType === StreamTypes.LL_LIVE;
 
   // We should use native playback for hls media sources if we a) can use native playback and don't also b) prefer to use MSE/hls.js if/when it's supported
-  const shouldUseNative =
-    !hlsType ||
-    (canUseNative && !((preferMse || defaultPreferMse) && hlsSupported));
+  const shouldUseNative = !hlsType || (canUseNative && !((preferMse || defaultPreferMse) && hlsSupported));
 
   const { src } = props;
   if (mediaEl && canUseNative && shouldUseNative) {
-    if (typeof src === "string") {
+    if (typeof src === 'string') {
       const { startTime } = props;
-      mediaEl.setAttribute("src", src);
+      mediaEl.setAttribute('src', src);
       if (startTime) {
-        const setStartTimeOnLoad = ({
-          target,
-        }: HTMLMediaElementEventMap["loadedmetadata"]) => {
+        const setStartTimeOnLoad = ({ target }: HTMLMediaElementEventMap['loadedmetadata']) => {
           (target as HTMLMediaElement).currentTime = startTime;
-          (target as HTMLMediaElement).removeEventListener(
-            "loadedmetadata",
-            setStartTimeOnLoad
-          );
+          (target as HTMLMediaElement).removeEventListener('loadedmetadata', setStartTimeOnLoad);
         };
 
-        mediaEl.addEventListener("loadedmetadata", setStartTimeOnLoad);
+        mediaEl.addEventListener('loadedmetadata', setStartTimeOnLoad);
       }
     } else {
-      mediaEl.removeAttribute("src");
+      mediaEl.removeAttribute('src');
     }
   } else if (hls && src) {
     hls.on(Hls.Events.ERROR, (_event, data) => {
@@ -356,11 +313,11 @@ export const loadMedia = (
         [Hls.ErrorTypes.NETWORK_ERROR]: MediaError.MEDIA_ERR_NETWORK,
         [Hls.ErrorTypes.MEDIA_ERROR]: MediaError.MEDIA_ERR_DECODE,
       };
-      const error = new MediaError("", errorCodeMap[data.type]);
+      const error = new MediaError('', errorCodeMap[data.type]);
       error.fatal = data.fatal;
       error.data = data;
       mediaEl.dispatchEvent(
-        new CustomEvent("error", {
+        new CustomEvent('error', {
           detail: error,
         })
       );
@@ -369,22 +326,20 @@ export const loadMedia = (
     const forceHiddenThumbnails = () => {
       // Keeping this a forEach in case we want to expand the scope of this.
       Array.from(mediaEl.textTracks).forEach((track) => {
-        if (["subtitles", "caption"].includes(track.kind)) return;
-        if (track.label !== "thumbnails") return;
+        if (['subtitles', 'caption'].includes(track.kind)) return;
+        if (track.label !== 'thumbnails') return;
         if (!track.cues?.length) {
-          const trackEl = mediaEl.querySelector(
-            'track[label="thumbnails"]'
-          ) as HTMLTrackElement;
+          const trackEl = mediaEl.querySelector('track[label="thumbnails"]') as HTMLTrackElement;
           // Force a reload of the cues if they've been removed
-          const src = trackEl?.getAttribute("src") ?? "";
-          trackEl?.removeAttribute("src");
+          const src = trackEl?.getAttribute('src') ?? '';
+          trackEl?.removeAttribute('src');
           setTimeout(() => {
-            trackEl?.setAttribute("src", src);
+            trackEl?.setAttribute('src', src);
           }, 0);
         }
         // Force hidden mode if it's not hidden
-        if (track.mode !== "hidden") {
-          track.mode = "hidden";
+        if (track.mode !== 'hidden') {
+          track.mode = 'hidden';
         }
       });
     };
@@ -403,11 +358,7 @@ export const loadMedia = (
   }
 };
 
-export const initialize = (
-  props: Partial<MuxMediaPropsInternal>,
-  mediaEl?: HTMLMediaElement | null,
-  hls?: Hls
-) => {
+export const initialize = (props: Partial<MuxMediaPropsInternal>, mediaEl?: HTMLMediaElement | null, hls?: Hls) => {
   // Automatically tear down previously initialized mux data & hls instance if it exists.
   teardown(mediaEl, hls);
   const nextHlsInstance = setupHls(props, mediaEl);
@@ -425,11 +376,11 @@ export class MediaError extends Error {
   static MEDIA_ERR_ENCRYPTED: number = 5;
 
   static defaultMessages: Record<number, string> = {
-    1: "You aborted the media playback",
-    2: "A network error caused the media download to fail.",
-    3: "A media error caused playback to be aborted. The media could be corrupt or your browser does not support this format.",
-    4: "An unsupported error occurred. The server or network failed, or your browser does not support this format.",
-    5: "The media is encrypted and there are no keys to decrypt it.",
+    1: 'You aborted the media playback',
+    2: 'A network error caused the media download to fail.',
+    3: 'A media error caused playback to be aborted. The media could be corrupt or your browser does not support this format.',
+    4: 'An unsupported error occurred. The server or network failed, or your browser does not support this format.',
+    5: 'The media is encrypted and there are no keys to decrypt it.',
   };
 
   name: string;
@@ -439,12 +390,12 @@ export class MediaError extends Error {
 
   constructor(message?: string, code: number = 0, fatal?: boolean) {
     super(message);
-    this.name = "MediaError";
+    this.name = 'MediaError';
     this.code = code;
     this.fatal = fatal ?? code >= MediaError.MEDIA_ERR_NETWORK;
 
     if (!this.message) {
-      this.message = MediaError.defaultMessages[this.code] ?? "";
+      this.message = MediaError.defaultMessages[this.code] ?? '';
     }
   }
 }

--- a/scripts/esbuilder/esbuilder.js
+++ b/scripts/esbuilder/esbuilder.js
@@ -1,21 +1,21 @@
 #!/usr/bin/env node
-import path from "path";
-import { build } from "esbuild";
+import path from 'path';
+import { build } from 'esbuild';
 
 const camelCase = (name) => {
   return name.replace(/[-_]([a-z])/g, ($0, $1) => $1.toUpperCase());
 };
 
 const args = process.argv.slice(3).reduce((processArgs, val) => {
-  let [key, value] = val.split("=");
-  let [name, prop] = key.replace(/^--?/g, "").split(":");
+  let [key, value] = val.split('=');
+  let [name, prop] = key.replace(/^--?/g, '').split(':');
   processArgs[camelCase(name)] = prop ? { [prop]: value } : value ?? true;
   return processArgs;
 }, {});
 
 // e.g. yarn build:esm --lang=nl
 const i18nPlugin = {
-  name: "example",
+  name: 'example',
   setup(builder) {
     const { lang } = args;
     if (lang) {
@@ -28,7 +28,7 @@ const i18nPlugin = {
     if (!lang) {
       builder.onLoad({ filter: /en.json$/ }, () => {
         // No need to import English, it's defined in the tagged template.
-        return { contents: "export default {}" };
+        return { contents: 'export default {}' };
       });
     }
   },
@@ -36,17 +36,17 @@ const i18nPlugin = {
 
 build({
   entryPoints: [process.argv[2]],
-  outdir: args.outdir ?? "dist",
+  outdir: args.outdir ?? 'dist',
   bundle: true,
-  target: "es2019",
+  target: 'es2019',
   minify: args.minify,
   format: args.format,
   watch: args.watch,
   outExtension: args.outExtension,
   plugins: [i18nPlugin],
   loader: {
-    ".css": "text",
-    ".svg": "text",
+    '.css': 'text',
+    '.svg': 'text',
   },
   define: {
     PLAYER_VERSION: `"${process.env.npm_package_version}"`,

--- a/scripts/eslint-plugin-i18n/no-substitutions.js
+++ b/scripts/eslint-plugin-i18n/no-substitutions.js
@@ -1,16 +1,13 @@
 module.exports = {
   rules: {
-    "no-substitutions": {
+    'no-substitutions': {
       create: function (context) {
         return {
           TaggedTemplateExpression(node) {
             const tag = node.tag.name;
-            if (tag === "i18n") {
+            if (tag === 'i18n') {
               for (const expr of node.quasi.expressions) {
-                context.report(
-                  expr,
-                  `No expressions allowed, use ICU Message syntax`
-                );
+                context.report(expr, `No expressions allowed, use ICU Message syntax`);
               }
             }
           },

--- a/scripts/i18n-utils/i18n-utils.js
+++ b/scripts/i18n-utils/i18n-utils.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import fs from "fs";
-import path from "path";
+import fs from 'fs';
+import path from 'path';
 
 const srcFile = process.argv[2];
 const langFolder = process.argv[3];
@@ -19,7 +19,7 @@ while ((result = regex.exec(srcContents)) !== null) {
 for (let file of walkSync(langFolder)) {
   const oldDict = JSON.parse(fs.readFileSync(file).toString());
   let dict = {};
-  if (file.endsWith("en.json")) {
+  if (file.endsWith('en.json')) {
     for (let str of strings) {
       dict[str] = str;
     }
@@ -29,12 +29,8 @@ for (let file of walkSync(langFolder)) {
     }
   }
 
-  fs.writeFileSync(file, JSON.stringify(dict, null, "  "));
-  console.log(
-    `${strings.length} strings (${
-      Object.keys(dict).length
-    } unique) written to ${file}`
-  );
+  fs.writeFileSync(file, JSON.stringify(dict, null, '  '));
+  console.log(`${strings.length} strings (${Object.keys(dict).length} unique) written to ${file}`);
 }
 
 function* walkSync(dir) {

--- a/scripts/open-process/open-process.js
+++ b/scripts/open-process/open-process.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-"use strict";
+'use strict';
 
 setInterval(() => {}, 1 << 30);
-console.info("stdin open?");
+console.info('stdin open?');

--- a/shared/polyfills/index.js
+++ b/shared/polyfills/index.js
@@ -1,1 +1,1 @@
-import "./window";
+import './window';

--- a/types/mux-embed.d.ts
+++ b/types/mux-embed.d.ts
@@ -1,6 +1,6 @@
 /** @TODO Add type defs to mux-embed directly */
-declare module "mux-embed" {
-  import Hls from "hls.js";
+declare module 'mux-embed' {
+  import Hls from 'hls.js';
 
   export type HighPriorityMetadata = {
     video_id: string;
@@ -74,15 +74,9 @@ declare module "mux-embed" {
     hb: Partial<Metadata>;
   };
 
-  export function monitor(
-    id: string | HTMLMediaElement,
-    options: Options
-  ): void;
+  export function monitor(id: string | HTMLMediaElement, options: Options): void;
 
-  export function emit<K extends keyof EventTypesMap>(
-    type: K,
-    payload: EventTypesMap[K]
-  ): void;
+  export function emit<K extends keyof EventTypesMap>(type: K, payload: EventTypesMap[K]): void;
 
   export function destroy(): void;
 


### PR DESCRIPTION
Adds a prettier config in the root for all packages.

The only difference with media-chrome's is the `singleQuote: false`
https://github.com/muxinc/media-chrome/blob/main/.prettierrc

I guess those are the defaults used by the `pretty-quick` package that runs prettier in the git pre-commit hook.

