### PR TITLE
feat: default-hidden-captions to turn off showing captions by default

### DIFF
--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -47,6 +47,7 @@ type MuxMediaPropTypes = {
 };
 
 export type MuxPlayerProps = {
+  defaultHiddenCaptions?: boolean;
   forwardSeekOffset?: number;
   backwardSeekOffset?: number;
   metadataVideoId?: string;

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -248,7 +248,7 @@ const MuxVideoAttributes = {
 };
 
 const PlayerAttributes = {
-  DEFAULT_SHOW_CAPTIONS: "default-show-captions",
+  DEFAULT_HIDDEN_CAPTIONS: "default-hidden-captions",
   PRIMARY_COLOR: "primary-color",
   SECONDARY_COLOR: "secondary-color",
   FORWARD_SEEK_OFFSET: "forward-seek-offset",
@@ -270,7 +270,7 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
     secondaryColor: el.secondaryColor,
     forwardSeekOffset: el.forwardSeekOffset,
     backwardSeekOffset: el.backwardSeekOffset,
-    defaultShowCaptions: el.defaultShowCaptions,
+    defaultHiddenCaptions: el.defaultHiddenCaptions,
     playerSize: getPlayerSize(el),
     hasCaptions: !!getCcSubTracks(el).length,
     ...state,
@@ -347,8 +347,8 @@ class MuxPlayerElement extends VideoApiElement {
     );
   }
 
-  get defaultShowCaptions() {
-    return this.getAttribute(PlayerAttributes.DEFAULT_SHOW_CAPTIONS) || true;
+  get defaultHiddenCaptions() {
+    return this.hasAttribute(PlayerAttributes.DEFAULT_HIDDEN_CAPTIONS);
   }
 
   get playerSoftwareName() {

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -127,7 +127,7 @@ const MediaMuteButton = () => html`
 
 // prettier-ignore
 const MediaCaptionsButton = (props: MuxTemplateProps) => html`
-<media-captions-button default-showing="${props.defaultShowCaptions}">
+<media-captions-button default-showing="${!props.defaultHiddenCaptions}" >
   ${icons.CaptionsOff()}
   ${icons.CaptionsOn()}
 </media-captions-button>`;

--- a/packages/mux-player/src/types.d.ts
+++ b/packages/mux-player/src/types.d.ts
@@ -16,5 +16,5 @@ export type MuxTemplateProps = Partial<MuxPlayerProps> & {
   backwardSeekOffset: number;
   dialog: { title: string; message: string };
   isDialogOpen: boolean;
-  defaultShowCaptions: boolean;
+  defaultHiddenCaptions: boolean;
 };


### PR DESCRIPTION
Setting `default-hidden-captions` on the WC element or `defaultHiddenCaptions` on the React element will have the captions not turn on by default.