### PR TITLE
ci: only try deploy on new tags

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,8 +4,8 @@ concurrency: production
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - '**' # Push events to every tag including hierarchical tags like v1.0/beta
 
 jobs:
   build:


### PR DESCRIPTION
Currently we're trying to deploy on every push to main, this will do it only on new tag pushes