### PR TITLE
Add publish & release GH action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Publish
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          lerna publish from-package --yes --no-private --conventional-commits --create-release github
+          yarn release --yes --conventional-commits --create-release github
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v2
       # extract `engines.node` from package.json and save it to output

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Publish
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          yarn release --yes --conventional-commits --conventional-prerelease=@mux-elements/mux-player,@mux-elements/mux-player-react --create-release github
+          yarn deploy --yes --create-release github
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,47 @@
+name: Deployment
+
+concurrency: production
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      # extract `engines.node` from package.json and save it to output
+      - name: Get Node.JS version from package.json
+        id: get-versions
+        run: echo ::set-output name=node::$(jq -r .engines.node ./package.json)
+      - name: Use Node.js ${{ steps.get-versions.outputs.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.get-versions.outputs.node }}
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: yarn test
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # extract `engines.node` from package.json and save it to output
+      - name: Get Node.JS version from package.json
+        id: get-versions
+        run: echo ::set-output name=node::$(jq -r .engines.node ./package.json)
+      - name: Use Node.js ${{ steps.get-versions.outputs.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.get-versions.outputs.node }}
+      - name: Publish
+        run: |
+          npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
+          lerna publish from-package --yes --no-private --conventional-commits --create-release github
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Publish
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-          yarn release --yes --conventional-commits --create-release github
+          yarn release --yes --conventional-commits --conventional-prerelease=@mux-elements/mux-player,@mux-elements/mux-player-react --create-release github
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/README_INTERNAL.md
+++ b/README_INTERNAL.md
@@ -16,4 +16,9 @@ Examples:
 # Releasing
 
 This repo uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-and Github Actions for continuously publishing and releasing Mux elements.
+and Github Actions for continuously publishing Mux elements.
+
+1. From the workspace root directory, run `yarn version:update`.
+   This will bump the version of the packages changed since the last release and push those changes to Github.
+   You might have to manually correct the version if the suggestion of Conventional Commits is not right.
+2. The cd.yml Github action will publish the new versions to NPM.

--- a/README_INTERNAL.md
+++ b/README_INTERNAL.md
@@ -15,6 +15,5 @@ Examples:
 
 # Releasing
 
-1. From the workspace root directory, run `yarn release`
-2. `git push && git push origin --tags`
-3. Create a [new release in GitHub](https://github.com/muxinc/elements/releases) and write a description
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+and Github Actions for continuously publishing and releasing Mux elements.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build:packages": "lerna run build --scope @mux-elements/*",
     "build": "lerna run build",
     "prepare": "husky install && yarn build:packages",
-    "release": "lerna publish from-package --no-private",
-    "version:update": "lerna version --no-private"
+    "deploy": "lerna publish from-package --no-private",
+    "version:update": "lerna version --no-private --conventional-commits --conventional-prerelease=@mux-elements/mux-player,@mux-elements/mux-player-react"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build:packages": "lerna run build --scope @mux-elements/*",
     "build": "lerna run build",
     "prepare": "husky install && yarn build:packages",
-    "release": "lerna publish --no-private",
+    "release": "lerna publish from-package --no-private",
     "version:update": "lerna version --no-private"
   }
 }


### PR DESCRIPTION
This change adds a publish job after the CI build job that automatically publishes the public packages if the version in package.json was bumped in the package. It checks against the version in the registry. 

`from-package`: https://github.com/lerna/lerna/tree/main/commands/publish#usage
`--yes`: https://github.com/lerna/lerna/tree/main/commands/publish#--yes

Adds Github Release via 
https://github.com/lerna/lerna/tree/main/commands/version#--conventional-commits
https://github.com/lerna/lerna/tree/main/commands/version#--create-release-type

Process:

```
#. Human - checkout main and make sure local main head is up to date w/upstream main
#. Human - version locally via yarn version - should use conventional commit to update versions (will tag and push commit + tags)
#. Robot - GitHub action on main will detect version bump, and then…
	#. Build, lint, test, run all vercel deploys, prepare npm release, prepare draft GitHub release
#. Human - Final approval for release
```