### PR TITLE
Fix dialog flashing glitch

### DIFF
--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -5,6 +5,11 @@
   width: 100%;
 }
 
+/* Hide custom elements that are not defined yet */
+:not(:defined) {
+  display: none;
+}
+
 media-controller {
   --media-control-background: transparent;
   --media-control-hover-background: transparent;


### PR DESCRIPTION
Fixes an issue where the custom element `<mxp-dialog>` was flashing on player load while it should be hidden.