### PR TITLE
fix: devLog links to GH base URL

### DIFF
--- a/packages/mux-player/src/logger.ts
+++ b/packages/mux-player/src/logger.ts
@@ -16,7 +16,7 @@ export function error(...args: any[]) {
 export function devlog(opts: DevlogOptions) {
   let message = opts.message ?? '';
   if (opts.file) {
-    const githubErrorsBase = 'https://github.com/muxinc/elements/main/errors/';
+    const githubErrorsBase = 'https://github.com/muxinc/elements/blob/main/errors/';
     message += ` ${i18n`Read more: `}\n${githubErrorsBase}${opts.file}`;
   }
   warn(message);


### PR DESCRIPTION
Right now devLog links are 404:

```
https://github.com/muxinc/elements/main/errors/403-playback-id-mismatch.md
```

This corrects the path:

```
https://github.com/muxinc/elements/blob/main/errors/403-playback-id-mismatch.md
```