### PR TITLE
Improve error handling

### DIFF
--- a/packages/mux-player/lang/en.json
+++ b/packages/mux-player/lang/en.json
@@ -1,0 +1,15 @@
+{
+  "(opens in a new window)": "(opens in a new window)",
+  "Network Error": "Network Error",
+  " - Offline": " - Offline",
+  " Your device appears to be disconnected from the internet.": " Your device appears to be disconnected from the internet.",
+  " ${0} - Precondition Failed": " ${0} - Precondition Failed",
+  " Nobody is currently streaming to this live stream endpoint.": " Nobody is currently streaming to this live stream endpoint.",
+  " ${0} - Forbidden": " ${0} - Forbidden",
+  " You don't have permission to access the video URL.": " You don't have permission to access the video URL.",
+  " ${0} - Not Found": " ${0} - Not Found",
+  " The video URL could not be found at this address:": " The video URL could not be found at this address:",
+  "Media Error": "Media Error",
+  "Source Not Supported": "Source Not Supported",
+  "Error": "Error"
+}

--- a/packages/mux-player/lang/nl.json
+++ b/packages/mux-player/lang/nl.json
@@ -1,0 +1,15 @@
+{
+  "(opens in a new window)": "(opent in een nieuw venster)",
+  "Network Error": "Network Error",
+  " - Offline": " - Offline",
+  " Your device appears to be disconnected from the internet.": " Your device appears to be disconnected from the internet.",
+  " ${0} - Precondition Failed": " ${0} - Precondition Failed",
+  " Nobody is currently streaming to this live stream endpoint.": " Nobody is currently streaming to this live stream endpoint.",
+  " ${0} - Forbidden": " ${0} - Forbidden",
+  " You don't have permission to access the video URL.": " You don't have permission to access the video URL.",
+  " ${0} - Not Found": " ${0} - Not Found",
+  " The video URL could not be found at this address:": " The video URL could not be found at this address:",
+  "Media Error": "Media Error",
+  "Source Not Supported": "Source Not Supported",
+  "Error": "Error"
+}

--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -19,9 +19,9 @@
     "dev:esm": "open-process | yarn build:esm --watch",
     "dev:types": "yarn build:types -w",
     "dev": "npm-run-all --parallel dev:types dev:esm dev:iife",
-    "build:esm": "node scripts/esbuild.js --format=esm --out-extension:.js=.mjs",
-    "build:iife": "node scripts/esbuild.js --format=iife --out-extension:.js=.js",
-    "build:cjs": "node scripts/esbuild.js --format=cjs --out-extension:.js=.cjs",
+    "build:esm": "esbuilder src/index.ts --format=esm --out-extension:.js=.mjs",
+    "build:iife": "esbuilder src/index.ts --format=iife --out-extension:.js=.js",
+    "build:cjs": "esbuilder src/index.ts --format=cjs --out-extension:.js=.cjs",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
     "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify'",
     "prepublishOnly": "yarn build"

