### PR TITLE
Fix basic css so player doesn't collapse

### DIFF
--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -2,6 +2,7 @@
   /* default aspect ratio, overwrite w/ e.g. style="aspect-ratio: 16 / 10" */
   aspect-ratio: 16 / 9;
   display: block;
+  width: 100%;
 }
 
 media-controller {


### PR DESCRIPTION
Adds width 100% internally so the player doesn't collapse with no external CSS set.