### PR TITLE
fix(mux-player): metadata fields should be set based on 'external'/at…

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -54,13 +54,12 @@
      -->
 
     <mux-player
-      playback-id="g65IqSFtWdpGR100c2W8VUHrfIVWTNRen"
-      env-key="5e67cqdt7hgc9vkla7p0qch7q"
-      primary-color="#f97316"
-      metadata-video-id="video-id-54321"
-      metadata-video-title="Star Wars: Episode 2"
-      metadata-viewer-user-id="user-id-007"
       stream-type="on-demand"
+      playback-id="g65IqSFtWdpGR100c2W8VUHrfIVWTNRen"
+      primary-color="#f97316"
+      metadata-video-id="video-id-is-dylan"
+      metadata-video-title="DID IT WORK DYLAN?????"
+      metadata-viewer-user-id="user-id-well-dylan"
     ></mux-player>
 
     <div class="buttons">

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -103,6 +103,11 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
     defaultHiddenCaptions: el.defaultHiddenCaptions,
     playerSize: getPlayerSize(el),
     hasCaptions: !!getCcSubTracks(el).length,
+    // NOTE: In order to guarantee all expected metadata props are set "from the outside" when used
+    // and to guarantee they'll all be set *before* the playback id is set, using attr values here (CJP)
+    metadataVideoId: el.getAttribute(MuxVideoAttributes.METADATA_VIDEO_ID),
+    metadataVideoTitle: el.getAttribute(MuxVideoAttributes.METADATA_VIDEO_TITLE),
+    metadataViewerUserId: el.getAttribute(MuxVideoAttributes.METADATA_VIEWER_USER_ID),
     ...state,
   };
 }

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -43,6 +43,14 @@ export const content = (props: MuxTemplateProps) => html`
       debug="${props.debug ?? false}"
       prefer-mse="${props.preferMse ?? false}"
       start-time="${props.startTime != null ? props.startTime : false}"
+      metadata-video-id="${props.metadataVideoId ?? props.metadata?.video_id ?? false}"
+      metadata-video-title="${props.metadataVideoTitle ?? props.metadata?.video_title ?? false}"
+      metadata-viewer-user-id="${props.metadataViewerUserId ?? props.metadata?.viewer_user_id ?? false}"
+      beacon-collection-domain="${props.beaconCollectionDomain ?? false}"
+      player-software-name="${props.playerSoftwareName}"
+      player-software-version="${props.playerSoftwareVersion}"
+      env-key="${props.envKey ?? false}"
+      stream-type="${props.streamType ?? false}"
       src="${!!props.src
         ? props.src
         : props.playbackId
@@ -53,14 +61,6 @@ export const content = (props: MuxTemplateProps) => html`
         : props.playbackId
         ? getPosterURLFromPlaybackId(props.playbackId, props.tokens.thumbnail)
         : false}"
-      player-software-name="${props.playerSoftwareName}"
-      player-software-version="${props.playerSoftwareVersion}"
-      env-key="${props.envKey ?? false}"
-      stream-type="${props.streamType ?? false}"
-      metadata-video-id="${props.metadata?.video_id ?? false}"
-      metadata-video-title="${props.metadata?.video_title ?? false}"
-      metadata-viewer-user-id="${props.metadata?.viewer_user_id ?? false}"
-      beacon-collection-domain="${props.beaconCollectionDomain ?? false}"
     >
       ${props.playbackId && props.streamType !== StreamTypes.LIVE && props.streamType !== StreamTypes.LL_LIVE
         ? html`<track

--- a/packages/mux-player/src/types.d.ts
+++ b/packages/mux-player/src/types.d.ts
@@ -25,6 +25,9 @@ export type MuxTemplateProps = Partial<MuxPlayerProps> & {
     thumbnail?: string;
     storyboard?: string;
   };
+  metadataVideoId: string;
+  metadataVideoTitle: string;
+  metadataViewerUserId: string;
 };
 
 export type DialogOptions = {

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -402,7 +402,7 @@ describe('<mux-player> playbackId transitions', () => {
       })
     );
 
-    await waitUntil(() => player.shadowRoot.querySelector('mxp-dialog h3'));
+    await waitUntil(() => player.shadowRoot.querySelector('mxp-dialog h3'), 2000);
     assert.equal(player.shadowRoot.querySelector('mxp-dialog h3').textContent, 'Network Error');
 
     player.playbackId = 'xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE';

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -251,6 +251,21 @@ describe('<mux-player>', () => {
     );
   });
 
+  it('should forward metadata attributes to the media element', async () => {
+    const video_id = 'test-video-id';
+    const video_title = 'test-video-title';
+    const viewer_user_id = 'test-viewer-user-id';
+    const player = await fixture(`<mux-player
+      metadata-video-id="${video_id}"
+      metadata-video-title="${video_title}"
+      metadata-viewer-user-id="${viewer_user_id}"
+    ></mux-player>`);
+
+    const actual = player.video.metadata;
+    const expected = { video_id, video_title, viewer_user_id };
+    assert.include(actual, expected, 'has expected metadata entries from attrs');
+  });
+
   it('muted attribute behaves like expected', async function () {
     const player = await fixture(`<mux-player
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"


### PR DESCRIPTION
…tr values in mux-player.

Still needs tests.