--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -14,13 +14,14 @@
   "license": "MIT",
   "scripts": {
     "test": "web-test-runner **/*test.js --coverage --config test/web-test-runner.config.js",
+    "i18n": "yarn build:esm --keep-names && i18n-utils dist/index.mjs ./lang",
     "dev:iife": "open-process | yarn build:iife --watch",
     "dev:esm": "open-process | yarn build:esm --watch",
     "dev:types": "yarn build:types -w",
     "dev": "npm-run-all --parallel dev:types dev:esm dev:iife",
-    "build:esm": "esbuild src/index.ts --target=es2019 --bundle --sourcemap --format=esm --loader:.css=text --loader:.svg=text --outdir=dist --out-extension:.js=.mjs --define:PLAYER_VERSION=\"'$npm_package_version'\"",
-    "build:iife": "esbuild src/index.ts --target=es2019 --bundle --sourcemap --format=iife --loader:.css=text --loader:.svg=text --outdir=dist --define:PLAYER_VERSION=\"'$npm_package_version'\"",
-    "build:cjs": "esbuild src/index.ts --target=es2019 --bundle --sourcemap --format=cjs --loader:.css=text --loader:.svg=text --outdir=dist --out-extension:.js=.cjs --define:PLAYER_VERSION=\"'$npm_package_version'\"",
+    "build:esm": "node scripts/esbuild.js --format=esm --out-extension:.js=.mjs",
+    "build:iife": "node scripts/esbuild.js --format=iife --out-extension:.js=.js",
+    "build:cjs": "node scripts/esbuild.js --format=cjs --out-extension:.js=.cjs",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
     "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify'",
     "prepublishOnly": "yarn build"

--- a/packages/mux-player/scripts/esbuild.js
+++ b/packages/mux-player/scripts/esbuild.js
@@ -1,0 +1,53 @@
+import path from "path";
+import { build } from "esbuild";
+
+const camelCase = (name) => {
+  return name.replace(/[-_]([a-z])/g, ($0, $1) => $1.toUpperCase());
+};
+
+const args = process.argv.slice(2).reduce((processArgs, val) => {
+  let [key, value] = val.split("=");
+  let [name, prop] = key.replace(/^--?/g, "").split(":");
+  processArgs[camelCase(name)] = prop ? { [prop]: value } : value ?? true;
+  return processArgs;
+}, {});
+
+// e.g. yarn build:esm --lang=nl
+const i18nPlugin = {
+  name: "example",
+  setup(builder) {
+    const { lang } = args;
+    if (lang) {
+      builder.onResolve({ filter: /en.json$/ }, (params) => {
+        // Redirect all paths ending with "en.json" to "LANG.json"
+        return { path: path.join(params.resolveDir, `../lang/${lang}.json`) };
+      });
+    }
+
+    if (!lang) {
+      builder.onLoad({ filter: /en.json$/ }, () => {
+        // No need to import English, it's defined in the tagged template.
+        return { contents: "export default {}" };
+      });
+    }
+  },
+};
+
+build({
+  entryPoints: ["src/index.ts"],
+  outdir: "dist",
+  bundle: true,
+  target: "es2019",
+  minify: args.minify,
+  format: args.format,
+  watch: args.watch,
+  outExtension: args.outExtension,
+  plugins: [i18nPlugin],
+  loader: {
+    ".css": "text",
+    ".svg": "text",
+  },
+  define: {
+    PLAYER_VERSION: `"${process.env.npm_package_version}"`,
+  },
+}).catch(() => process.exit(1));

--- a/packages/mux-player/src/helpers.ts
+++ b/packages/mux-player/src/helpers.ts
@@ -97,36 +97,3 @@ export function getChromeStylesFromProps(props: any) {
     ...secondaryColorStyles,
   });
 }
-
-export class MediaError extends Error {
-  static MEDIA_ERR_CUSTOM: number = 0;
-  static MEDIA_ERR_ABORTED: number = 1;
-  static MEDIA_ERR_NETWORK: number = 2;
-  static MEDIA_ERR_DECODE: number = 3;
-  static MEDIA_ERR_SRC_NOT_SUPPORTED: number = 4;
-  static MEDIA_ERR_ENCRYPTED: number = 5;
-
-  static defaultMessages: Record<number, string> = {
-    1: "You aborted the media playback",
-    2: "A network error caused the media download to fail.",
-    3: "A media error caused playback to be aborted. The media could be corrupt or your browser does not support this format.",
-    4: "An unsupported error occurred. The server or network failed, or your browser does not support this format.",
-    5: "The media is encrypted and there are no keys to decrypt it.",
-  };
-
-  name: string;
-  code: number;
-  fatal: boolean;
-  data?: any;
-
-  constructor(message?: string, code: number = 0, fatal?: boolean) {
-    super(message);
-    this.name = "MediaError";
-    this.code = code;
-    this.fatal = fatal ?? code >= MediaError.MEDIA_ERR_NETWORK;
-
-    if (!this.message) {
-      this.message = MediaError.defaultMessages[this.code] ?? "";
-    }
-  }
-}

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from "./helpers";
 import { template } from "./template";
 import { render } from "./html";
-import { toNumberOrUndefined } from "./utils";
+import { toNumberOrUndefined, i18n } from "./utils";
 
 import type { MuxTemplateProps } from "./types";
 import type { Metadata } from "@mux-elements/playback-core";
