### PR TITLE
fix/aria-hide-inactive-error-dialog: set display to none for dialog w…

### DIFF
--- a/packages/mux-player/src/dialog.ts
+++ b/packages/mux-player/src/dialog.ts
@@ -19,6 +19,10 @@ template.innerHTML = `
       top: 1rem;
       right: 1rem;
     }
+
+    :host(:not([open])) {
+      display: none;
+    }
   </style>
 
   <div class="dialog">


### PR DESCRIPTION
…hen closed, in part to keep it from showing up in the AOM.