### PR TITLE
fix: make set autoplay prop same than all str prop

### DIFF
--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -250,15 +250,7 @@ class VideoApiElement extends HTMLElement {
   }
 
   set autoplay(val) {
-    if (val) {
-      this.setAttribute(
-        AllowedVideoAttributes.AUTOPLAY,
-        typeof val === "string" ? val : ""
-      );
-    } else {
-      // Remove boolean attribute if false, 0, '', null, undefined.
-      this.removeAttribute(AllowedVideoAttributes.AUTOPLAY);
-    }
+    this.setAttribute(AllowedVideoAttributes.AUTOPLAY, `${val}`);
   }
 
   get loop() {


### PR DESCRIPTION
Just a tiny PR to test out the auto releasing.

Currently the behavior for the mux-player properties was that it casts them to strings no matter what the value is.
No removal of attributes based on nullish value, see https://github.com/muxinc/elements/issues/66

This change makes it the same than the other props like crossOrigin
https://github.com/muxinc/elements/blob/ef1f004f4a5b736837e78af682be75b3824806e3/packages/mux-player/src/video-api.ts#L244-L246