@@ -205,30 +205,29 @@ class MuxPlayerElement extends VideoApiElement {
       let dialog;
       switch (error.code) {
         case MediaError.MEDIA_ERR_NETWORK: {
-          let title = "Network Error";
+          let title = i18n`Network Error`;
           let { message } = error;
           let linkText;
           let linkUrl;
 
           if (!window.navigator.onLine) {
-            title += " - Offline";
-            message +=
-              " Your device appears to be disconnected from the internet.";
+            title += i18n` - Offline`;
+            message += i18n` Your device appears to be disconnected from the internet.`;
           }
 
           // Only works when hls.js is used.
           switch (error.data?.response.code) {
             case 412:
-              title += " 412 - Precondition Failed";
-              message += ` Nobody is currently streaming to this live stream endpoint.`;
+              title += i18n` ${error.data?.response.code} - Precondition Failed`;
+              message += i18n` Nobody is currently streaming to this live stream endpoint.`;
               break;
             case 403:
-              title += " 403 - Forbidden";
-              message += ` You don't have permission to access the manifest URL.`;
+              title += i18n` ${error.data?.response.code} - Forbidden`;
+              message += i18n` You don't have permission to access the video URL.`;
               break;
             case 404:
-              title += " 404 - Not Found";
-              message += ` The manifest URL could not be found at this address:`;
+              title += i18n` ${error.data?.response.code} - Not Found`;
+              message += i18n` The video URL could not be found at this address:`;
               linkUrl = this.video?.src;
               break;
           }
@@ -244,21 +243,21 @@ class MuxPlayerElement extends VideoApiElement {
         case MediaError.MEDIA_ERR_DECODE: {
           let { message } = error;
           dialog = {
-            title: "Media Error",
+            title: i18n`Media Error`,
             message,
           };
           break;
         }
         case MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED: {
           dialog = {
-            title: "Source Not Supported",
+            title: i18n`Source Not Supported`,
             message: error.message,
           };
           break;
         }
         default:
           dialog = {
-            title: "Error",
+            title: i18n`Error`,
             message: error.message,
           };
           break;

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -207,6 +207,8 @@ class MuxPlayerElement extends VideoApiElement {
         case MediaError.MEDIA_ERR_NETWORK: {
           let title = "Network Error";
           let { message } = error;
+          let linkText;
+          let linkUrl;
 
           if (!window.navigator.onLine) {
             title += " - Offline";
@@ -222,13 +224,16 @@ class MuxPlayerElement extends VideoApiElement {
               break;
             case 404:
               title += " 404 - Not Found";
-              message += ` The manifest URL could not be found at this address: ${this.video?.src}`;
+              message += ` The manifest URL could not be found at this address:`;
+              linkUrl = this.video?.src;
               break;
           }
 
           dialog = {
             title,
             message,
+            linkText,
+            linkUrl,
           };
           break;
         }

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -218,6 +218,10 @@ class MuxPlayerElement extends VideoApiElement {
 
           // Only works when hls.js is used.
           switch (error.data?.response.code) {
+            case 412:
+              title += " 412 - Precondition Failed";
+              message += ` Nobody is currently streaming to this live stream endpoint.`;
+              break;
             case 403:
               title += " 403 - Forbidden";
               message += ` You don't have permission to access the manifest URL.`;

--- a/packages/mux-player/src/media-chrome/dialog.ts
+++ b/packages/mux-player/src/media-chrome/dialog.ts
@@ -53,6 +53,7 @@ const styles = `
     background: var(--media-dialog-background, none);
     padding: var(--media-dialog-padding, 10px);
     width: min(320px, 100%);
+    word-wrap: break-word;
     max-height: 100%;
     overflow: auto;
     text-align: center;

--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -10,6 +10,12 @@
   display: none;
 }
 
+a {
+  color: #fff;
+  font-size: 0.9em;
+  text-decoration: underline;
+}
+
 media-controller {
   --media-control-background: transparent;
   --media-control-hover-background: transparent;

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -87,8 +87,18 @@ export const template = (props: MuxTemplateProps) => html`
       no-auto-hide
       open="${props.isDialogOpen}"
     >
-      ${props.dialog?.title ? html`<h3>${props.dialog.title}</h3>` : ""}
-      ${props.dialog?.message ? html`<p>${props.dialog.message}</p>` : ""}
+      ${props.dialog?.title && html`<h3>${props.dialog.title}</h3>`}
+      <p>
+        ${props.dialog?.message}
+        ${props.dialog?.linkUrl &&
+        html`<a
+          href="${props.dialog.linkUrl}"
+          target="_blank"
+          rel="external noopener"
+          aria-label="${props.dialog.linkText ?? ""} (opens in a new window)"
+          >${props.dialog.linkText ?? props.dialog.linkUrl}</a
+        >`}
+      </p>
     </mxp-dialog>
   </media-controller>
 `;

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -9,6 +9,7 @@ import { html } from "./html";
 import * as icons from "./icons";
 // @ts-ignore
 import cssStr from "./styles.css";
+import { i18n } from "./utils";
 
 import type { MuxTemplateProps } from "./types";
 
@@ -95,7 +96,8 @@ export const template = (props: MuxTemplateProps) => html`
           href="${props.dialog.linkUrl}"
           target="_blank"
           rel="external noopener"
-          aria-label="${props.dialog.linkText ?? ""} (opens in a new window)"
+          aria-label="${props.dialog.linkText ??
+          ""} ${i18n`(opens in a new window)`}"
           >${props.dialog.linkText ?? props.dialog.linkUrl}</a
         >`}
       </p>

--- a/packages/mux-player/src/types.d.ts
+++ b/packages/mux-player/src/types.d.ts
@@ -14,9 +14,14 @@ export type MuxTemplateProps = Partial<MuxPlayerProps> & {
   secondaryColor: string;
   forwardSeekOffset: number;
   backwardSeekOffset: number;
-  dialog: { title: string; message: string };
   isDialogOpen: boolean;
   defaultHiddenCaptions: boolean;
+  dialog: {
+    title: string;
+    message: string;
+    linkText?: string;
+    linkUrl?: string;
+  };
   tokens: {
     playback?: string;
     thumbnail?: string;

--- a/packages/mux-player/src/utils.ts
+++ b/packages/mux-player/src/utils.ts
@@ -1,3 +1,25 @@
+// @ts-ignore
+import lang from "../lang/en.json";
+
+// NL example
+// lang = {
+//   "Network Error": "Netwerk Fout",
+// };
+export function i18n(strings: TemplateStringsArray, ...exprs: any[]): string {
+  const i18nLangKeyParts = [];
+  for (let i in strings) {
+    i18nLangKeyParts.push(strings[i], "${" + i + "}");
+  }
+  i18nLangKeyParts.pop();
+
+  let i18nLangTemplate = i18nLangKeyParts.join("");
+  i18nLangTemplate = lang?.[i18nLangTemplate] ?? i18nLangTemplate;
+
+  return i18nLangTemplate.replace(/\$\{(\d)\}/g, (match, key) => {
+    return exprs[key] ?? "";
+  });
+}
+
 export function stylePropsToString(props: any) {
   let style = "";
   Object.entries(props).forEach(([key, value]) => {

--- a/packages/mux-player/test/web-test-runner.config.js
+++ b/packages/mux-player/test/web-test-runner.config.js
@@ -3,6 +3,10 @@ import { esbuildPlugin } from "@web/dev-server-esbuild";
 export default {
   nodeResolve: true,
   plugins: [
-    esbuildPlugin({ ts: true, loaders: { ".css": "text", ".svg": "text" } }),
+    esbuildPlugin({
+      ts: true,
+      json: true,
+      loaders: { ".css": "text", ".svg": "text" },
+    }),
   ],
 };

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -11,6 +11,7 @@ import {
   Metadata,
   PlaybackEngine,
   mux,
+  MediaError,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
 
@@ -393,6 +394,7 @@ export {
   PlaybackEngine,
   PlaybackEngine as Hls,
   ExtensionMimeTypeMap as MimeTypes,
+  MediaError,
 };
 
 export default MuxVideoElement;

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -323,26 +323,26 @@ export const loadMedia = (
     }
   } else if (hls && src) {
     hls.on(Hls.Events.ERROR, (_event, data) => {
-      if (data.fatal) {
-        switch (data.type) {
-          case Hls.ErrorTypes.NETWORK_ERROR:
-            // try to recover network error
-            console.error("fatal network error encountered, try to recover");
-            hls.startLoad();
-            break;
-          case Hls.ErrorTypes.MEDIA_ERROR:
-            console.error("fatal media error encountered, try to recover");
-            hls.recoverMediaError();
-            break;
-          default:
-            // cannot recover
-            console.error(
-              "unrecoverable fatal error encountered, cannot recover (check logs for more info)"
-            );
-            hls.destroy();
-            break;
-        }
-      }
+      // if (data.fatal) {
+      //   switch (data.type) {
+      //     case Hls.ErrorTypes.NETWORK_ERROR:
+      //       // try to recover network error
+      //       console.error("fatal network error encountered, try to recover");
+      //       hls.startLoad();
+      //       break;
+      //     case Hls.ErrorTypes.MEDIA_ERROR:
+      //       console.error("fatal media error encountered, try to recover");
+      //       hls.recoverMediaError();
+      //       break;
+      //     default:
+      //       // cannot recover
+      //       console.error(
+      //         "unrecoverable fatal error encountered, cannot recover (check logs for more info)"
+      //       );
+      //       hls.destroy();
+      //       break;
+      //   }
+      // }
 
       const errorCodeMap: Record<string, number> = {
         [Hls.ErrorTypes.NETWORK_ERROR]: MediaError.MEDIA_ERR_NETWORK,

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -322,7 +322,28 @@ export const loadMedia = (
       mediaEl.removeAttribute("src");
     }
   } else if (hls && src) {
-    const onHlsError = (_event: any, data: any) => {
+    hls.on(Hls.Events.ERROR, (_event, data) => {
+      if (data.fatal) {
+        switch (data.type) {
+          case Hls.ErrorTypes.NETWORK_ERROR:
+            // try to recover network error
+            console.error("fatal network error encountered, try to recover");
+            hls.startLoad();
+            break;
+          case Hls.ErrorTypes.MEDIA_ERROR:
+            console.error("fatal media error encountered, try to recover");
+            hls.recoverMediaError();
+            break;
+          default:
+            // cannot recover
+            console.error(
+              "unrecoverable fatal error encountered, cannot recover (check logs for more info)"
+            );
+            hls.destroy();
+            break;
+        }
+      }
+
       const errorCodeMap: Record<string, number> = {
         [Hls.ErrorTypes.NETWORK_ERROR]: MediaError.MEDIA_ERR_NETWORK,
         [Hls.ErrorTypes.MEDIA_ERROR]: MediaError.MEDIA_ERR_DECODE,
@@ -335,31 +356,7 @@ export const loadMedia = (
           detail: error,
         })
       );
-    };
-    hls.on(Hls.Events.ERROR, onHlsError);
-
-    // hls.on(Hls.Events.ERROR, (_event, data) => {
-    //   if (data.fatal) {
-    //     switch (data.type) {
-    //       case Hls.ErrorTypes.NETWORK_ERROR:
-    //         // try to recover network error
-    //         console.error("fatal network error encountered, try to recover");
-    //         hls.startLoad();
-    //         break;
-    //       case Hls.ErrorTypes.MEDIA_ERROR:
-    //         console.error("fatal media error encountered, try to recover");
-    //         hls.recoverMediaError();
-    //         break;
-    //       default:
-    //         // cannot recover
-    //         console.error(
-    //           "unrecoverable fatal error encountered, cannot recover (check logs for more info)"
-    //         );
-    //         hls.destroy();
-    //         break;
-    //     }
-    //   }
-    // });
+    });
 
     const forceHiddenThumbnails = () => {
       // Keeping this a forEach in case we want to expand the scope of this.

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -322,6 +322,22 @@ export const loadMedia = (
       mediaEl.removeAttribute("src");
     }
   } else if (hls && src) {
+    const onHlsError = (_event: any, data: any) => {
+      const errorCodeMap: Record<string, number> = {
+        [Hls.ErrorTypes.NETWORK_ERROR]: MediaError.MEDIA_ERR_NETWORK,
+        [Hls.ErrorTypes.MEDIA_ERROR]: MediaError.MEDIA_ERR_DECODE,
+      };
+      const error = new MediaError("", errorCodeMap[data.type]);
+      error.fatal = data.fatal;
+      error.data = data;
+      mediaEl.dispatchEvent(
+        new CustomEvent("error", {
+          detail: error,
+        })
+      );
+    };
+    hls.on(Hls.Events.ERROR, onHlsError);
+
     // hls.on(Hls.Events.ERROR, (_event, data) => {
     //   if (data.fatal) {
     //     switch (data.type) {
@@ -415,3 +431,36 @@ export const initialize = (
   loadMedia(props, mediaEl, nextHlsInstance);
   return nextHlsInstance;
 };
+
+export class MediaError extends Error {
+  static MEDIA_ERR_CUSTOM: number = 0;
+  static MEDIA_ERR_ABORTED: number = 1;
+  static MEDIA_ERR_NETWORK: number = 2;
+  static MEDIA_ERR_DECODE: number = 3;
+  static MEDIA_ERR_SRC_NOT_SUPPORTED: number = 4;
+  static MEDIA_ERR_ENCRYPTED: number = 5;
+
+  static defaultMessages: Record<number, string> = {
+    1: "You aborted the media playback",
+    2: "A network error caused the media download to fail.",
+    3: "A media error caused playback to be aborted. The media could be corrupt or your browser does not support this format.",
+    4: "An unsupported error occurred. The server or network failed, or your browser does not support this format.",
+    5: "The media is encrypted and there are no keys to decrypt it.",
+  };
+
+  name: string;
+  code: number;
+  fatal: boolean;
+  data?: any;
+
+  constructor(message?: string, code: number = 0, fatal?: boolean) {
+    super(message);
+    this.name = "MediaError";
+    this.code = code;
+    this.fatal = fatal ?? code >= MediaError.MEDIA_ERR_NETWORK;
+
+    if (!this.message) {
+      this.message = MediaError.defaultMessages[this.code] ?? "";
+    }
+  }
+}

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -322,28 +322,28 @@ export const loadMedia = (
       mediaEl.removeAttribute("src");
     }
   } else if (hls && src) {
-    hls.on(Hls.Events.ERROR, (_event, data) => {
-      if (data.fatal) {
-        switch (data.type) {
-          case Hls.ErrorTypes.NETWORK_ERROR:
-            // try to recover network error
-            console.error("fatal network error encountered, try to recover");
-            hls.startLoad();
-            break;
-          case Hls.ErrorTypes.MEDIA_ERROR:
-            console.error("fatal media error encountered, try to recover");
-            hls.recoverMediaError();
-            break;
-          default:
-            // cannot recover
-            console.error(
-              "unrecoverable fatal error encountered, cannot recover (check logs for more info)"
-            );
-            hls.destroy();
-            break;
-        }
-      }
-    });
+    // hls.on(Hls.Events.ERROR, (_event, data) => {
+    //   if (data.fatal) {
+    //     switch (data.type) {
+    //       case Hls.ErrorTypes.NETWORK_ERROR:
+    //         // try to recover network error
+    //         console.error("fatal network error encountered, try to recover");
+    //         hls.startLoad();
+    //         break;
+    //       case Hls.ErrorTypes.MEDIA_ERROR:
+    //         console.error("fatal media error encountered, try to recover");
+    //         hls.recoverMediaError();
+    //         break;
+    //       default:
+    //         // cannot recover
+    //         console.error(
+    //           "unrecoverable fatal error encountered, cannot recover (check logs for more info)"
+    //         );
+    //         hls.destroy();
+    //         break;
+    //     }
+    //   }
+    // });
 
     const forceHiddenThumbnails = () => {
       // Keeping this a forEach in case we want to expand the scope of this.

--- a/scripts/esbuilder/esbuilder.js
+++ b/scripts/esbuilder/esbuilder.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import path from "path";
 import { build } from "esbuild";
 
@@ -5,7 +6,7 @@ const camelCase = (name) => {
   return name.replace(/[-_]([a-z])/g, ($0, $1) => $1.toUpperCase());
 };
 
-const args = process.argv.slice(2).reduce((processArgs, val) => {
+const args = process.argv.slice(3).reduce((processArgs, val) => {
   let [key, value] = val.split("=");
   let [name, prop] = key.replace(/^--?/g, "").split(":");
   processArgs[camelCase(name)] = prop ? { [prop]: value } : value ?? true;
@@ -34,8 +35,8 @@ const i18nPlugin = {
 };
 
 build({
-  entryPoints: ["src/index.ts"],
-  outdir: "dist",
+  entryPoints: [process.argv[2]],
+  outdir: args.outdir ?? "dist",
   bundle: true,
   target: "es2019",
   minify: args.minify,

--- a/scripts/esbuilder/package.json
+++ b/scripts/esbuilder/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@mux-elements/esbuilder",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./esbuilder.js",
+  "repository": "https://github.com/muxinc/elements",
+  "author": "Mux, Inc.",
+  "license": "MIT",
+  "private": true,
+  "bin": {
+    "esbuilder": "./esbuilder.js"
+  },
+  "dependencies": {
+    "esbuild": "^0.13.13"
+  }
+}

--- a/scripts/i18n-utils/i18n-utils.js
+++ b/scripts/i18n-utils/i18n-utils.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+
+const srcFile = process.argv[2];
+const langFolder = process.argv[3];
+const baseLangFile = `${langFolder}/en.json`;
+const srcContents = fs.readFileSync(srcFile).toString();
+const baseLangContents = {};
+
+const strings = [];
+const regex = /\b(?:i18n`(.*?)`)/g;
+let result;
+
+while ((result = regex.exec(srcContents)) !== null) {
+  let i = 0;
+  strings.push(
+    result[1].replace(/\$\{(.*?)\}/g, (match, key) => {
+      return "${" + i++ + "}";
+    })
+  );
+}
+
+for (let file of walkSync(langFolder)) {
+  const oldDict = JSON.parse(fs.readFileSync(file).toString());
+  let dict = {};
+  if (file.endsWith("en.json")) {
+    for (let str of strings) {
+      dict[str] = str;
+    }
+  } else {
+    for (let str of strings) {
+      dict[str] = oldDict[str] ?? str;
+    }
+  }
+
+  fs.writeFileSync(file, JSON.stringify(dict, null, "  "));
+  console.log(
+    `${strings.length} strings (${
+      Object.keys(dict).length
+    } unique) written to ${file}`
+  );
+}
+
+function* walkSync(dir) {
+  const files = fs.readdirSync(dir, { withFileTypes: true });
+  for (const file of files) {
+    if (file.isDirectory()) {
+      yield* walkSync(path.join(dir, file.name));
+    } else {
+      yield path.join(dir, file.name);
+    }
+  }
+}

--- a/scripts/i18n-utils/package.json
+++ b/scripts/i18n-utils/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@mux-elements/i18n-utils",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./i18n-utils.js",
+  "repository": "https://github.com/muxinc/elements",
+  "author": "Mux, Inc.",
+  "license": "MIT",
+  "private": true,
+  "bin": {
+    "i18n-utils": "./i18n-utils.js"
+  }
+}


### PR DESCRIPTION
Just wanted to open up a draft PR to start a discussion because I think we should initially remove the playback-core error handling for some reasons like:

- Currently it's possible to get in an endless loop
- It looks like this sample code shouldn't be taken literally, it requires more work on our part to handle it and check for specific conditions before to actually try and recover. The hls.js demo shows more of this, see here: https://github.com/video-dev/hls.js/blob/2635570ca3ffc6ec2c0f8ef4be84b7da9bf39443/demo/main.js#L1041-L1084
- hls.js does already retry many areas if they fail with an exponential backoff for network errors etc. and retries for appending segments see https://github.com/video-dev/hls.js/blob/master/docs/design.md#error-detection-and-handling
- A fatal network error can be on the master manifest or the playlist which need different recovery; `hls.startLoad();` and `hls.loadSource(manifestURL)` but again this is already retried in hls.js itself.
- The sample code at https://github.com/video-dev/hls.js/commit/c4f6564e7dcf50da295e938a166fda48d02d3fa9#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R139-R158 was written in 2015.

Some resources for offline / online handling:
- https://github.com/video-dev/hls.js/issues/1878#issuecomment-416752563
- https://github.hubspot.com/offline/docs/welcome/