### PR TITLE
Fix Mux data integration for mux-video

### DIFF
--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -140,6 +140,36 @@ class MuxVideoElement
     }
   }
 
+  get playbackId(): string | undefined {
+    return this.getAttribute(Attributes.PLAYBACK_ID) ?? undefined;
+  }
+
+  set playbackId(val: string | undefined) {
+    // dont' cause an infinite loop
+    if (val === this.playbackId) return;
+
+    if (val) {
+      this.setAttribute(Attributes.PLAYBACK_ID, val);
+    } else {
+      this.removeAttribute(Attributes.PLAYBACK_ID);
+    }
+  }
+
+  get envKey(): string | undefined {
+    return this.getAttribute(Attributes.ENV_KEY) ?? undefined;
+  }
+
+  set envKey(val: string | undefined) {
+    // dont' cause an infinite loop
+    if (val === this.envKey) return;
+
+    if (val) {
+      this.setAttribute(Attributes.ENV_KEY, val);
+    } else {
+      this.removeAttribute(Attributes.ENV_KEY);
+    }
+  }
+
   get beaconDomain(): string | undefined {
     return this.getAttribute(Attributes.BEACON_DOMAIN) ?? undefined;
   }


### PR DESCRIPTION
This change is needed to get Mux data working for the `<mux-video>` element.

https://github.com/muxinc/elements/blob/afa33d281bf9ddabbd53877b786466aaef2996cf/packages/playback-core/src/index.ts#L215-L215

In the case of `<mux-video>`, props is the `<mux-video>` itself so it requires a `envKey` property on it.