### PR TITLE
Add ready event to mux-player

### DIFF
--- a/packages/mux-player/src/helpers.ts
+++ b/packages/mux-player/src/helpers.ts
@@ -34,10 +34,8 @@ export const hasVolumeSupportAsync = async (
   if (!mediaEl) return false;
   const prevVolume = mediaEl.volume;
   mediaEl.volume = prevVolume / 2 + 0.1;
-  return new Promise<boolean>((resolve, reject) => {
-    setTimeout(() => {
-      resolve(mediaEl.volume !== prevVolume);
-    }, 0);
+  return Promise.resolve().then(() => {
+    return mediaEl.volume !== prevVolume;
   });
 };
 

--- a/packages/mux-player/src/utils.ts
+++ b/packages/mux-player/src/utils.ts
@@ -1,3 +1,14 @@
+export function promisify(fn: Function, ctx?: any) {
+  return (...args: any[]) =>
+    new Promise((resolve) => {
+      // fn.call() didn't work for some reason.
+      fn.bind(ctx)(...args, (...res: any[]) => {
+        if (res.length > 1) resolve(res);
+        else resolve(res[0]);
+      });
+    });
+}
+
 export function stylePropsToString(props: any) {
   let style = "";
   Object.entries(props).forEach(([key, value]) => {


### PR DESCRIPTION
This adds a `ready` event for the player signaling to the user, the player is ready to accept API requests.

Intentionally doesn't listen to `canplay` or `metadata` (better use those events directly then), 
it's not always sure a `src` is set or video content will be loaded (preload=none).

Maybe one addition could be in case hls.js is used to listen for the manifest loaded event and fire `ready` after that?
But then ideally that would live in playback core if we want to have mux-player not interface directly with the `muxVideo.hls` api.