### PR TITLE
Time Display: show the ascending time instead of negative time remaining

### DIFF
--- a/examples/vanilla-ts-esm/package.json
+++ b/examples/vanilla-ts-esm/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@mux-elements/mux-audio": "^0.2.0",
-    "@mux-elements/mux-player": "^0.1.0-alpha.3",
+    "@mux-elements/mux-player": "^0.1.0-alpha.7",
     "@mux-elements/mux-video": "^0.2.0"
   }
 }

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -1,6 +1,5 @@
 import "media-chrome";
 import "@mux-elements/mux-video";
-import MxpDialog from "./dialog";
 import VideoApiElement from "./video-api";
 import {
   getCcSubTracks,

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -1,4 +1,5 @@
 import "./dialog";
+import "./time-display";
 import {
   getChromeStylesFromProps,
   getSrcFromPlaybackId,
@@ -206,7 +207,7 @@ export const VodChromeSmall = (props: MuxTemplateProps) => html`
   </div>
   <media-control-bar>
     <media-time-range></media-time-range>
-    <media-time-display show-duration></media-time-display>
+    <mpx-time-display></mpx-time-display>
     ${MediaMuteButton()}
     ${props.supportsVolume && html`<media-volume-range></media-volume-range>`}
     <media-playback-rate-button></media-playback-rate-button>
@@ -224,7 +225,7 @@ export const VodChromeLarge = (props: MuxTemplateProps) => html`
     ${MediaSeekBackwardButton(props)}
     ${MediaSeekForwardButton(props)}
     <media-time-range></media-time-range>
-    <media-time-display show-duration></media-time-display>
+    <mxp-time-display></mxp-time-display>
     ${MediaMuteButton()}
     ${props.supportsVolume && html`<media-volume-range></media-volume-range>`}
     <media-playback-rate-button></media-playback-rate-button>

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -207,7 +207,7 @@ export const VodChromeSmall = (props: MuxTemplateProps) => html`
   </div>
   <media-control-bar>
     <media-time-range></media-time-range>
-    <mpx-time-display></mpx-time-display>
+    <mxp-time-display></mxp-time-display>
     ${MediaMuteButton()}
     ${props.supportsVolume && html`<media-volume-range></media-volume-range>`}
     <media-playback-rate-button></media-playback-rate-button>

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -206,7 +206,7 @@ export const VodChromeSmall = (props: MuxTemplateProps) => html`
   </div>
   <media-control-bar>
     <media-time-range></media-time-range>
-    <media-time-display show-duration remaining></media-time-display>
+    <media-time-display show-duration></media-time-display>
     ${MediaMuteButton()}
     ${props.supportsVolume && html`<media-volume-range></media-volume-range>`}
     <media-playback-rate-button></media-playback-rate-button>
@@ -224,7 +224,7 @@ export const VodChromeLarge = (props: MuxTemplateProps) => html`
     ${MediaSeekBackwardButton(props)}
     ${MediaSeekForwardButton(props)}
     <media-time-range></media-time-range>
-    <media-time-display show-duration remaining></media-time-display>
+    <media-time-display show-duration></media-time-display>
     ${MediaMuteButton()}
     ${props.supportsVolume && html`<media-volume-range></media-volume-range>`}
     <media-playback-rate-button></media-playback-rate-button>

--- a/packages/mux-player/src/time-display.ts
+++ b/packages/mux-player/src/time-display.ts
@@ -1,0 +1,69 @@
+const styles = `
+  :host {
+    cursor: pointer;
+  }
+`;
+
+const template = document.createElement("template");
+template.innerHTML = `
+  <style>
+    ${styles}
+  </style>
+  <media-time-display show-duration></media-time-display>
+`;
+
+const ButtonPressedKeys = ["Enter", " "];
+
+class MediaTimeDisplayToggle extends HTMLElement {
+  static styles: string = styles;
+  static template: HTMLTemplateElement = template;
+  timeDisplayEl: HTMLElement | null | undefined;
+
+  constructor() {
+    super();
+
+    this.attachShadow({ mode: "open" });
+    this.shadowRoot?.appendChild(
+      (this.constructor as any).template.content.cloneNode(true)
+    );
+    this.timeDisplayEl = this.shadowRoot?.querySelector("media-time-display");
+  }
+
+  toggleTimeDisplay() {
+    if (this.timeDisplayEl?.hasAttribute("remaining")) {
+      this.timeDisplayEl?.removeAttribute("remaining");
+    } else {
+      this.timeDisplayEl?.setAttribute("remaining", "");
+    }
+  }
+
+  connectedCallback() {
+    const keyUpHandler = (e: KeyboardEvent) => {
+      const { key } = e;
+      if (!ButtonPressedKeys.includes(key)) {
+        this.removeEventListener("keyup", keyUpHandler);
+        return;
+      }
+
+      this.toggleTimeDisplay();
+    };
+
+    this.addEventListener("keydown", (e) => {
+      const { metaKey, altKey, key } = e;
+      if (metaKey || altKey || !ButtonPressedKeys.includes(key)) {
+        this.removeEventListener("keyup", keyUpHandler);
+        return;
+      }
+      this.addEventListener("keyup", keyUpHandler);
+    });
+
+    this.addEventListener("click", this.toggleTimeDisplay);
+  }
+}
+
+if (!globalThis.customElements.get("mxp-time-display")) {
+  globalThis.customElements.define("mxp-time-display", MediaTimeDisplayToggle);
+  (globalThis as any).MediaTimeDisplayToggle = MediaTimeDisplayToggle;
+}
+
+export default MediaTimeDisplayToggle;

--- a/packages/mux-player/src/time-display.ts
+++ b/packages/mux-player/src/time-display.ts
@@ -14,7 +14,7 @@ template.innerHTML = `
 
 const ButtonPressedKeys = ["Enter", " "];
 
-class MediaTimeDisplayToggle extends HTMLElement {
+class MxpTimeDisplay extends HTMLElement {
   static styles: string = styles;
   static template: HTMLTemplateElement = template;
   timeDisplayEl: HTMLElement | null | undefined;
@@ -62,8 +62,8 @@ class MediaTimeDisplayToggle extends HTMLElement {
 }
 
 if (!globalThis.customElements.get("mxp-time-display")) {
-  globalThis.customElements.define("mxp-time-display", MediaTimeDisplayToggle);
-  (globalThis as any).MediaTimeDisplayToggle = MediaTimeDisplayToggle;
+  globalThis.customElements.define("mxp-time-display", MxpTimeDisplay);
+  (globalThis as any).MxpTimeDisplay = MxpTimeDisplay;
 }
 
-export default MediaTimeDisplayToggle;
+export default MxpTimeDisplay;


### PR DESCRIPTION
This seems like a much more intuitive way to show time in the `<media-time-display>`. This feels like a better default. Maybe in the future we allow this to be configurable.

We don't show time display on live, so this should only impact VOD (and all my screenshots in the docs 😭 )

Thoughts?

# Before

![time-remaining_2022-03-07_12-37-41](https://user-images.githubusercontent.com/764988/157114035-b4bb6675-899c-4ed7-842b-be5b9efac675.png)

# After

![no-tr_2022-03-07_12-35-55](https://user-images.githubusercontent.com/764988/157114070-4c1ec984-5060-44ca-9f9e-9c41999e0f7a.png)

