### PR TITLE
Fix poster loading multiple times on re-render

### DIFF
--- a/packages/mux-player/src/html.ts
+++ b/packages/mux-player/src/html.ts
@@ -27,6 +27,14 @@ export function processPropertyIdentity(
   part: TemplatePart,
   value: unknown
 ): boolean {
+  if (part instanceof AttributeTemplatePart) {
+    const ns = part.attributeNamespace;
+    const oldValue = part.element.getAttributeNS(ns, part.attributeName);
+    if (String(value) !== oldValue) {
+      part.value = String(value);
+    }
+    return true;
+  }
   part.value = String(value);
   return true;
 }
@@ -41,7 +49,11 @@ export function processBooleanAttribute(
     // can't use this because on custom elements the props are always undefined
     // typeof part.element[part.attributeName as keyof Element] === 'boolean'
   ) {
-    part.booleanValue = value;
+    const ns = part.attributeNamespace;
+    const oldValue = part.element.hasAttributeNS(ns, part.attributeName);
+    if (value !== oldValue) {
+      part.booleanValue = value;
+    }
     return true;
   }
   return false;


### PR DESCRIPTION
This change prevents setting the poster attribute if it didn't change. Re-setting the poster attribute on a video elements makes it re-request the poster url and shows a brief flash. This would also happen going from one UI view to another, small to large for example.