### PR TITLE
feat: Extended autoplay options

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxAudio.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxAudio.tsx
@@ -7,7 +7,7 @@ const INITIAL_MUTED = false;
 
 function MuxAudioPage() {
   const mediaElRef = useRef(null);
-  const [autoplay, setAutoplay] = useState(INITIAL_AUTOPLAY);
+  const [autoplay, setAutoplay] = useState<"muted" | boolean>(INITIAL_AUTOPLAY);
   const [muted, setMuted] = useState(INITIAL_MUTED);
 
   return (
@@ -44,7 +44,7 @@ function MuxAudioPage() {
             id="autoplay-control"
             type="checkbox"
             onChange={() => setAutoplay(!autoplay ? "muted" : false)}
-            checked={autoplay}
+            checked={!!autoplay}
           />
         </div>
         <div>

--- a/examples/nextjs-with-typescript/pages/MuxAudio.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxAudio.tsx
@@ -1,7 +1,15 @@
 import Link from "next/link";
+import { useRef, useState } from "react";
 import MuxAudio from "@mux-elements/mux-audio-react";
 
-function MuxVideoPage() {
+const INITIAL_AUTOPLAY = false;
+const INITIAL_MUTED = false;
+
+function MuxAudioPage() {
+  const mediaElRef = useRef(null);
+  const [autoplay, setAutplay] = useState(INITIAL_AUTOPLAY);
+  const [muted, setMuted] = useState(INITIAL_MUTED);
+
   return (
     <div
       style={{
@@ -14,6 +22,7 @@ function MuxVideoPage() {
       <h1>MuxAudio Demo</h1>
       <div style={{ flexGrow: 1, flexShrink: 1 }}>
         <MuxAudio
+          ref={mediaElRef}
           style={{ maxWidth: "100%" }}
           playbackId="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
           // metadata={{
@@ -24,9 +33,29 @@ function MuxVideoPage() {
           // envKey="mux-data-env-key"
           streamType="on-demand"
           controls
-          autoPlay
-          muted
+          autoPlay={autoplay}
+          muted={muted}
         />
+      </div>
+      <div>
+        <div>
+          <label htmlFor="autoplay-control">Muted Autoplay</label>
+          <input
+            id="autoplay-control"
+            type="checkbox"
+            onChange={() => setAutplay(!autoplay ? "muted" : false)}
+            checked={autoplay}
+          />
+        </div>
+        <div>
+          <label htmlFor="muted-control">Muted</label>
+          <input
+            id="muted-control"
+            type="checkbox"
+            onChange={() => setMuted(!muted)}
+            checked={muted}
+          />
+        </div>
       </div>
       <h3 className="title">
         <Link href="/">
@@ -37,4 +66,4 @@ function MuxVideoPage() {
   );
 }
 
-export default MuxVideoPage;
+export default MuxAudioPage;

--- a/examples/nextjs-with-typescript/pages/MuxAudio.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxAudio.tsx
@@ -7,7 +7,7 @@ const INITIAL_MUTED = false;
 
 function MuxAudioPage() {
   const mediaElRef = useRef(null);
-  const [autoplay, setAutplay] = useState(INITIAL_AUTOPLAY);
+  const [autoplay, setAutoplay] = useState(INITIAL_AUTOPLAY);
   const [muted, setMuted] = useState(INITIAL_MUTED);
 
   return (
@@ -43,7 +43,7 @@ function MuxAudioPage() {
           <input
             id="autoplay-control"
             type="checkbox"
-            onChange={() => setAutplay(!autoplay ? "muted" : false)}
+            onChange={() => setAutoplay(!autoplay ? "muted" : false)}
             checked={autoplay}
           />
         </div>

--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -41,7 +41,7 @@ function MuxPlayerPage() {
   const [paused, setPaused] = useState<boolean | undefined>(true);
   const [muted, setMuted] = useState(INITIAL_MUTED);
   const [debug, setDebug] = useState(INITIAL_DEBUG);
-  const [autoplay, setAutoplay] = useState(INITIAL_AUTOPLAY);
+  const [autoplay, setAutoplay] = useState<"muted" | boolean>(INITIAL_AUTOPLAY);
   return (
     <div
       style={{
@@ -102,7 +102,7 @@ function MuxPlayerPage() {
             id="autoplay-control"
             type="checkbox"
             onChange={() => setAutoplay(!autoplay ? "muted" : false)}
-            checked={autoplay}
+            checked={!!autoplay}
           />
         </div>
         <div>

--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -101,7 +101,7 @@ function MuxPlayerPage() {
           <input
             id="autoplay-control"
             type="checkbox"
-            onChange={() => setAutplay(!autoplay ? "muted" : false)}
+            onChange={() => setAutoplay(!autoplay ? "muted" : false)}
             checked={autoplay}
           />
         </div>

--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -97,6 +97,15 @@ function MuxPlayerPage() {
           />
         </div>
         <div>
+          <label htmlFor="autoplay-control">Autoplay</label>
+          <input
+            id="autoplay-control"
+            type="checkbox"
+            onChange={() => setAutplay(!autoplay ? "muted" : false)}
+            checked={autoplay}
+          />
+        </div>
+        <div>
           <label htmlFor="muted-control">Muted</label>
           <input
             id="muted-control"

--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -5,7 +5,7 @@ import { useRef, useState } from "react";
 import mediaAssetsJSON from "@mux-elements/assets/media-assets.json";
 
 const INITIAL_DEBUG = false;
-const INITIAL_MUTED = true;
+const INITIAL_MUTED = false;
 const INITIAL_AUTOPLAY = false;
 const INITIAL_ENV_KEY = "5e67cqdt7hgc9vkla7p0qch7q";
 const INITIAL_METADATA = {
@@ -41,7 +41,7 @@ function MuxPlayerPage() {
   const [paused, setPaused] = useState<boolean | undefined>(true);
   const [muted, setMuted] = useState(INITIAL_MUTED);
   const [debug, setDebug] = useState(INITIAL_DEBUG);
-  const [autoPlay, setAutoPlay] = useState(INITIAL_AUTOPLAY);
+  const [autoplay, setAutoplay] = useState(INITIAL_AUTOPLAY);
   return (
     <div
       style={{
@@ -66,7 +66,7 @@ function MuxPlayerPage() {
           debug={debug}
           muted={muted}
           paused={paused}
-          autoPlay={autoPlay}
+          autoPlay={autoplay}
           streamType={
             selectedAsset["stream-type"] as "live" | "ll-live" | "on-demand"
           }
@@ -97,7 +97,7 @@ function MuxPlayerPage() {
           />
         </div>
         <div>
-          <label htmlFor="autoplay-control">Autoplay</label>
+          <label htmlFor="autoplay-control">Muted Autoplay</label>
           <input
             id="autoplay-control"
             type="checkbox"
@@ -112,15 +112,6 @@ function MuxPlayerPage() {
             type="checkbox"
             onChange={() => setMuted(!muted)}
             checked={muted}
-          />
-        </div>
-        <div>
-          <label htmlFor="autoplay-control">Autoplay</label>
-          <input
-            id="autoplay-control"
-            type="checkbox"
-            onChange={() => setAutoPlay(!autoPlay)}
-            checked={autoPlay}
           />
         </div>
         <div>

--- a/examples/nextjs-with-typescript/pages/MuxVideo.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxVideo.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import MuxVideo from "@mux-elements/mux-video-react";
 
 const INITIAL_AUTOPLAY = false;
@@ -7,8 +7,12 @@ const INITIAL_MUTED = false;
 
 function MuxVideoPage() {
   const mediaElRef = useRef(null);
-  const [autoplay, setAutoplay] = useState(INITIAL_AUTOPLAY);
+  const [autoplay, setAutoplay] = useState<"muted" | boolean>(INITIAL_AUTOPLAY);
   const [muted, setMuted] = useState(INITIAL_MUTED);
+  const [paused, setPaused] = useState<boolean | undefined>(true);
+  useEffect(() => {
+    if (!mediaElRef.current) return;
+  }, [paused]);
 
   return (
     <div
@@ -35,16 +39,31 @@ function MuxVideoPage() {
           controls
           autoPlay={autoplay}
           muted={muted}
+          onPlay={() => {
+            setPaused(false);
+          }}
+          onPause={() => {
+            setPaused(true);
+          }}
         />
       </div>
       <div>
+        <div>
+          <label htmlFor="paused-control">Paused</label>
+          <input
+            id="paused-control"
+            type="checkbox"
+            onChange={() => setPaused(!paused)}
+            checked={paused}
+          />
+        </div>
         <div>
           <label htmlFor="autoplay-control">Muted Autoplay</label>
           <input
             id="autoplay-control"
             type="checkbox"
             onChange={() => setAutoplay(!autoplay ? "muted" : false)}
-            checked={autoplay}
+            checked={!!autoplay}
           />
         </div>
         <div>

--- a/examples/nextjs-with-typescript/pages/MuxVideo.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxVideo.tsx
@@ -7,7 +7,7 @@ const INITIAL_MUTED = false;
 
 function MuxVideoPage() {
   const mediaElRef = useRef(null);
-  const [autoplay, setAutplay] = useState(INITIAL_AUTOPLAY);
+  const [autoplay, setAutoplay] = useState(INITIAL_AUTOPLAY);
   const [muted, setMuted] = useState(INITIAL_MUTED);
 
   return (
@@ -43,7 +43,7 @@ function MuxVideoPage() {
           <input
             id="autoplay-control"
             type="checkbox"
-            onChange={() => setAutplay(!autoplay ? "muted" : false)}
+            onChange={() => setAutoplay(!autoplay ? "muted" : false)}
             checked={autoplay}
           />
         </div>

--- a/examples/nextjs-with-typescript/pages/MuxVideo.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxVideo.tsx
@@ -1,7 +1,15 @@
 import Link from "next/link";
+import { useRef, useState } from "react";
 import MuxVideo from "@mux-elements/mux-video-react";
 
+const INITIAL_AUTOPLAY = false;
+const INITIAL_MUTED = false;
+
 function MuxVideoPage() {
+  const mediaElRef = useRef(null);
+  const [autoplay, setAutplay] = useState(INITIAL_AUTOPLAY);
+  const [muted, setMuted] = useState(INITIAL_MUTED);
+
   return (
     <div
       style={{
@@ -14,6 +22,7 @@ function MuxVideoPage() {
       <h1>MuxVideo Demo</h1>
       <div style={{ flexGrow: 1, flexShrink: 1, height: "400px" }}>
         <MuxVideo
+          ref={mediaElRef}
           style={{ height: "100%", maxWidth: "100%" }}
           playbackId="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
           // metadata={{
@@ -24,9 +33,29 @@ function MuxVideoPage() {
           // envKey="mux-data-env-key"
           streamType="on-demand"
           controls
-          autoPlay
-          muted
+          autoPlay={autoplay}
+          muted={muted}
         />
+      </div>
+      <div>
+        <div>
+          <label htmlFor="autoplay-control">Muted Autoplay</label>
+          <input
+            id="autoplay-control"
+            type="checkbox"
+            onChange={() => setAutplay(!autoplay ? "muted" : false)}
+            checked={autoplay}
+          />
+        </div>
+        <div>
+          <label htmlFor="muted-control">Muted</label>
+          <input
+            id="muted-control"
+            type="checkbox"
+            onChange={() => setMuted(!muted)}
+            checked={muted}
+          />
+        </div>
       </div>
       <h3 className="title">
         <Link href="/">

--- a/examples/nextjs-with-typescript/pages/MuxVideo.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxVideo.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import MuxVideo from "@mux-elements/mux-video-react";
 
 const INITIAL_AUTOPLAY = false;
@@ -10,9 +10,6 @@ function MuxVideoPage() {
   const [autoplay, setAutoplay] = useState<"muted" | boolean>(INITIAL_AUTOPLAY);
   const [muted, setMuted] = useState(INITIAL_MUTED);
   const [paused, setPaused] = useState<boolean | undefined>(true);
-  useEffect(() => {
-    if (!mediaElRef.current) return;
-  }, [paused]);
 
   return (
     <div

--- a/examples/nextjs-with-typescript/pages/mux-player.tsx
+++ b/examples/nextjs-with-typescript/pages/mux-player.tsx
@@ -4,7 +4,8 @@ import "@mux-elements/mux-player";
 import { useState } from "react";
 
 const INITIAL_DEBUG = false;
-const INITIAL_MUTED = true;
+const INITIAL_MUTED = false;
+const INITIAL_AUTOPLAY = false;
 const INITIAL_PLAYBACK_ID = "g65IqSFtWdpGR100c2W8VUHrfIVWTNRen";
 
 function MuxPlayerWCPage() {
@@ -12,8 +13,10 @@ function MuxPlayerWCPage() {
   const [playbackId, setPlaybackId] = useState(INITIAL_PLAYBACK_ID);
   const [muted, setMuted] = useState(INITIAL_MUTED);
   const [debug, setDebug] = useState(INITIAL_DEBUG);
+  const [autoplay, setAutoplay] = useState(INITIAL_AUTOPLAY);
   const debugObj = debug ? { debug: "" } : {};
   const mutedObj = muted ? { muted: "" } : {};
+  const autoplayObj = autoplay ? { autoplay } : {};
   return (
     <div
       style={{
@@ -33,7 +36,7 @@ function MuxPlayerWCPage() {
           // onPlayerReady={() => console.log("ready!")}
           {...debugObj}
           {...mutedObj}
-          // auto-play=""
+          {...autoplayObj}
           // stream-type="live"
           // primary-color="#ec407a"
           // secondary-color="#64b5f6"
@@ -42,6 +45,15 @@ function MuxPlayerWCPage() {
         ></mux-player>
       </div>
       <div>
+        <div>
+          <label htmlFor="autoplay-control">Muted Autoplay</label>
+          <input
+            id="autoplay-control"
+            type="checkbox"
+            onChange={() => setAutoplay(!autoplay ? "muted" : false)}
+            checked={autoplay}
+          />
+        </div>
         <div>
           <label htmlFor="muted-control">Muted</label>
           <input

--- a/examples/nextjs-with-typescript/pages/mux-player.tsx
+++ b/examples/nextjs-with-typescript/pages/mux-player.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import "@mux-elements/mux-player";
 import { useState } from "react";
 
-const INITIAL_DEBUG = true;
+const INITIAL_DEBUG = false;
 const INITIAL_MUTED = true;
 const INITIAL_PLAYBACK_ID = "g65IqSFtWdpGR100c2W8VUHrfIVWTNRen";
 

--- a/examples/nextjs-with-typescript/pages/mux-video.tsx
+++ b/examples/nextjs-with-typescript/pages/mux-video.tsx
@@ -5,7 +5,8 @@ import { useState } from "react";
 
 // const INITIAL_DEBUG = true;
 const INITIAL_DEBUG = false;
-const INITIAL_MUTED = true;
+const INITIAL_MUTED = false;
+const INITIAL_AUTOPLAY = false;
 const INITIAL_PLAYBACK_ID = "g65IqSFtWdpGR100c2W8VUHrfIVWTNRen";
 
 function MuxVideoWCPage() {
@@ -13,8 +14,10 @@ function MuxVideoWCPage() {
   const [playbackId, setPlaybackId] = useState(INITIAL_PLAYBACK_ID);
   const [muted, setMuted] = useState(INITIAL_MUTED);
   const [debug, setDebug] = useState(INITIAL_DEBUG);
+  const [autoplay, setAutoplay] = useState(INITIAL_AUTOPLAY);
   const debugObj = debug ? { debug: "" } : {};
   const mutedObj = muted ? { muted: "" } : {};
+  const autoplayObj = autoplay ? { autoplay } : {};
   return (
     <div
       style={{
@@ -32,7 +35,7 @@ function MuxVideoWCPage() {
           // onPlayerReady={() => console.log("ready!")}
           {...debugObj}
           {...mutedObj}
-          // auto-play=""
+          {...autoplayObj}
           // stream-type="live"
           // primary-color="#ec407a"
           // secondary-color="#64b5f6"
@@ -42,6 +45,15 @@ function MuxVideoWCPage() {
         ></mux-video>
       </div>
       <div>
+        <div>
+          <label htmlFor="autoplay-control">Muted Autoplay</label>
+          <input
+            id="autoplay-control"
+            type="checkbox"
+            onChange={() => setAutoplay(!autoplay ? "muted" : false)}
+            checked={autoplay}
+          />
+        </div>
         <div>
           <label htmlFor="muted-control">Muted</label>
           <input

--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -54,6 +54,7 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
 
     const mediaElRef = useCombinedRefs(innerMediaElRef, ref);
     const updateAutoplayRef = useRef<UpdateAutoplay | undefined>(undefined);
+    const [updateAutoplay, setUpdateAutoplay] = useState(() => (x: any) => {});
 
     useEffect(() => {
       const src = toMuxVideoURL(playbackId) ?? outerSrc;
@@ -75,16 +76,13 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
         playbackEngineRef.current
       );
       playbackEngineRef.current = nextPlaybackEngineRef;
-      const updateAutoplay = setupAutoplay(
-        mediaElRef.current,
-        autoPlay,
-        playbackEngineRef.current
+      setUpdateAutoplay(() =>
+        setupAutoplay(mediaElRef.current, autoPlay, playbackEngineRef.current)
       );
-      updateAutoplayRef.current = updateAutoplay;
     }, [src]);
 
     useEffect(() => {
-      updateAutoplayRef.current?.(autoPlay);
+      updateAutoplay(autoPlay);
     }, [autoPlay]);
 
     return (

--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import {
   allMediaTypes,
   initialize,
+  setupAutoplay,
   MuxMediaProps,
   StreamTypes,
   toMuxVideoURL,
@@ -50,6 +51,7 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
     const innerMediaElRef = useRef<HTMLAudioElement>(null);
 
     const mediaElRef = useCombinedRefs(innerMediaElRef, ref);
+    const updateAutoplayRef = useRef(null);
 
     useEffect(() => {
       const src = toMuxVideoURL(playbackId) ?? outerSrc;
@@ -71,7 +73,17 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
         playbackEngineRef.current
       );
       playbackEngineRef.current = nextPlaybackEngineRef;
+      const updateAutoplay = setupAutoplay(
+        mediaElRef.current,
+        autoPlay,
+        playbackEngineRef.current
+      );
+      updateAutoplayRef.current = updateAutoplay;
     }, [src]);
+
+    useEffect(() => {
+      updateAutoplayRef.current(autoPlay);
+    }, [autoPlay]);
 
     return (
       <audio ref={mediaElRef} {...restProps}>

--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -11,9 +11,12 @@ import {
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
 
-export type Props = React.DetailedHTMLProps<
-  React.AudioHTMLAttributes<HTMLAudioElement>,
-  HTMLAudioElement
+export type Props = Omit<
+  React.DetailedHTMLProps<
+    React.AudioHTMLAttributes<HTMLAudioElement>,
+    HTMLAudioElement
+  >,
+  "autoPlay"
 > &
   MuxMediaProps;
 
@@ -33,6 +36,7 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
       startTime,
       src: outerSrc,
       children,
+      autoPlay,
       ...restProps
     } = props;
 
@@ -59,7 +63,7 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
         playerInitTime,
         playerSoftwareName,
         playerSoftwareVersion,
-        autoplay: props.autoPlay,
+        autoplay: autoPlay,
       };
       const nextPlaybackEngineRef = initialize(
         propsWithState,

--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -59,6 +59,7 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
         playerInitTime,
         playerSoftwareName,
         playerSoftwareVersion,
+        autoplay: props.autoPlay,
       };
       const nextPlaybackEngineRef = initialize(
         propsWithState,

--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -4,6 +4,8 @@ import PropTypes from "prop-types";
 import {
   allMediaTypes,
   initialize,
+  type Autoplay,
+  type UpdateAutoplay,
   setupAutoplay,
   MuxMediaProps,
   StreamTypes,
@@ -51,7 +53,7 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
     const innerMediaElRef = useRef<HTMLAudioElement>(null);
 
     const mediaElRef = useCombinedRefs(innerMediaElRef, ref);
-    const updateAutoplayRef = useRef(null);
+    const updateAutoplayRef = useRef<UpdateAutoplay | undefined>(undefined);
 
     useEffect(() => {
       const src = toMuxVideoURL(playbackId) ?? outerSrc;
@@ -82,7 +84,7 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
     }, [src]);
 
     useEffect(() => {
-      updateAutoplayRef.current(autoPlay);
+      updateAutoplayRef.current?.(autoPlay);
     }, [autoPlay]);
 
     return (

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -3,7 +3,6 @@ import CustomAudioElement from "./CustomAudioElement";
 import {
   initialize,
   setupAutoplay,
-  type Autoplay,
   MuxMediaProps,
   StreamTypes,
   ValueOf,
@@ -13,6 +12,7 @@ import {
   PlaybackEngine,
   Metadata,
   mux,
+  type UpdateAutoplay,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
 
@@ -67,7 +67,7 @@ class MuxAudioElement
   protected __hls?: PlaybackEngine;
   protected __muxPlayerInitTime: number;
   protected __metadata: Readonly<Metadata> = {};
-  protected __updateAutoplay?: (a: Autoplay) => void;
+  protected __updateAutoplay?: UpdateAutoplay;
 
   constructor() {
     super();
@@ -245,7 +245,7 @@ class MuxAudioElement
         }
         break;
       case "autoplay":
-        this.__updateAutoplay?.(newValue as Autoplay);
+        this.__updateAutoplay?.(newValue);
         break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -3,6 +3,7 @@ import CustomAudioElement from "./CustomAudioElement";
 import {
   initialize,
   setupAutoplay,
+  type Autoplay,
   MuxMediaProps,
   StreamTypes,
   ValueOf,
@@ -66,6 +67,7 @@ class MuxAudioElement
   protected __hls?: PlaybackEngine;
   protected __muxPlayerInitTime: number;
   protected __metadata: Readonly<Metadata> = {};
+  protected __updateAutoplay?: (a: Autoplay) => void;
 
   constructor() {
     super();
@@ -243,7 +245,7 @@ class MuxAudioElement
         }
         break;
       case "autoplay":
-        this.__updateAutoplay(newValue);
+        this.__updateAutoplay?.(newValue as Autoplay);
         break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -2,6 +2,7 @@ import CustomAudioElement from "./CustomAudioElement";
 
 import {
   initialize,
+  setupAutoplay,
   MuxMediaProps,
   StreamTypes,
   ValueOf,
@@ -209,6 +210,12 @@ class MuxAudioElement
       this.__hls
     );
     this.__hls = nextHlsInstance;
+    const updateAutoplay = setupAutoplay(
+      this.nativeEl,
+      this.autoplay,
+      nextHlsInstance
+    );
+    this.__updateAutoplay = updateAutoplay;
   }
 
   unload() {
@@ -234,6 +241,9 @@ class MuxAudioElement
           this.unload();
           this.load();
         }
+        break;
+      case "autoplay":
+        this.__updateAutoplay(newValue);
         break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -6,7 +6,7 @@ import type { Tokens } from "@mux-elements/mux-player";
 import { toNativeProps } from "./common/utils";
 import { useRef } from "react";
 import { useCombinedRefs } from "./useCombinedRefs";
-import useObjectPropEffect from "./useObjectPropEffect";
+import useObjectPropEffect, { defaultHasChanged } from "./useObjectPropEffect";
 import { getPlayerVersion } from "./env";
 
 type ValueOf<T> = T[keyof T];
@@ -156,7 +156,7 @@ const usePlayer = (
       if (playerEl.hasAttribute("autoplay") && !playerEl.hasPlayed) {
         return false;
       }
-      return true;
+      return defaultHasChanged(playerEl, value, propName);
     }
   );
   useEventCallbackEffect("loadstart", ref, onLoadStart);

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -22,7 +22,7 @@ type VideoApiAttributes = {
   playsInline: boolean;
   // preload: string;
   crossOrigin: string;
-  autoPlay: boolean;
+  autoPlay: boolean | string;
   loop: boolean;
   muted: boolean;
   style: CSSProperties;

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -151,6 +151,12 @@ const usePlayer = (
       } else {
         playerEl.play();
       }
+    },
+    (playerEl, value, propName) => {
+      if (playerEl.hasAttribute("autoplay") && !playerEl.hasPlayed) {
+        return false;
+      }
+      return true;
     }
   );
   useEventCallbackEffect("loadstart", ref, onLoadStart);

--- a/packages/mux-player-react/src/useObjectPropEffect.ts
+++ b/packages/mux-player-react/src/useObjectPropEffect.ts
@@ -48,7 +48,7 @@ const shallowEqual = (objA: any, objB: any): boolean => {
   return true;
 };
 
-const defaultHasChanged = (obj: any, v: any, k: string) => {
+export const defaultHasChanged = (obj: any, v: any, k: string) => {
   return !shallowEqual(v, obj[k]);
 };
 

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -148,7 +148,6 @@ class MuxPlayerElement extends VideoApiElement {
     // }
 
     this.#setUpErrors();
-    this.#setUpMutedAutoplay();
     this.#setUpCaptionsButton();
     this.#setUpAirplayButton();
     this.#setUpVolumeRange();
@@ -262,27 +261,6 @@ class MuxPlayerElement extends VideoApiElement {
         );
       };
       this.video.hls.on(Hls.Events.ERROR, onHlsError);
-    }
-  }
-
-  #setUpMutedAutoplay() {
-    if (this.video?.hls) {
-      const Hls: any = this.video.hls.constructor;
-      if (this.autoplay) {
-        this.video.hls.on(Hls.Events.MANIFEST_PARSED, () => {
-          var playPromise = this.video?.play();
-          if (playPromise) {
-            playPromise.catch((error: Error) => {
-              console.log(`${error.name} ${error.message}`);
-              if (error.name === "NotAllowedError") {
-                console.log("Attempting to play with video muted");
-                if (this.video) this.video.muted = true;
-                return this.video?.play().catch(console.error);
-              }
-            });
-          }
-        });
-      }
     }
   }
 

--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -241,7 +241,7 @@ class VideoApiElement extends HTMLElement {
 
   set autoplay(val) {
     if (val) {
-      this.setAttribute(AllowedVideoAttributes.AUTOPLAY, "");
+      this.setAttribute(AllowedVideoAttributes.AUTOPLAY, val);
     } else {
       // Remove boolean attribute if false, 0, '', null, undefined.
       this.removeAttribute(AllowedVideoAttributes.AUTOPLAY);

--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -153,6 +153,12 @@ class VideoApiElement extends HTMLElement {
     return this.shadowRoot?.querySelector("mux-video");
   }
 
+  get hasPlayed() {
+    return this.shadowRoot
+      ?.querySelector("media-controller")
+      .hasAttribute("media-has-played");
+  }
+
   get paused() {
     return this.video?.paused ?? true;
   }

--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -154,9 +154,13 @@ class VideoApiElement extends HTMLElement {
   }
 
   get hasPlayed() {
-    return this.shadowRoot
-      ?.querySelector("media-controller")
-      .hasAttribute("media-has-played");
+    const mc = this.shadowRoot?.querySelector("media-controller");
+
+    if (mc) {
+      return mc.hasAttribute("media-has-played");
+    }
+
+    return false;
   }
 
   get paused() {

--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -241,7 +241,10 @@ class VideoApiElement extends HTMLElement {
 
   set autoplay(val) {
     if (val) {
-      this.setAttribute(AllowedVideoAttributes.AUTOPLAY, val);
+      this.setAttribute(
+        AllowedVideoAttributes.AUTOPLAY,
+        typeof val === "string" ? val : ""
+      );
     } else {
       // Remove boolean attribute if false, 0, '', null, undefined.
       this.removeAttribute(AllowedVideoAttributes.AUTOPLAY);

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -1,11 +1,10 @@
 import useCombinedRefs from "./use-combined-refs";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import {
   allMediaTypes,
   initialize,
   setupAutoplay,
-  type Autoplay,
   MuxMediaProps,
   StreamTypes,
   toMuxVideoURL,
@@ -50,10 +49,9 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
 
     const playbackEngineRef = useRef<PlaybackEngine | undefined>(undefined);
     const innerMediaElRef = useRef<HTMLVideoElement>(null);
+    const [updateAutoplay, setUpdateAutoplay] = useState(() => (x: any) => {});
 
     const mediaElRef = useCombinedRefs(innerMediaElRef, ref);
-    const updateAutoplayRef =
-      useRef<(a: Autoplay) => void | undefined>(undefined);
 
     useEffect(() => {
       const src = toMuxVideoURL(playbackId) ?? outerSrc;
@@ -75,16 +73,13 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
         playbackEngineRef.current
       );
       playbackEngineRef.current = nextPlaybackEngineRef;
-      const updateAutoplay = setupAutoplay(
-        mediaElRef.current,
-        autoPlay,
-        playbackEngineRef.current
+      setUpdateAutoplay(() =>
+        setupAutoplay(mediaElRef.current, autoPlay, playbackEngineRef.current)
       );
-      updateAutoplayRef.current = updateAutoplay;
     }, [src]);
 
     useEffect(() => {
-      updateAutoplayRef.current?.(autoPlay);
+      updateAutoplay(autoPlay);
     }, [autoPlay]);
 
     return (

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import {
   allMediaTypes,
   initialize,
+  setupAutoplay,
   MuxMediaProps,
   StreamTypes,
   toMuxVideoURL,
@@ -50,6 +51,7 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
     const innerMediaElRef = useRef<HTMLVideoElement>(null);
 
     const mediaElRef = useCombinedRefs(innerMediaElRef, ref);
+    const updateAutoplayRef = useRef(null);
 
     useEffect(() => {
       const src = toMuxVideoURL(playbackId) ?? outerSrc;
@@ -71,10 +73,16 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
         playbackEngineRef.current
       );
       playbackEngineRef.current = nextPlaybackEngineRef;
+      const updateAutoplay = setupAutoplay(
+        mediaElRef.current,
+        autoPlay,
+        playbackEngineRef.current
+      );
+      updateAutoplayRef.current = updateAutoplay;
     }, [src]);
 
     useEffect(() => {
-      console.log("autoplay updated", autoPlay);
+      updateAutoplayRef.current(autoPlay);
     }, [autoPlay]);
 
     return (

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -59,6 +59,7 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
         playerInitTime,
         playerSoftwareName,
         playerSoftwareVersion,
+        autoplay: props.autoPlay,
       };
       const nextPlaybackEngineRef = initialize(
         propsWithState,

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -5,6 +5,7 @@ import {
   allMediaTypes,
   initialize,
   setupAutoplay,
+  type Autoplay,
   MuxMediaProps,
   StreamTypes,
   toMuxVideoURL,
@@ -51,7 +52,8 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
     const innerMediaElRef = useRef<HTMLVideoElement>(null);
 
     const mediaElRef = useCombinedRefs(innerMediaElRef, ref);
-    const updateAutoplayRef = useRef(null);
+    const updateAutoplayRef =
+      useRef<(a: Autoplay) => void | undefined>(undefined);
 
     useEffect(() => {
       const src = toMuxVideoURL(playbackId) ?? outerSrc;
@@ -82,7 +84,7 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
     }, [src]);
 
     useEffect(() => {
-      updateAutoplayRef.current(autoPlay);
+      updateAutoplayRef.current?.(autoPlay);
     }, [autoPlay]);
 
     return (

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -11,9 +11,12 @@ import {
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
 
-export type Props = React.DetailedHTMLProps<
-  React.VideoHTMLAttributes<HTMLVideoElement>,
-  HTMLVideoElement
+export type Props = Omit<
+  React.DetailedHTMLProps<
+    React.VideoHTMLAttributes<HTMLVideoElement>,
+    HTMLVideoElement
+  >,
+  "autoPlay"
 > &
   MuxMediaProps;
 
@@ -33,6 +36,7 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
       startTime,
       src: outerSrc,
       children,
+      autoPlay,
       ...restProps
     } = props;
 
@@ -59,7 +63,7 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
         playerInitTime,
         playerSoftwareName,
         playerSoftwareVersion,
-        autoplay: props.autoPlay,
+        autoplay: autoPlay,
       };
       const nextPlaybackEngineRef = initialize(
         propsWithState,

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -1,5 +1,5 @@
 import useCombinedRefs from "./use-combined-refs";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import {
   allMediaTypes,

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -73,6 +73,10 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
       playbackEngineRef.current = nextPlaybackEngineRef;
     }, [src]);
 
+    useEffect(() => {
+      console.log("autoplay updated", autoPlay);
+    }, [autoPlay]);
+
     return (
       <video ref={mediaElRef} {...restProps}>
         {children}

--- a/packages/mux-video/src/CustomVideoElement.js
+++ b/packages/mux-video/src/CustomVideoElement.js
@@ -121,11 +121,9 @@ class CustomVideoElement extends HTMLElement {
   // We need to handle sub-class custom attributes differently from
   // attrs meant to be passed to the internal native el.
   attributeChangedCallback(attrName, oldValue, newValue) {
-
     // Find the matching prop for custom attributes
     const ownProps = Object.getOwnPropertyNames(Object.getPrototypeOf(this));
     const propName = arrayFindAnyCase(ownProps, attrName);
-
 
     // Check if this is the original custom native elemnt or a subclass
     const isBaseElement =

--- a/packages/mux-video/src/CustomVideoElement.js
+++ b/packages/mux-video/src/CustomVideoElement.js
@@ -121,9 +121,11 @@ class CustomVideoElement extends HTMLElement {
   // We need to handle sub-class custom attributes differently from
   // attrs meant to be passed to the internal native el.
   attributeChangedCallback(attrName, oldValue, newValue) {
+
     // Find the matching prop for custom attributes
     const ownProps = Object.getOwnPropertyNames(Object.getPrototypeOf(this));
     const propName = arrayFindAnyCase(ownProps, attrName);
+
 
     // Check if this is the original custom native elemnt or a subclass
     const isBaseElement =

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -12,6 +12,7 @@ import {
   Metadata,
   PlaybackEngine,
   mux,
+  type UpdateAutoplay,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
 
@@ -72,7 +73,7 @@ class MuxVideoElement
   protected __metadata: Readonly<Metadata> = {};
   protected __playerSoftwareVersion?: string;
   protected __playerSoftwareName?: string;
-  protected __updateAutoplay?;
+  protected __updateAutoplay?: UpdateAutoplay;
 
   constructor() {
     super();
@@ -329,7 +330,7 @@ class MuxVideoElement
         }
         break;
       case "autoplay":
-        this.__updateAutoplay(newValue);
+        this.__updateAutoplay?.(newValue);
         break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -72,6 +72,7 @@ class MuxVideoElement
   protected __metadata: Readonly<Metadata> = {};
   protected __playerSoftwareVersion?: string;
   protected __playerSoftwareName?: string;
+  protected __updateAutoplay?;
 
   constructor() {
     super();

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -217,7 +217,7 @@ class MuxVideoElement
     }
   }
 
-  get streamType(): ValueOf<StreamTypes> {
+  get streamType(): ValueOf<StreamTypes> | undefined {
     // getAttribute doesn't know that this attribute is well defined. Should explore extending for MuxVideo (CJP)
     return (
       (this.getAttribute(Attributes.STREAM_TYPE) as ValueOf<StreamTypes>) ??
@@ -225,7 +225,7 @@ class MuxVideoElement
     );
   }
 
-  set streamType(val: ValueOf<StreamTypes>) {
+  set streamType(val: ValueOf<StreamTypes> | undefined) {
     // dont' cause an infinite loop
     if (val === this.streamType) return;
 

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -4,7 +4,6 @@ import {
   initialize,
   MuxMediaProps,
   StreamTypes,
-  AutoplayTypes,
   ValueOf,
   ExtensionMimeTypeMap,
   toMuxVideoURL,
@@ -118,39 +117,6 @@ class MuxVideoElement
       this.removeAttribute("src");
     } else {
       this.setAttribute("src", val);
-    }
-  }
-
-  get autoplay(): boolean | ValueOf<AutoplayTypes> {
-    if (!this.hasAttribute("autoplay")) {
-      return false;
-    }
-
-    const autoplay = this.getAttribute("autoplay") as ValeOf<AutoplayTypes>;
-
-    if (autoplay === "") {
-      return true;
-    }
-
-    return autoplay ?? false;
-  }
-
-  set autoplay(val: boolean | ValeOf<AutoplayTypes>) {
-    if (
-      val === this.getAttribute("autoplay") ||
-      (val && this.hasAttribute("autoplay"))
-    ) {
-      return;
-    }
-
-    if (typeof val === "boolean") {
-      if (val) {
-        this.setAttribute("autoplay", "");
-      } else {
-        this.removeAttribute("autoplay");
-      }
-    } else {
-      this.setAttribute("autoplay", val);
     }
   }
 

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -320,14 +320,6 @@ class MuxVideoElement
           this.load();
         }
         break;
-      // case "autoplay":
-      //   if (newValue === old value) {
-      //     break;
-      //   }
-      //
-      //   if (typeof newValue === 'boolean')
-      //
-      //   break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */
         this.src = toMuxVideoURL(newValue ?? undefined) as string;

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -4,6 +4,7 @@ import {
   initialize,
   MuxMediaProps,
   StreamTypes,
+  AutoplayTypes,
   ValueOf,
   ExtensionMimeTypeMap,
   toMuxVideoURL,
@@ -120,6 +121,39 @@ class MuxVideoElement
     }
   }
 
+  get autoplay(): boolean | ValueOf<AutoplayTypes> {
+    if (!this.hasAttribute("autoplay")) {
+      return false;
+    }
+
+    const autoplay = this.getAttribute("autoplay") as ValeOf<AutoplayTypes>;
+
+    if (autoplay === "") {
+      return true;
+    }
+
+    return autoplay ?? false;
+  }
+
+  set autoplay(val: boolean | ValeOf<AutoplayTypes>) {
+    if (
+      val === this.getAttribute("autoplay") ||
+      (val && this.hasAttribute("autoplay"))
+    ) {
+      return;
+    }
+
+    if (typeof val === "boolean") {
+      if (val) {
+        this.setAttribute("autoplay", "");
+      } else {
+        this.removeAttribute("autoplay");
+      }
+    } else {
+      this.setAttribute("autoplay", val);
+    }
+  }
+
   get type(): ValueOf<ExtensionMimeTypeMap> | undefined {
     return (
       (this.getAttribute(Attributes.TYPE) as ValueOf<ExtensionMimeTypeMap>) ??
@@ -217,7 +251,7 @@ class MuxVideoElement
     }
   }
 
-  get streamType(): ValueOf<StreamTypes> | undefined {
+  get streamType(): ValueOf<StreamTypes> {
     // getAttribute doesn't know that this attribute is well defined. Should explore extending for MuxVideo (CJP)
     return (
       (this.getAttribute(Attributes.STREAM_TYPE) as ValueOf<StreamTypes>) ??
@@ -225,7 +259,7 @@ class MuxVideoElement
     );
   }
 
-  set streamType(val: ValueOf<StreamTypes> | undefined) {
+  set streamType(val: ValueOf<StreamTypes>) {
     // dont' cause an infinite loop
     if (val === this.streamType) return;
 
@@ -320,6 +354,14 @@ class MuxVideoElement
           this.load();
         }
         break;
+      // case "autoplay":
+      //   if (newValue === old value) {
+      //     break;
+      //   }
+      //
+      //   if (typeof newValue === 'boolean')
+      //
+      //   break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */
         this.src = toMuxVideoURL(newValue ?? undefined) as string;

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -2,6 +2,7 @@ import CustomVideoElement from "./CustomVideoElement";
 
 import {
   initialize,
+  setupAutoplay,
   MuxMediaProps,
   StreamTypes,
   ValueOf,
@@ -277,6 +278,12 @@ class MuxVideoElement
       this.__hls
     );
     this.__hls = nextHlsInstance;
+    const updateAutoplay = setupAutoplay(
+      this.nativeEl,
+      this.autoplay,
+      nextHlsInstance
+    );
+    this.__updateAutoplay = updateAutoplay;
   }
 
   unload() {
@@ -319,6 +326,9 @@ class MuxVideoElement
           this.unload();
           this.load();
         }
+        break;
+      case "autoplay":
+        this.__updateAutoplay(newValue);
         break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */

--- a/packages/playback-core/src/autoplay.ts
+++ b/packages/playback-core/src/autoplay.ts
@@ -14,16 +14,29 @@ export const AutoplayTypes: AutoplayTypes = {
 };
 
 type ValueOf<T> = T[keyof T];
-export type Autoplay = boolean | ValueOf<AutoplayTypes> | undefined;
-export type UpdateAutoplay = (newAutoplay: Autoplay) => void;
+type Maybe<T> = T | null | undefined;
+export type Autoplay = boolean | ValueOf<AutoplayTypes>;
+export type UpdateAutoplay = (newAutoplay: Maybe<string | boolean>) => void;
+
+const AutoplayTypeValues = Object.values(AutoplayTypes);
+export const isAutoplayValue = (value: unknown): value is Autoplay => {
+  return (
+    typeof value == "boolean" ||
+    (typeof value === "string" &&
+      AutoplayTypeValues.includes(value as ValueOf<AutoplayTypes>))
+  );
+};
 
 export const setupAutoplay = (
   mediaEl: HTMLMediaElement,
-  autoplay: Autoplay,
+  maybeAutoplay: Maybe<string | boolean>,
   hls: PlaybackEngine | undefined
 ) => {
   let hasPlayed = false;
   let isLive = false;
+  let autoplay: Autoplay = isAutoplayValue(maybeAutoplay)
+    ? maybeAutoplay
+    : !!maybeAutoplay;
 
   const updateHasPlayed = () => {
     // hasPlayed
@@ -90,7 +103,7 @@ export const setupAutoplay = (
 
   const updateAutoplay: UpdateAutoplay = (newAutoplay) => {
     if (!hasPlayed) {
-      autoplay = newAutoplay;
+      autoplay = isAutoplayValue(newAutoplay) ? newAutoplay : !!newAutoplay;
       handleAutoplay(mediaEl, autoplay);
     }
   };

--- a/packages/playback-core/src/autoplay.ts
+++ b/packages/playback-core/src/autoplay.ts
@@ -1,0 +1,52 @@
+export type ValueOf<T> = T[keyof T];
+
+// TODO add INVIEW_MUTED, INVIEW_ANY
+export type AutoplayTypes = {
+  ANY: "any";
+  MUTED: "muted";
+};
+
+export const AutoplayTypes: AutoplayTypes = {
+  ANY: "any",
+  MUTED: "muted",
+};
+
+// export const setupAutoplay = (mediaEl: HTMLMediaElement) => {
+//   const hasPlayed = false;
+//
+//   return (newAutoplay) => {
+//   };
+// };
+
+export const handleAutoplay = (
+  mediaEl: HTMLMediaElement,
+  autoplay: boolean | ValueOf<AutoplayTypes> | undefined
+) => {
+  const oldMuted = mediaEl.muted;
+  const restoreMuted = () => (mediaEl.muted = oldMuted);
+  switch (autoplay) {
+    // ANY:
+    // try to play with current options
+    // if it fails, mute and try playing again
+    // if that fails, restore muted state and don't try playing again
+    case AutoplayTypes.ANY:
+      mediaEl.play().catch((error: Error) => {
+        mediaEl.muted = true;
+        mediaEl.play().catch(restoreMuted);
+      });
+      break;
+    // MUTED:
+    // mute the player and then try playing
+    // if that fails, restore muted state
+    case AutoplayTypes.MUTED:
+      mediaEl.muted = true;
+      mediaEl.play().catch(restoreMuted);
+
+      break;
+    // Default or if autoplay is a boolean attribute:
+    // Try playing the video and catch the failed autoplay warning
+    default:
+      mediaEl.play().catch(() => {});
+      break;
+  }
+};

--- a/packages/playback-core/src/autoplay.ts
+++ b/packages/playback-core/src/autoplay.ts
@@ -21,7 +21,7 @@ export type UpdateAutoplay = (newAutoplay: Maybe<string | boolean>) => void;
 const AutoplayTypeValues = Object.values(AutoplayTypes);
 export const isAutoplayValue = (value: unknown): value is Autoplay => {
   return (
-    typeof value == "boolean" ||
+    typeof value === "boolean" ||
     (typeof value === "string" &&
       AutoplayTypeValues.includes(value as ValueOf<AutoplayTypes>))
   );

--- a/packages/playback-core/src/autoplay.ts
+++ b/packages/playback-core/src/autoplay.ts
@@ -1,5 +1,7 @@
 import Hls from "hls.js";
 
+type PlaybackEngine = Hls;
+
 // TODO add INVIEW_MUTED, INVIEW_ANY
 export type AutoplayTypes = {
   ANY: "any";
@@ -12,12 +14,13 @@ export const AutoplayTypes: AutoplayTypes = {
 };
 
 type ValueOf<T> = T[keyof T];
-type Autoplay = boolean | ValueOf<AutoplayTypes> | undefined;
+export type Autoplay = boolean | ValueOf<AutoplayTypes> | undefined;
+export type UpdateAutoplay = (newAutoplay: Autoplay) => void;
 
 export const setupAutoplay = (
   mediaEl: HTMLMediaElement,
   autoplay: Autoplay,
-  hls
+  hls: PlaybackEngine | undefined
 ) => {
   let hasPlayed = false;
   let isLive = false;
@@ -85,12 +88,14 @@ export const setupAutoplay = (
     );
   }
 
-  return (newAutoplay) => {
+  const updateAutoplay: UpdateAutoplay = (newAutoplay) => {
     if (!hasPlayed) {
       autoplay = newAutoplay;
       handleAutoplay(mediaEl, autoplay);
     }
   };
+
+  return updateAutoplay;
 };
 
 export const handleAutoplay = (

--- a/packages/playback-core/src/autoplay.ts
+++ b/packages/playback-core/src/autoplay.ts
@@ -45,6 +45,18 @@ export const setupAutoplay = (
     { once: true }
   );
 
+  mediaEl.addEventListener(
+    "loadedmetadata",
+    () => {
+      // only update isLive here if we're using native playback
+      if (!hls) {
+        isLive = !Number.isFinite(mediaEl.duration);
+      }
+      handleAutoplay(mediaEl, autoplay);
+    },
+    { once: true }
+  );
+
   if (hls) {
     hls.once(Hls.Events.LEVEL_LOADED, (e: any, data: any) => {
       isLive = data.details.live ?? false;
@@ -58,20 +70,16 @@ export const setupAutoplay = (
     mediaEl.addEventListener(
       "play",
       () => {
+        // don't seek if we're not live
+        if (!isLive) {
+          return;
+        }
         // seek to either hls.js's liveSyncPosition or the native seekable end
         if (hls?.liveSyncPosition) {
           mediaEl.currentTime = hls.liveSyncPosition;
         } else {
           mediaEl.currentTime = mediaEl.seekable.end(0);
         }
-      },
-      { once: true }
-    );
-  } else if (autoplay) {
-    mediaEl.addEventListener(
-      "loadedmetadata",
-      () => {
-        handleAutoplay(mediaEl, autoplay);
       },
       { once: true }
     );

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -3,13 +3,14 @@ import mux, { Options } from "mux-embed";
 import Hls, { HlsConfig } from "hls.js";
 import { AutoplayTypes, setupAutoplay } from "./autoplay";
 import { isKeyOf } from "./util";
-export type ValueOf<T> = T[keyof T];
+import type { Autoplay, UpdateAutoplay } from "./autoplay";
 
+export type ValueOf<T> = T[keyof T];
 export type Metadata = Partial<Options["data"]>;
 export type PlaybackEngine = Hls;
 export { mux };
 export { Hls };
-export { setupAutoplay };
+export { Autoplay, UpdateAutoplay, setupAutoplay };
 
 export type StreamTypes = {
   VOD: "on-demand";

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -77,6 +77,7 @@ export type MuxMediaPropTypes = {
     | `${Uppercase<keyof MimeTypeShorthandMap>}`;
   streamType: ValueOf<StreamTypes>;
   startTime: HlsConfig["startPosition"];
+  autoPlay: boolean | ValueOf<AutoplayTypes>;
   autoplay: boolean | ValueOf<AutoplayTypes>;
 };
 
@@ -273,7 +274,13 @@ export const loadMedia = (
   props: Partial<
     Pick<
       MuxMediaProps,
-      "preferMse" | "src" | "type" | "startTime" | "streamType" | "autoplay"
+      | "preferMse"
+      | "src"
+      | "type"
+      | "startTime"
+      | "streamType"
+      | "autoplay"
+      | "autoPlay"
     >
   >,
   mediaEl?: HTMLMediaElement | null,

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -1,7 +1,7 @@
 import mux, { Options } from "mux-embed";
 
 import Hls, { HlsConfig } from "hls.js";
-import { AutoplayTypes, handleAutoplay } from "./autoplay";
+import { AutoplayTypes, setupAutoplay } from "./autoplay";
 import { isKeyOf } from "./util";
 export type ValueOf<T> = T[keyof T];
 
@@ -9,6 +9,7 @@ export type Metadata = Partial<Options["data"]>;
 export type PlaybackEngine = Hls;
 export { mux };
 export { Hls };
+export { setupAutoplay };
 
 export type StreamTypes = {
   VOD: "on-demand";
@@ -373,31 +374,6 @@ export const loadMedia = (
     // This ensures that we re-load them after it's done that.
     hls.on(Hls.Events.MANIFEST_LOADED, forceHiddenThumbnails);
     hls.on(Hls.Events.MEDIA_ATTACHED, forceHiddenThumbnails);
-
-    // When we are not auto-playing, we should seek to the live sync position
-    // This will seek first play event of *any* live video including event-type,
-    // which probably shouldn't seek
-    if (!props.autoplay) {
-      hls.once(Hls.Events.LEVEL_LOADED, (e: any, data: any) => {
-        const isLive: boolean = data.details.live;
-
-        if (isLive) {
-          mediaEl.addEventListener(
-            "play",
-            () => {
-              if (hls?.liveSyncPosition) {
-                mediaEl.currentTime = hls.liveSyncPosition;
-              }
-            },
-            { once: true }
-          );
-        }
-      });
-    } else if (props.autoplay) {
-      hls.once(Hls.Events.MANIFEST_PARSED, () => {
-        handleAutoplay(mediaEl, props.autoplay);
-      });
-    }
 
     hls.loadSource(src);
     hls.attachMedia(mediaEl);

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -77,7 +77,7 @@ export type MuxMediaPropTypes = {
     | `${Uppercase<keyof MimeTypeShorthandMap>}`;
   streamType: ValueOf<StreamTypes>;
   startTime: HlsConfig["startPosition"];
-  autoplay: ValueOf<AutoplayTypes>;
+  autoplay: boolean | ValueOf<AutoplayTypes>;
 };
 
 declare global {
@@ -402,7 +402,7 @@ export const loadMedia = (
           );
         }
       });
-    } else {
+    } else if (props.autoplay) {
       hls.once(Hls.Events.MANIFEST_PARSED, () => {
         const oldMuted = mediaEl.muted;
         const restoreMuted = () => (mediaEl.muted = oldMuted);
@@ -427,7 +427,6 @@ export const loadMedia = (
             break;
           // Default or if autoplay is a boolean attribute:
           // Try playing the video and catch the failed autoplay warning
-          case true:
           default:
             mediaEl.play().catch(() => {});
             break;

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -274,13 +274,7 @@ export const loadMedia = (
   props: Partial<
     Pick<
       MuxMediaProps,
-      | "preferMse"
-      | "src"
-      | "type"
-      | "startTime"
-      | "streamType"
-      | "autoplay"
-      | "autoPlay"
+      "preferMse" | "src" | "type" | "startTime" | "streamType" | "autoplay"
     >
   >,
   mediaEl?: HTMLMediaElement | null,


### PR DESCRIPTION
This change adds a couple of string options for the `autoplay` attribute/`autoPlay` prop. The exiting boolean-attribute nature of `autoplay`/`autoPlay` lives on.
Specifically:
- `muted` - will mute the player and try autoplaying. If autoplaying fails, muted state is restored and player continues as a standard click-to-play player.
- `any` - will try playing with the current options, if it fails it'll behave like `muted` above.
  Happy to get alternatives to the name `any`.

In addition to the above, this switches from relying on native autoplay attribute behavior to calling `play` manually. In terms of behavior, it should be backwards compatible, but will allow us to better control this behavior going forward.

Example usage:
WC
```html
<!-- no autoplay -->
<mux-player ></mux-player>
<!-- autoplay muted, likely to work -->
<mux-player autoplay="muted"></mux-player>
<!-- autoplay with sound, likely to fail -->
<mux-player autoplay></mux-player>
```
React:
```jsx
// autoplay with sound, if possible, then muted if possible
<MuxPlayer autoPlay="any" />
```
