### PR TITLE
Fix/thumbnails after playback id changed

### DIFF
--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -359,7 +359,9 @@ describe("<mux-player>", () => {
     ></mux-player>`);
 
     const muxVideo = player.video;
-    const storyboardTrack = muxVideo.querySelector("track[label='thumbnails']");
+    const storyboardTrack = muxVideo.shadowRoot.querySelector(
+      "track[label='thumbnails']"
+    );
 
     assert.equal(
       muxVideo.getAttribute("src"),

--- a/packages/mux-video/src/CustomVideoElement.js
+++ b/packages/mux-video/src/CustomVideoElement.js
@@ -35,6 +35,7 @@ template.innerHTML = `
 </style>
 
 <video crossorigin></video>
+<slot></slot>
 `;
 
 class CustomVideoElement extends HTMLElement {
@@ -60,28 +61,12 @@ class CustomVideoElement extends HTMLElement {
       nativeEl.muted = true;
     }
 
-    this.querySelectorAll(":scope > track").forEach((track) => {
-      this.nativeEl.appendChild(track.cloneNode());
+    const slotEl = this.shadowRoot.querySelector("slot");
+    slotEl.addEventListener("slotchange", () => {
+      slotEl.assignedElements().forEach((el) => {
+        nativeEl.appendChild(el);
+      });
     });
-
-    // Watch for child adds/removes and update the native element if necessary
-    const mutationCallback = (mutationsList, observer) => {
-      for (let mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          // Child being removed
-          mutation.removedNodes.forEach((node) => {
-            this.nativeEl.querySelector(`track[src="${node.src}"]`)?.remove();
-          });
-
-          mutation.addedNodes.forEach((node) => {
-            this.nativeEl.appendChild(node.cloneNode());
-          });
-        }
-      }
-    };
-
-    const observer = new MutationObserver(mutationCallback);
-    observer.observe(this, { childList: true, subtree: true });
   }
 
   // observedAttributes is required to trigger attributeChangedCallback

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -386,8 +386,8 @@ export const loadMedia = (
 
     // hls.js will forcibly clear all cues from tracks on manifest loads or media attaches.
     // This ensures that we re-load them after it's done that.
-    hls.on(Hls.Events.MANIFEST_LOADED, forceHiddenThumbnails);
-    hls.on(Hls.Events.MEDIA_ATTACHED, forceHiddenThumbnails);
+    hls.once(Hls.Events.MANIFEST_LOADED, forceHiddenThumbnails);
+    hls.once(Hls.Events.MEDIA_ATTACHED, forceHiddenThumbnails);
 
     hls.loadSource(src);
     hls.attachMedia(mediaEl);


### PR DESCRIPTION
NOTE: This PR is intended to resolve an issue exposed in `mux-player`. It should be fully backwards compatible with the current implementation and should also resolve the issue of updating `track` src. There should be a followup PR to also handle more complex cases of adds and removes of descendants over time.

Additionally, this updates `CustomAudioElement` for greater parity between it and `CustomVideoElement` on the assumption that we'll want to eventually try to unify these two.