### PR TITLE
Add type to mux-video for playback-core

### DIFF
--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -106,6 +106,24 @@ class MuxVideoElement
     }
   }
 
+  get type(): ValueOf<ExtensionMimeTypeMap> | undefined {
+    return (
+      (this.getAttribute(Attributes.TYPE) as ValueOf<ExtensionMimeTypeMap>) ??
+      undefined
+    );
+  }
+
+  set type(val: ValueOf<ExtensionMimeTypeMap> | undefined) {
+    // dont' cause an infinite loop
+    if (val === this.type) return;
+
+    if (val) {
+      this.setAttribute(Attributes.TYPE, val);
+    } else {
+      this.removeAttribute(Attributes.TYPE);
+    }
+  }
+
   /** @TODO write a generic module for well defined primitive types -> attribute getter/setters/removers (CJP) */
   get debug(): boolean {
     return this.getAttribute(Attributes.DEBUG) != null;


### PR DESCRIPTION
Adds the `type` as a property. 

I ran into an issue with an m3u8 without an extension and tried this attribute but it didn't work because the prop was not on the element.
