### PR TITLE
Fix/mux embed player time

### DIFF
--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -11,6 +11,7 @@ import {
   StreamTypes,
   toMuxVideoURL,
   PlaybackEngine,
+  generatePlayerInitTime,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
 
@@ -43,7 +44,7 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
       ...restProps
     } = props;
 
-    const [playerInitTime] = useState(Date.now());
+    const [playerInitTime] = useState(generatePlayerInitTime());
 
     const [src, setSrc] = useState<MuxMediaProps["src"]>(
       toMuxVideoURL(playbackId) ?? outerSrc

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -13,6 +13,7 @@ import {
   Metadata,
   mux,
   type UpdateAutoplay,
+  generatePlayerInitTime,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
 
@@ -71,7 +72,7 @@ class MuxAudioElement
 
   constructor() {
     super();
-    this.__playerInitTime = Date.now();
+    this.__playerInitTime = generatePlayerInitTime();
   }
 
   get playerInitTime() {

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -9,6 +9,7 @@ import {
   StreamTypes,
   toMuxVideoURL,
   PlaybackEngine,
+  generatePlayerInitTime,
 } from "@mux-elements/playback-core";
 import { getPlayerVersion } from "./env";
 
@@ -41,7 +42,7 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
       ...restProps
     } = props;
 
-    const [playerInitTime] = useState(Date.now());
+    const [playerInitTime] = useState(generatePlayerInitTime());
 
     const [src, setSrc] = useState<MuxMediaProps["src"]>(
       toMuxVideoURL(playbackId) ?? outerSrc

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -3,6 +3,7 @@ import CustomVideoElement from "./CustomVideoElement";
 import {
   initialize,
   setupAutoplay,
+  generatePlayerInitTime,
   MuxMediaProps,
   StreamTypes,
   ValueOf,
@@ -78,7 +79,7 @@ class MuxVideoElement
 
   constructor() {
     super();
-    this.__playerInitTime = Date.now();
+    this.__playerInitTime = generatePlayerInitTime();
   }
 
   get playerInitTime() {

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -13,6 +13,10 @@ export { mux };
 export { Hls };
 export { Autoplay, UpdateAutoplay, setupAutoplay };
 
+export const generatePlayerInitTime = () => {
+  return mux.utils.now();
+};
+
 export type StreamTypes = {
   VOD: "on-demand";
   LIVE: "live";

--- a/types/mux-embed.d.ts
+++ b/types/mux-embed.d.ts
@@ -87,4 +87,8 @@ declare module "mux-embed" {
   export function destroy(): void;
 
   export const deleted: boolean;
+
+  export const utils: {
+    now: () => number;
+  };
 }


### PR DESCRIPTION
Per a recent conversation with the data folks, it's preferred to use mux-embed's built in `utils.now()` instead of `Date.now()`. This PR/refactor does that.