### PR TITLE
fix: make mux-player size based on video element

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -17,6 +17,8 @@
         max-width: 800px;
         margin: 40px auto;
         display: block;
+        aspect-ratio: 16 / 9;
+        background-color: #000;
       }
 
       .buttons {

--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@github/template-parts": "https://github.com/muxinc/template-parts.git#mux-player",
     "@mux-elements/mux-video": "0.4.3",
-    "media-chrome": "0.5.4"
+    "media-chrome": "0.6.0"
   },
   "devDependencies": {
     "@mux-elements/open-process": "0.1.0",

--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -1,8 +1,5 @@
 :host {
-  /* default aspect ratio, overwrite w/ e.g. style="aspect-ratio: 16 / 10" */
-  aspect-ratio: 16 / 9;
-  display: block;
-  width: 100%;
+  display: inline-block;
 }
 
 /* Hide custom elements that are not defined yet */
@@ -21,10 +18,6 @@ media-controller {
   --media-control-hover-background: transparent;
   --media-range-track-background-color: rgba(255, 255, 255, 0.5);
   --media-range-track-border-radius: 3px;
-  --media-aspect-ratio: auto;
-  display: block;
-  width: 100%;
-  height: 100%;
 }
 
 media-control-bar {

--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -18,6 +18,8 @@ media-controller {
   --media-control-hover-background: transparent;
   --media-range-track-background-color: rgba(255, 255, 255, 0.5);
   --media-range-track-border-radius: 3px;
+  width: 100%;
+  height: 100%;
 }
 
 media-control-bar {

--- a/packages/mux-video/src/CustomVideoElement.js
+++ b/packages/mux-video/src/CustomVideoElement.js
@@ -17,6 +17,7 @@ template.innerHTML = `
     /* display:inline (like the native el) makes it so you can't fill
       the container with the native el */
     display: inline-block;
+    line-height: 0;
     box-sizing: border-box;
 
     width: auto;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11431,10 +11431,10 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-media-chrome@0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-0.5.4.tgz#9f88eb71a323a4318a00978893dae9cadb9a8ded"
-  integrity sha512-0ujg8fwbXVgJUXykiBUU8tdg5S2eIuFXRcfQSh/ULj+iOakhsDJq0cETbJVkz31FOZGSbbhzAsGFx1Zqkr/z6w==
+media-chrome@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-0.6.0.tgz#0b8b43fe53958d7d8effff1c8b957aa48316d452"
+  integrity sha512-KF2yMvVSzoDFuGFNQQ2iQ622bSbHC5UI5kJAmHfiNpQXT87///epYwn4ivHBi6gH8nrEg3sMQJBKqXPnUeBA9w==
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
~Requires this PR in Media Chrome: https://github.com/muxinc/media-chrome/pull/205~

Upgraded media-chrome to 0.6.0