### PR TITLE
fix: primary color should be also used for the text color on controls

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -56,6 +56,7 @@
     <mux-player
       playback-id="g65IqSFtWdpGR100c2W8VUHrfIVWTNRen"
       env-key="5e67cqdt7hgc9vkla7p0qch7q"
+      primary-color="#f97316"
       metadata-video-id="video-id-54321"
       metadata-video-title="Star Wars: Episode 2"
       metadata-viewer-user-id="user-id-007"

--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -116,6 +116,10 @@ media-time-display {
   white-space: nowrap;
 }
 
+:is(media-time-display, media-text-display, media-playback-rate-button) {
+  color: inherit;
+}
+
 .mxp-seek-to-live-button {
   background-color: var(--media-control-background);
   color: white;

--- a/packages/mux-player/src/time-display.ts
+++ b/packages/mux-player/src/time-display.ts
@@ -2,6 +2,9 @@ const styles = `
   :host {
     cursor: pointer;
   }
+  media-time-display {
+    color: inherit;
+  }
 `;
 
 const template = document.createElement('template');


### PR DESCRIPTION
Fixes a bug where `primaryColor` is not being applied to controls that have text (but it is being applied to controls that have icons via `--media-icon-color`.

Relates to the problem encountered here:

https://github.com/muxinc/media-chrome/discussions/198

# Before

<img width="837" alt="before_2022-04-07_13-19-27" src="https://user-images.githubusercontent.com/764988/162289171-e0e4fbd4-cdce-45ae-9497-fe5199373059.png">


# After

<img width="867" alt="after_2022-04-07_13-19-38" src="https://user-images.githubusercontent.com/764988/162289185-6d63577d-01f0-45d9-a433-83cc69d8a23d.png">

