### PR TITLE
feat: move captions up when controls are showing

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -54,6 +54,12 @@ function MuxPlayerPage() {
       <h1>MuxPlayer Demo</h1>
       <div>
         <MuxPlayer
+          style={{
+            // set the max height of the player to be the viewport height
+            // minus the block height of the h1 so that the player
+            // will never go out of view
+            maxHeight: "calc(100vh - 6em)"
+          }}
           ref={mediaElRef}
           // style={{ aspectRatio: "16 / 9" }}
           // envKey={envKey}

--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@github/template-parts": "https://github.com/muxinc/template-parts.git#mux-player",
     "@mux-elements/mux-video": "^0.3.0",
-    "media-chrome": "0.5.3"
+    "media-chrome": "0.5.4"
   },
   "devDependencies": {
     "@mux-elements/open-process": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11414,10 +11414,10 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-media-chrome@0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-0.5.3.tgz#da09338e63e390653164561832d18ccba3c13815"
-  integrity sha512-kpMQe90B/9xrZIDtV2lEe9DZXH0RB9CyZeS5dneXbq/HUh3ixaDy3JQsogOoglngBwVL1bmCB+Haev7w0aTXqg==
+media-chrome@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-0.5.4.tgz#9f88eb71a323a4318a00978893dae9cadb9a8ded"
+  integrity sha512-0ujg8fwbXVgJUXykiBUU8tdg5S2eIuFXRcfQSh/ULj+iOakhsDJq0cETbJVkz31FOZGSbbhzAsGFx1Zqkr/z6w==
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Controls are currently defined as showing when the user is active or the player is paused.

This is more or less the MVP for this, as it only covers moving the bottom captions out of the way of the bottom controls.
The full thing would also probably need to handle the top controls as well as the middle controls.
I am also ignoring some cues depending on how they are positioned, as they are likely not going to be obscured by the bottom controls or thumbnails.