### PR TITLE
Run GH action jobs in parallel, add yarn cache, add lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: ${{ steps.get-versions.outputs.node }}
           cache: yarn
       - run: yarn install --frozen-lockfile --ignore-scripts
-      - run: yarn build
+      - run: yarn build --scope @mux-elements/*
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.get-versions.outputs.node }}
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn build
       - run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.get-versions.outputs.node }}
+          cache: yarn
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn build
 
@@ -32,6 +33,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.get-versions.outputs.node }}
+          cache: yarn
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn lint
 
@@ -48,6 +50,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.get-versions.outputs.node }}
+          cache: yarn
       # esbuild requires --ignore-scripts to NOT be added here.
       - run: yarn install --frozen-lockfile
       - run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,22 @@ jobs:
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn build
 
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      # extract `engines.node` from package.json and save it to output
+      - name: Get Node.JS version from package.json
+        id: get-versions
+        run: echo ::set-output name=node::$(jq -r .engines.node ./package.json)
+      - name: Use Node.js ${{ steps.get-versions.outputs.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.get-versions.outputs.node }}
+      - run: yarn install --frozen-lockfile --ignore-scripts
+      - run: yarn lint
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,19 @@ jobs:
           node-version: ${{ steps.get-versions.outputs.node }}
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn build
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      # extract `engines.node` from package.json and save it to output
+      - name: Get Node.JS version from package.json
+        id: get-versions
+        run: echo ::set-output name=node::$(jq -r .engines.node ./package.json)
+      - name: Use Node.js ${{ steps.get-versions.outputs.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.get-versions.outputs.node }}
+      - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.get-versions.outputs.node }}
-      - run: yarn install --frozen-lockfile --ignore-scripts
+      # esbuild requires --ignore-scripts to NOT be added here.
+      - run: yarn install --frozen-lockfile
       - run: yarn test

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "shared/*"
   ],
   "scripts": {
+    "lint": "lerna run lint --scope @mux-elements/*",
     "test": "lerna run test --scope @mux-elements/*",
     "dev": "lerna run dev --parallel --scope @mux-elements/*",
     "build": "lerna run build",


### PR DESCRIPTION
- Adds `--ignore-scripts` because we don't want an automatic build to happen right after yarn install
- Adds a lint job 
- Separates `build` and `test` so they can run in parallel
- Adds `cache: yarn` 
  https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies