### PR TITLE
missing-explicit-dep(mux-player): mux-player has a direct dep on play…

### DIFF
--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@github/template-parts": "https://github.com/muxinc/template-parts.git#mux-player",
     "@mux-elements/mux-video": "0.4.3",
+    "@mux-elements/playback-core": "0.3.1",
     "media-chrome": "0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
…back-core. Adding to package.json