### PR TITLE
Fix low latency live buffering in mux-player

### DIFF
--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -423,7 +423,10 @@ class MuxPlayerElement extends VideoApiElement {
    * @return {number}
    */
   get startTime() {
-    return Number(getVideoAttribute(this, MuxVideoAttributes.START_TIME));
+    const val = getVideoAttribute(this, MuxVideoAttributes.START_TIME);
+    if (val == null) return undefined;
+    const num = +val;
+    return !Number.isNaN(num) ? num : undefined;
   }
 
   /**


### PR DESCRIPTION
Fix start-time attr being set automatically causing video playhead for low latency to be out of sync.