### PR TITLE
build(build-when-needed): Update scripts to not redundantly build.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,8 +24,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: yarn install --frozen-lockfile
-      - name: Build packages
-        run: yarn build:packages
       - name: Test
         run: yarn test
       - name: Publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: ${{ steps.get-versions.outputs.node }}
           cache: yarn
       - run: yarn install --frozen-lockfile
-      - run: yarn build --scope @mux-elements/*
+      - run: yarn build:packages
 
   lint:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
     "clean": "lerna run clean --parallel --scope @mux-elements/*",
     "format": "prettier --write .",
     "lint": "lerna run lint --scope @mux-elements/*",
+    "pretest": "yarn build:packages",
     "test": "lerna run test --scope @mux-elements/*",
     "i18n": "lerna run i18n --scope @mux-elements/*",
     "dev": "lerna run dev --parallel --scope @mux-elements/*",
     "predev": "yarn build:packages",
     "build:packages": "lerna run build --scope @mux-elements/*",
     "build": "lerna run build",
-    "prepare": "husky install && yarn build:packages",
+    "prepare": "husky install",
     "deploy": "lerna publish from-package --no-private --no-verify-access --conventional-commits --conventional-prerelease=@mux-elements/mux-player,@mux-elements/mux-player-react",
     "version:update": "lerna version --no-private --conventional-commits --conventional-prerelease=@mux-elements/mux-player,@mux-elements/mux-player-react"
   }


### PR DESCRIPTION
- Removes build from workspace level `prepare`.
- Removes redundant/unnecessary builds from ci workflows
- Adds `build:packages` to workspace level `pretest` (Can discuss tradeoffs vs. per-package `pretest` vs. independent build in github action scripts)
- No longer `--ignore-scripts` on installs, as this is brittle and may have been working in some cases as a result of previous cached installs
  - `--ignore-scripts`: Do not execute any scripts defined in the project package.json **_and its dependencies_**. (From: https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-ignore-scripts)

After change approval but before merge, we will also need to change our vercel apps setup to `build:packages` on install.