### PR TITLE
fix: initial muted autoplay should autoplay muted

### DIFF
--- a/packages/mux-video/src/CustomVideoElement.d.ts
+++ b/packages/mux-video/src/CustomVideoElement.d.ts
@@ -1,9 +1,11 @@
 /** @TODO Add type defs to custom-video-element directly */
-export default class CustomVideoElement<V extends HTMLVideoElement = HTMLVideoElement>
+export default class CustomVideoElement<
+    V extends Omit<HTMLVideoElement, 'autoplay'> = Omit<HTMLVideoElement, 'autoplay'>
+  >
   // NOTE: "lying" here since we programmatically merge props/methods from HTMLVideoElement into the CustomVideoElement's prototype in an attempt to make it "look like"
   // it extends an HTMLVideoElement.
-  extends HTMLVideoElement
-  implements HTMLVideoElement
+  extends Omit<HTMLVideoElement, 'autoplay'>
+  implements Omit<HTMLVideoElement, 'autoplay'>
 {
   static readonly observedAttributes: Array<string>;
   readonly nativeEl: V;

--- a/packages/mux-video/src/CustomVideoElement.d.ts
+++ b/packages/mux-video/src/CustomVideoElement.d.ts
@@ -1,13 +1,13 @@
 /** @TODO Add type defs to custom-video-element directly */
-export default class CustomVideoElement<
-    V extends Omit<HTMLVideoElement, 'autoplay'> = Omit<HTMLVideoElement, 'autoplay'>
-  >
+export default class CustomVideoElement<V extends HTMLVideoElement = HTMLVideoElement>
   // NOTE: "lying" here since we programmatically merge props/methods from HTMLVideoElement into the CustomVideoElement's prototype in an attempt to make it "look like"
   // it extends an HTMLVideoElement.
-  extends Omit<HTMLVideoElement, 'autoplay'>
-  implements Omit<HTMLVideoElement, 'autoplay'>
+  extends HTMLVideoElement
+  implements HTMLVideoElement
 {
   static readonly observedAttributes: Array<string>;
   readonly nativeEl: V;
   attributeChangedCallback(attrName: string, oldValue?: string | null, newValue?: string | null): void;
+  get autoplay(): string | boolean;
+  set autoplay(): string | boolean;
 }

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -329,7 +329,7 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
         break;
       case 'autoplay':
         if (newValue === oldValue) {
-          return;
+          break;
         }
         this.__updateAutoplay?.(newValue);
         break;

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -136,6 +136,26 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
     }
   }
 
+  get autoplay(): string | boolean {
+    const attr = this.getAttribute('autoplay');
+
+    if (attr === null) {
+      return false;
+    } else if (attr === '') {
+      return true;
+    } else {
+      return attr;
+    }
+  }
+
+  set autoplay(val: string | boolean) {
+    if (val) {
+      this.setAttribute('autoplay', typeof val === 'string' ? val : '');
+    } else {
+      this.removeAttribute('autoplay');
+    }
+  }
+
   /** @TODO write a generic module for well defined primitive types -> attribute getter/setters/removers (CJP) */
   get debug(): boolean {
     return this.getAttribute(Attributes.DEBUG) != null;
@@ -308,6 +328,9 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
         }
         break;
       case 'autoplay':
+        if (newValue === oldValue) {
+          return;
+        }
         this.__updateAutoplay?.(newValue);
         break;
       case Attributes.PLAYBACK_ID:

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -56,9 +56,7 @@ const AttributeNameValues = Object.values(Attributes);
 const playerSoftwareVersion = getPlayerVersion();
 const playerSoftwareName = 'mux-video';
 
-type Props = Omit<HTMLVideoElement, 'autoplay'> & MuxMediaProps;
-
-class MuxVideoElement extends CustomVideoElement<Omit<HTMLVideoElement, 'autoplay'>> implements Partial<MuxMediaProps> {
+class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Partial<MuxMediaProps> {
   static get observedAttributes() {
     return [...AttributeNameValues, ...(CustomVideoElement.observedAttributes ?? [])];
   }

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -13,7 +13,7 @@ import {
   mux,
   MediaError,
 } from '@mux-elements/playback-core';
-import type { PlaybackEngine, UpdateAutoplay, ExtensionMimeTypeMap } from '@mux-elements/playback-core';
+import type { PlaybackEngine, Autoplay, UpdateAutoplay, ExtensionMimeTypeMap } from '@mux-elements/playback-core';
 import { getPlayerVersion } from './env';
 
 /** @TODO make the relationship between name+value smarter and more deriveable (CJP) */
@@ -136,7 +136,7 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
     }
   }
 
