### PR TITLE
Add custom attributes for muted, volume and playbackrate

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -39,6 +39,8 @@
       poster="https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=0"
       src="https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8"
       muted
+      volume="0.4"
+      playbackrate="2"
      -->
 
     <mux-player

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -44,14 +44,6 @@ class MuxPlayerInternal {
       el.attributeChangedCallback(attrNode.name, null, attrNode.value);
     });
 
-    // Neither Chrome or Firefox support setting the muted attribute
-    // after using document.createElement.
-    // One way to get around this would be to build the native tag as a string.
-    // But just fixing it manually for now.
-    if (el.video) {
-      el.video.muted = el.video.defaultMuted;
-    }
-
     /**
      * @todo determine sensible defaults for preloading buffer
      * @see https://github.com/muxinc/elements/issues/51

--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -1,15 +1,20 @@
 import type MuxVideoElement from "@mux-elements/mux-video";
 
-const AllowedVideoAttributeNames = [
-  "autoplay",
-  "crossorigin",
-  "loop",
-  "muted",
-  "playsinline",
-  "src",
-  "poster",
-  "preload",
-];
+const AllowedVideoAttributes = {
+  AUTOPLAY: "autoplay",
+  CROSSORIGIN: "crossorigin",
+  LOOP: "loop",
+  MUTED: "muted",
+  PLAYSINLINE: "playsinline",
+  SRC: "src",
+  POSTER: "poster",
+  PRELOAD: "preload",
+};
+
+const CustomVideoAttributes = {
+  VOLUME: "volume",
+  PLAYBACKRATE: "playbackrate",
+};
 
 const AllowedVideoEvents = [
   "loadstart",
@@ -28,6 +33,8 @@ const AllowedVideoEvents = [
   "seeked",
   "ended",
 ];
+
+const AllowedVideoAttributeNames = Object.values(AllowedVideoAttributes);
 
 class VideoApiElement extends HTMLElement {
   static get observedAttributes() {
@@ -75,6 +82,23 @@ class VideoApiElement extends HTMLElement {
     oldValue: string | null,
     newValue: string
   ) {
+    switch (attrName) {
+      case CustomVideoAttributes.VOLUME: {
+        const val = +newValue;
+        if (this.video && !Number.isNaN(val)) {
+          this.video.volume = val;
+        }
+        return;
+      }
+      case CustomVideoAttributes.PLAYBACKRATE: {
+        const val = +newValue;
+        if (this.video && !Number.isNaN(val)) {
+          this.video.playbackRate = val;
+        }
+        return;
+      }
+    }
+
     if (
       AllowedVideoAttributeNames.includes(attrName) &&
       this.video?.getAttribute(attrName) != newValue
@@ -172,19 +196,19 @@ class VideoApiElement extends HTMLElement {
   }
 
   get src() {
-    return getVideoAttribute(this, "src");
+    return getVideoAttribute(this, AllowedVideoAttributes.SRC);
   }
 
   set src(val) {
-    this.setAttribute("src", `${val}`);
+    this.setAttribute(AllowedVideoAttributes.SRC, `${val}`);
   }
 
   get poster() {
-    return getVideoAttribute(this, "poster") ?? "";
+    return getVideoAttribute(this, AllowedVideoAttributes.POSTER) ?? "";
   }
 
   set poster(val) {
-    this.setAttribute("poster", `${val}`);
+    this.setAttribute(AllowedVideoAttributes.POSTER, `${val}`);
   }
 
   get playbackRate() {
@@ -198,49 +222,49 @@ class VideoApiElement extends HTMLElement {
   }
 
   get crossOrigin() {
-    return getVideoAttribute(this, "crossorigin");
+    return getVideoAttribute(this, AllowedVideoAttributes.CROSSORIGIN);
   }
 
   set crossOrigin(val) {
-    this.setAttribute("crossorigin", `${val}`);
+    this.setAttribute(AllowedVideoAttributes.CROSSORIGIN, `${val}`);
   }
 
   get autoplay() {
-    return getVideoAttribute(this, "autoplay") != null;
+    return getVideoAttribute(this, AllowedVideoAttributes.AUTOPLAY) != null;
   }
 
   set autoplay(val) {
     if (val) {
-      this.setAttribute("autoplay", "");
+      this.setAttribute(AllowedVideoAttributes.AUTOPLAY, "");
     } else {
       // Remove boolean attribute if false, 0, '', null, undefined.
-      this.removeAttribute("autoplay");
+      this.removeAttribute(AllowedVideoAttributes.AUTOPLAY);
     }
   }
 
   get loop() {
-    return getVideoAttribute(this, "loop") != null;
+    return getVideoAttribute(this, AllowedVideoAttributes.LOOP) != null;
   }
 
   set loop(val) {
     if (val) {
-      this.setAttribute("loop", "");
+      this.setAttribute(AllowedVideoAttributes.LOOP, "");
     } else {
       // Remove boolean attribute if false, 0, '', null, undefined.
-      this.removeAttribute("loop");
+      this.removeAttribute(AllowedVideoAttributes.LOOP);
     }
   }
 
   get muted() {
-    return getVideoAttribute(this, "muted") != null;
+    return getVideoAttribute(this, AllowedVideoAttributes.MUTED) != null;
   }
 
   set muted(val) {
     if (val) {
-      this.setAttribute("muted", "");
+      this.setAttribute(AllowedVideoAttributes.MUTED, "");
     } else {
       // Remove boolean attribute if false, 0, '', null, undefined.
-      this.removeAttribute("muted");
+      this.removeAttribute(AllowedVideoAttributes.MUTED);
     }
   }
 }

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -14,8 +14,6 @@ describe("<mux-player>", () => {
   });
 
   it("has a Mux specific API", async function () {
-    this.timeout(10000);
-
     const player = await fixture(`<mux-player
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
       env-key="ilc02s65tkrc2mk69b7q2qdkf"
@@ -84,8 +82,6 @@ describe("<mux-player>", () => {
   });
 
   it("video attributes are forwarded to media element", async function () {
-    this.timeout(10000);
-
     const player = await fixture(`<mux-player
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
       muted
@@ -121,5 +117,79 @@ describe("<mux-player>", () => {
       player.removeAttribute(attrName);
       assert(!muxVideo.hasAttribute(attrName), `has ${attrName} attr removed`);
     }
+  });
+
+  it("muted attribute behaves like expected", async function () {
+    const player = await fixture(`<mux-player
+      playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
+      muted
+    ></mux-player>`);
+
+    const muxVideo = player.video;
+    const nativeVideo = muxVideo.shadowRoot.querySelector("video");
+
+    assert(player.muted, "player.muted is true");
+    assert(muxVideo.muted, "muxVideo.muted is true");
+    assert(nativeVideo.muted, "nativeVideo.muted is true");
+
+    player.removeAttribute("muted");
+
+    assert(!player.muted, "player.muted is false");
+    assert(!muxVideo.muted, "muxVideo.muted is false");
+    assert(!nativeVideo.muted, "nativeVideo.muted is false");
+
+    player.setAttribute("muted", "");
+
+    assert(player.muted, "player.muted is true");
+    assert(muxVideo.muted, "muxVideo.muted is true");
+    assert(nativeVideo.muted, "nativeVideo.muted is true");
+  });
+
+  it("volume attribute behaves like expected", async function () {
+    const player = await fixture(`<mux-player
+      playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
+      volume="0.4"
+    ></mux-player>`);
+
+    assert.equal(player.getAttribute("volume"), "0.4");
+
+    const muxVideo = player.video;
+    const nativeVideo = muxVideo.shadowRoot.querySelector("video");
+
+    assert.equal(player.volume, 0.4, "player.volume is 0.4");
+    assert.equal(muxVideo.volume, 0.4, "muxVideo.volume is 0.4");
+    assert.equal(nativeVideo.volume, 0.4, "nativeVideo.volume is 0.4");
+
+    player.setAttribute("volume", "0.9");
+
+    assert.equal(player.volume, 0.9, "player.volume is 0.9");
+    assert.equal(muxVideo.volume, 0.9, "muxVideo.volume is 0.9");
+    assert.equal(nativeVideo.volume, 0.9, "nativeVideo.volume is 0.9");
+  });
+
+  it("playbackrate attribute behaves like expected", async function () {
+    const player = await fixture(`<mux-player
+      playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
+      playbackrate="2"
+    ></mux-player>`);
+
+    assert.equal(player.getAttribute("playbackrate"), "2");
+
+    const muxVideo = player.video;
+    const nativeVideo = muxVideo.shadowRoot.querySelector("video");
+
+    assert.equal(player.playbackRate, 2, "player.playbackRate is 2");
+    assert.equal(muxVideo.playbackRate, 2, "muxVideo.playbackRate is 2");
+    assert.equal(nativeVideo.playbackRate, 2, "nativeVideo.playbackRate is 2");
+
+    player.setAttribute("playbackrate", "0.7");
+
+    assert.equal(player.playbackRate, 0.7, "player.playbackRate is 0.7");
+    assert.equal(muxVideo.playbackRate, 0.7, "muxVideo.playbackRate is 0.7");
+    assert.equal(
+      nativeVideo.playbackRate,
+      0.7,
+      "nativeVideo.playbackRate is 0.7"
+    );
   });
 });


### PR DESCRIPTION
This change adds a `volume` and `playbackrate` attribute that sets the corresponding video property.
Changing the video properties do not reflect back to the attributes.

It also changes the behavior of the `muted` attribute so it reflects to the native video muted property in addition to defaultMuted.