### PR TITLE
Improv/redundant streams with mux player

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ For feature requests, you can start by reviewing and filling out a [Feature Requ
 
 Before submitting a pull request, make sure you've reviewed and filled out an appropriate [Issue](https://github.com/muxinc/elements/issues/new/choose). We recommend doing this before starting any work, just in case an issue already exists, or it's unlikely the maintainers will be able to review the PR because it e.g. lacks sufficient reproduction steps. In addition, we recommend the following:
 
-1. While we do not (_**yet!**_) use [semantic releases/commits](https://openbase.com/js/@semantic-release/commit-analyzer/documentation), please try to name your branch and prefix your commits according to the type of changes you're making, and try to be as descriptive as possible in your commit messages. For example:
+1. We use [semantic releases/commits](https://openbase.com/js/@semantic-release/commit-analyzer/documentation), please try to name your branch and prefix your commits according to the type of changes you're making, and try to be as descriptive as possible in your commit messages. For example:
 
 - For Bug Fixes: `fix/my-fix-for-foo`
 - For Features: `feat/mux-video-feat-bar`

--- a/packages/mux-player/src/helpers.ts
+++ b/packages/mux-player/src/helpers.ts
@@ -14,7 +14,19 @@ const player_version = getEnvPlayerVersion();
 export const getPlayerVersion = () => player_version;
 
 export const getSrcFromPlaybackId = (playbackId?: string, token?: string) => {
-  return `https://stream.mux.com/${playbackId}.m3u8${toQuery({ token })}`;
+  /*
+   * 2022-04-01 djhaveri
+   *
+   * `redundant_streams` query param can only be added to public
+   * playback IDs, in order to use this feature with signed URLs
+   * the query param must be added to the signing token.
+   *
+   * https://docs.mux.com/guides/video/play-your-videos#add-delivery-redundancy-with-redundant-streams
+   *
+   * */
+  const isSignedUrl = !!token;
+  const query = isSignedUrl ? { token } : { redundant_streams: true };
+  return `https://stream.mux.com/${playbackId}.m3u8${toQuery(query)}`;
 };
 
 export const getPosterURLFromPlaybackId = (playbackId?: string, token?: string) => {

--- a/packages/mux-player/test/helpers.test.js
+++ b/packages/mux-player/test/helpers.test.js
@@ -1,0 +1,12 @@
+import { assert } from '@open-wc/testing';
+import { getSrcFromPlaybackId } from '../src/helpers.ts';
+
+describe('helpers', () => {
+  it('getSrcFromPlaybackId with no token', function () {
+    assert.equal(getSrcFromPlaybackId('12345'), 'https://stream.mux.com/12345.m3u8?redundant_streams=true');
+  });
+
+  it('getSrcFromPlaybackId with a token', function () {
+    assert.equal(getSrcFromPlaybackId('12345', 't-1234'), 'https://stream.mux.com/12345.m3u8?token=t-1234');
+  });
+});


### PR DESCRIPTION
closes https://app.shortcut.com/mux/story/19953/use-redundant-streams-for-public-playback-ids