-  get autoplay(): string | boolean {
+  get autoplay(): Autoplay {
     const attr = this.getAttribute('autoplay');
 
     if (attr === null) {
@@ -144,11 +144,11 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
     } else if (attr === '') {
       return true;
     } else {
-      return attr;
+      return attr as Autoplay;
     }
   }
 
-  set autoplay(val: string | boolean) {
+  set autoplay(val: Autoplay) {
     if (val) {
       this.setAttribute('autoplay', typeof val === 'string' ? val : '');
     } else {

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -149,6 +149,11 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
   }
 
   set autoplay(val: Autoplay) {
+    const currentVal = this.autoplay;
+    if (val === currentVal) {
+      return;
+    }
+
     if (val) {
       this.setAttribute('autoplay', typeof val === 'string' ? val : '');
     } else {

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -56,7 +56,9 @@ const AttributeNameValues = Object.values(Attributes);
 const playerSoftwareVersion = getPlayerVersion();
 const playerSoftwareName = 'mux-video';
 
-class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Partial<MuxMediaProps> {
+type Props = Omit<HTMLVideoElement, 'autoplay'> & MuxMediaProps;
+
+class MuxVideoElement extends CustomVideoElement<Omit<HTMLVideoElement, 'autoplay'>> implements Partial<MuxMediaProps> {
   static get observedAttributes() {
     return [...AttributeNameValues, ...(CustomVideoElement.observedAttributes ?? [])];
   }

--- a/packages/mux-video/test/player.test.js
+++ b/packages/mux-video/test/player.test.js
@@ -20,4 +20,65 @@ describe('<mux-video>', () => {
     assert.equal(player.preferMse, true, 'prefer-mse is on');
     assert.equal(player.debug, true, 'debug is on');
   });
+
+  it('can use extended autoplay properties on initial load', async function () {
+    const player = await fixture(`<mux-video
+      autoplay="muted"
+    ></mux-video>`);
+
+    assert.equal(player.autoplay, 'muted', 'our autoplay setting is muted');
+  });
+
+  it('can use extended autoplay properties', async function () {
+    const player = await fixture(`<mux-video
+    ></mux-video>`);
+
+    assert.equal(player.autoplay, false, 'initial autoplay is false');
+
+    player.autoplay = 'muted';
+
+    assert.equal(player.autoplay, 'muted', 'can set autoplay to "muted"');
+    assert.equal(player.getAttribute('autoplay'), 'muted', 'the attribute is set to "muted"');
+
+    player.autoplay = 'any';
+
+    assert.equal(player.autoplay, 'any', 'can set autoplay to "any"');
+    assert.equal(player.getAttribute('autoplay'), 'any', 'the attribute is set to "muted"');
+
+    player.autoplay = false;
+
+    assert.isFalse(player.autoplay, 'can turn off autoplay');
+    assert.isFalse(player.hasAttribute('autoplay'), 'setting to false reomves the attribute');
+
+    player.autoplay = true;
+    assert.isTrue(player.autoplay, 'can turn off autoplay');
+    assert.equal(player.getAttribute('autoplay'), '', 'when prop is set to true, attribute value is an empty string');
+  });
+
+  it('can use extended autoplay attributes', async function () {
+    const player = await fixture(`<mux-video
+    ></mux-video>`);
+
+    assert.equal(player.autoplay, false, 'initial autoplay is false');
+
+    player.setAttribute('autoplay', 'muted');
+
+    assert.equal(player.autoplay, 'muted', 'can set autoplay to "muted"');
+    assert.equal(player.getAttribute('autoplay'), 'muted', 'the attribute is set to "muted"');
+
+    player.setAttribute('autoplay', 'any');
+
+    assert.equal(player.autoplay, 'any', 'can set autoplay to "any"');
+    assert.equal(player.getAttribute('autoplay'), 'any', 'the attribute is set to "muted"');
+
+    player.removeAttribute('autoplay');
+    player.autoplay = false;
+
+    assert.isFalse(player.autoplay, 'can turn off autoplay');
+    assert.isFalse(player.hasAttribute('autoplay'), 'setting to false reomves the attribute');
+
+    player.setAttribute('autoplay', '');
+    assert.isTrue(player.autoplay, 'can turn off autoplay');
+    assert.equal(player.getAttribute('autoplay'), '', 'when prop is set to true, attribute value is an empty string');
+  });
 });


### PR DESCRIPTION
https://github.com/muxinc/elements/pull/116 added extended autoplay support, but setting the initial attribute to one of the extended values didn't work. This fixes it so that the attribute can be set initially and not just changed after the fact.