### PR TITLE
fix(mux-video): prevent forward custom attrs

### DIFF
--- a/packages/mux-video/src/CustomVideoElement.js
+++ b/packages/mux-video/src/CustomVideoElement.js
@@ -136,8 +136,9 @@ class CustomVideoElement extends HTMLElement {
         this.nativeEl.removeAttribute(attrName);
       } else {
         // Ignore a few that don't need to be passed through just in case
-        // it creates unexpected behavior.
-        if (['id', 'class'].indexOf(attrName) === -1) {
+        // it creates unexpected behavior. Exclude attributes with a dash
+        // which are most likely custom attributes.
+        if (!/^(id|class)$|-/.test(attrName)) {
           this.nativeEl.setAttribute(attrName, newValue);
         }
       }


### PR DESCRIPTION
This change prevents forwarding custom attributes to the native video element like player-software-name, env-key, etc...

![SCR-20220321-iff](https://user-images.githubusercontent.com/360826/161773579-64421bd6-4589-479e-ae08-010054701238.png)

