### PR TITLE
chore: fixup minify build with lerna.

### DIFF
--- a/packages/mux-audio-react/package.json
+++ b/packages/mux-audio-react/package.json
@@ -18,7 +18,7 @@
     "dev": "npm-run-all --parallel dev:types dev:cjs",
     "build:cjs": "esbuild src/index.tsx --target=es2019 --bundle --sourcemap --format=cjs --outdir=dist --external:react --external:prop-types --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
-    "build": "npm-run-all --parallel build:types 'build:cjs --minify'",
+    "build": "npm-run-all --parallel build:types 'build:cjs -- --minify'",
     "prepublishOnly": "yarn build"
   },
   "peerDependencies": {

--- a/packages/mux-audio/package.json
+++ b/packages/mux-audio/package.json
@@ -19,7 +19,7 @@
     "build:iife": "esbuild src/index.ts --target=es2019 --bundle --sourcemap --format=iife --outdir=dist --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:cjs": "esbuild src/index.ts --target=es2019 --bundle --sourcemap --format=cjs --outdir=dist --out-extension:.js=.cjs --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
-    "build": "npm-run-all --parallel build:types 'build:esm --minify' 'build:iife --minify' 'build:cjs --minify'",
+    "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify'",
     "prepublishOnly": "yarn build"
   },
   "dependencies": {

--- a/packages/mux-player-react/package.json
+++ b/packages/mux-player-react/package.json
@@ -16,9 +16,9 @@
     "dev:cjs": "open-process | yarn build:cjs --watch",
     "dev:types": "yarn build:types -w",
     "dev": "npm-run-all --parallel dev:types dev:cjs",
-    "build:cjs": "esbuild src/index.tsx --target=es2019 --minify --bundle --sourcemap --format=cjs --loader:.css=text --outdir=dist --external:react --external:prop-types --define:PLAYER_VERSION=\"'$npm_package_version'\"",
+    "build:cjs": "esbuild src/index.tsx --target=es2019 --bundle --sourcemap --format=cjs --loader:.css=text --outdir=dist --external:react --external:prop-types --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
-    "build": "npm-run-all --parallel build:types build:cjs"
+    "build": "npm-run-all --parallel build:types 'build:cjs -- --minify'"
   },
   "peerDependencies": {
     "@types/react": "^16.8.6 || ^17.0.0",

--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -22,7 +22,7 @@
     "build:iife": "esbuild src/index.ts --target=es2019 --bundle --sourcemap --format=iife --loader:.css=text --loader:.svg=text --outdir=dist --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:cjs": "esbuild src/index.ts --target=es2019 --bundle --sourcemap --format=cjs --loader:.css=text --loader:.svg=text --outdir=dist --out-extension:.js=.cjs --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
-    "build": "npm-run-all --parallel build:types 'build:esm --minify' 'build:iife --minify' 'build:cjs --minify'",
+    "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify'",
     "prepublishOnly": "yarn build"
   },
   "dependencies": {

--- a/packages/mux-video-react/package.json
+++ b/packages/mux-video-react/package.json
@@ -18,7 +18,7 @@
     "dev": "npm-run-all --parallel dev:types dev:cjs",
     "build:cjs": "esbuild src/index.tsx --target=es2019 --bundle --sourcemap --format=cjs --outdir=dist --external:react --external:prop-types --define:PLAYER_VERSION=\"'$npm_package_version'\"",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
-    "build": "npm-run-all --parallel build:types 'build:cjs --minify'",
+    "build": "npm-run-all --parallel build:types 'build:cjs -- --minify'",
     "prepublishOnly": "yarn build"
   },
   "peerDependencies": {

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -24,7 +24,7 @@
     "build:types": "npm-run-all --parallel copy-dts \"tsc {1}\" --",
     "tsc": "tsc --declaration --emitDeclarationOnly --outDir dist/types",
     "copy-dts": "copyfiles -u 1 \"src/**/*.d.ts\" dist/types",
-    "build": "npm-run-all --parallel build:types 'build:esm --minify' 'build:iife --minify' 'build:cjs --minify'",
+    "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify'",
     "prepublishOnly": "yarn build"
   },
   "dependencies": {

--- a/packages/playback-core/package.json
+++ b/packages/playback-core/package.json
@@ -18,7 +18,7 @@
     "dev": "npm-run-all --parallel dev:types dev:cjs",
     "build:cjs": "esbuild src/index.ts --target=es2019 --bundle --sourcemap --format=cjs --outdir=dist --external:mux-embed --external:hls.js",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
-    "build": "npm-run-all --parallel build:types 'build:cjs --minify'",
+    "build": "npm-run-all --parallel build:types 'build:cjs -- --minify'",
     "prepublishOnly": "yarn build"
   },
   "dependencies": {


### PR DESCRIPTION
lerna sets the npm_exec_path to pretend it's npm for some scripts. This
causes, `npm-run-all` to use lerna rather than `npm` or yarn and the
`--minify` doesn't get passed automatically.

Instead, by using `--` we can force the `--minify` flag to get passed to
the underlying command.