### PR TITLE
feat: add errorTranslator prop & muxVideo.error property

### DIFF
--- a/packages/mux-player/src/errors.ts
+++ b/packages/mux-player/src/errors.ts
@@ -8,35 +8,48 @@ export function getErrorLogs(
   error: MediaError,
   offline?: boolean,
   playbackId?: string,
-  playbackToken?: string
+  playbackToken?: string,
+  translate?: boolean
 ): { dialog: DialogOptions; devlog: DevlogOptions } {
   let dialog: DialogOptions = {};
   let devlog: DevlogOptions = {};
 
   switch (error.code) {
     case MediaError.MEDIA_ERR_NETWORK: {
-      dialog.title = i18n`Network Error`;
+      dialog.title = i18n(`Network Error`, translate);
       dialog.message = error.message;
 
       switch (error.data?.response.code) {
         case 412: {
-          dialog.title = i18n`Video is not currently available`;
-          dialog.message = i18n`The live stream or video file are not yet ready.`;
-          devlog.message = i18n`This playback-id may belong to a live stream that is not currently active or an asset that is not ready.`;
+          dialog.title = i18n(`Video is not currently available`, translate);
+          dialog.message = i18n(`The live stream or video file are not yet ready.`, translate);
+          devlog.message = i18n(
+            `This playback-id may belong to a live stream that is not currently active or an asset that is not ready.`,
+            translate
+          );
           devlog.file = '412-not-playable.md';
           break;
         }
         case 404: {
-          dialog.title = i18n`Video does not exist`;
+          dialog.title = i18n(`Video does not exist`, translate);
           dialog.message = '';
-          devlog.message = i18n`This playback-id does not exist. You may have used an Asset ID or an ID from a different resource.`;
+          devlog.message = i18n(
+            `This playback-id does not exist. You may have used an Asset ID or an ID from a different resource.`,
+            translate
+          );
           devlog.file = '404-not-found.md';
           break;
         }
         case 403: {
-          dialog.title = i18n`Invalid playback URL`;
-          dialog.message = i18n`The video URL or playback-token are formatted with incorrect or incomplete information.`;
-          devlog.message = i18n`403 error trying to access this playback URL. If this is a signed URL, you might need to provide a playback-token.`;
+          dialog.title = i18n(`Invalid playback URL`, translate);
+          dialog.message = i18n(
+            `The video URL or playback-token are formatted with incorrect or incomplete information.`,
+            translate
+          );
+          devlog.message = i18n(
+            `403 error trying to access this playback URL. If this is a signed URL, you might need to provide a playback-token.`,
+            translate
+          );
           devlog.file = 'missing-signed-tokens.md';
 
           if (!playbackToken) break;
@@ -51,45 +64,53 @@ export function getErrorLogs(
           };
 
           if (tokenExpired) {
-            dialog.title = i18n`Video URL has expired`;
-            dialog.message = i18n`The video’s secured playback-token has expired.`;
-            devlog.message =
-              i18n`This playback is using signed URLs and the playback-token has expired. Expired at: {expiredDate}. Current time: {currentDate}.`.format(
-                {
-                  expiredDate: new Intl.DateTimeFormat(lang.code, dateOptions).format(tokenExpiry * 1000),
-                  currentDate: new Intl.DateTimeFormat(lang.code, dateOptions).format(Date.now()),
-                }
-              );
+            dialog.title = i18n(`Video URL has expired`, translate);
+            dialog.message = i18n(`The video’s secured playback-token has expired.`, translate);
+            devlog.message = i18n(
+              `This playback is using signed URLs and the playback-token has expired. Expired at: {expiredDate}. Current time: {currentDate}.`,
+              translate
+            ).format({
+              expiredDate: new Intl.DateTimeFormat(lang.code, dateOptions).format(tokenExpiry * 1000),
+              currentDate: new Intl.DateTimeFormat(lang.code, dateOptions).format(Date.now()),
+            });
             devlog.file = '403-expired-token.md';
             break;
           }
 
           if (playbackIdMismatch) {
-            dialog.title = i18n`Video URL is formatted incorrectly`;
-            dialog.message = i18n`The video’s playback ID does not match the one encoded in the playback-token.`;
-            devlog.message =
-              i18n`The specified playback ID {playbackId} and the playback ID encoded in the playback-token {tokenPlaybackId} do not match.`.format(
-                {
-                  playbackId,
-                  tokenPlaybackId,
-                }
-              );
+            dialog.title = i18n(`Video URL is formatted incorrectly`, translate);
+            dialog.message = i18n(
+              `The video’s playback ID does not match the one encoded in the playback-token.`,
+              translate
+            );
+            devlog.message = i18n(
+              `The specified playback ID {playbackId} and the playback ID encoded in the playback-token {tokenPlaybackId} do not match.`,
+              translate
+            ).format({
+              playbackId,
+              tokenPlaybackId,
+            });
             devlog.file = '403-playback-id-mismatch.md';
             break;
           }
 
           if (badTokenType) {
-            dialog.title = i18n`Video URL is formatted incorrectly`;
-            dialog.message = i18n`The playback-token is formatted with incorrect information.`;
-            devlog.message =
-              i18n`The playback-token has an incorrect aud value: {tokenType}. aud value should be v.`.format({
-                tokenType,
-              });
+            dialog.title = i18n(`Video URL is formatted incorrectly`, translate);
+            dialog.message = i18n(`The playback-token is formatted with incorrect information.`, translate);
+            devlog.message = i18n(
+              `The playback-token has an incorrect aud value: {tokenType}. aud value should be v.`,
+              translate
+            ).format({
+              tokenType,
+            });
             devlog.file = '403-incorrect-aud-value.md';
             break;
           }
 
-          devlog.message = i18n`403 error trying to access this playback URL. If this is a signed playback ID, the token might not have been generated correctly.`;
+          devlog.message = i18n(
+            `403 error trying to access this playback URL. If this is a signed playback ID, the token might not have been generated correctly.`,
+            translate
+          );
           devlog.file = '403-malformatted-token.md';
           break;
         }
@@ -99,7 +120,7 @@ export function getErrorLogs(
     case MediaError.MEDIA_ERR_DECODE: {
       const { message } = error;
       dialog = {
-        title: i18n`Media Error`,
+        title: i18n(`Media Error`, translate),
         message,
       };
       devlog.file = 'media-decode-error.md';
@@ -108,7 +129,7 @@ export function getErrorLogs(
     case MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED: {
       // If native HLS is used on Safari, M3U8 response errors cause media src not supported errors.
       // If the response returns an error code, fix the MediaError.code and get detailed error logs.
-      const status = error.data?.response?.status;
+      const status = error.data?.response?.code;
       if (status >= 400 && status < 500) {
         error.code = MediaError.MEDIA_ERR_NETWORK;
         error.data = { response: { code: status } };
@@ -117,7 +138,7 @@ export function getErrorLogs(
       }
 
       dialog = {
-        title: i18n`Source Not Supported`,
+        title: i18n(`Source Not Supported`, translate),
         message: error.message,
       };
       devlog.file = 'media-src-not-supported.md';
@@ -125,7 +146,7 @@ export function getErrorLogs(
     }
     default:
       dialog = {
-        title: i18n`Error`,
+        title: i18n(`Error`, translate),
         message: error.message,
       };
       break;
@@ -133,8 +154,8 @@ export function getErrorLogs(
 
   if (offline) {
     dialog = {
-      title: i18n`Your device appears to be offline`,
-      message: i18n`Check your internet connection and try reloading this video.`,
+      title: i18n(`Your device appears to be offline`, translate),
+      message: i18n(`Check your internet connection and try reloading this video.`, translate),
     };
   }
 

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -297,19 +297,19 @@ class MuxPlayerElement extends VideoApiElement {
 
     if (this.media) {
       this.media.errorTranslator = (errorEvent: ErrorEvent = {}) => {
-        const { player_error, player_error_message } = errorEvent;
-        if (!player_error) return errorEvent;
+        if (!this.media?.error) return errorEvent;
 
         const { devlog } = getErrorLogs(
-          player_error,
+          this.media?.error,
           !window.navigator.onLine,
           this.playbackId,
           this.playbackToken,
           false
         );
+
         return {
-          player_error_code: player_error.code,
-          player_error_message: devlog.message ? String(devlog.message) : player_error_message,
+          player_error_code: this.media?.error.code,
+          player_error_message: devlog.message ? String(devlog.message) : errorEvent.player_error_message,
         };
       };
     }

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -442,7 +442,7 @@ class MuxPlayerElement extends VideoApiElement {
         const { aud } = parseJwt(newValue);
         if (newValue && aud !== 't') {
           logger.warn(
-            i18n`The provided thumbnail-token should have audience value 't' instead of '{aud}'.`.format({ aud })
+            i18n(`The provided thumbnail-token should have audience value 't' instead of '{aud}'.`).format({ aud })
           );
         }
         break;
@@ -451,7 +451,7 @@ class MuxPlayerElement extends VideoApiElement {
         const { aud } = parseJwt(newValue);
         if (newValue && aud !== 's') {
           logger.warn(
-            i18n`The provided storyboard-token should have audience value 's' instead of '{aud}'.`.format({ aud })
+            i18n(`The provided storyboard-token should have audience value 's' instead of '{aud}'.`).format({ aud })
           );
         }
         break;
@@ -461,16 +461,17 @@ class MuxPlayerElement extends VideoApiElement {
           logger.devlog({
             file: 'invalid-stream-type.md',
             message: String(
-              i18n`No stream-type value supplied. Defaulting to \`on-demand\`. Please provide stream-type as either: \`on-demand\`, \`live\` or \`ll-live\``
+              i18n(
+                `No stream-type value supplied. Defaulting to \`on-demand\`. Please provide stream-type as either: \`on-demand\`, \`live\` or \`ll-live\``
+              )
             ),
           });
         } else if (!['on-demand', 'live', 'll-live'].includes(this.streamType)) {
           logger.devlog({
             file: 'invalid-stream-type.md',
-            message:
-              i18n`Invalid stream-type value supplied: \`{streamType}\`. Please provide stream-type as either: \`on-demand\`, \`live\` or \`ll-live\``.format(
-                { streamType: this.streamType }
-              ),
+            message: i18n(
+              `Invalid stream-type value supplied: \`{streamType}\`. Please provide stream-type as either: \`on-demand\`, \`live\` or \`ll-live\``
+            ).format({ streamType: this.streamType }),
           });
         }
         break;

--- a/packages/mux-player/src/logger.ts
+++ b/packages/mux-player/src/logger.ts
@@ -17,7 +17,7 @@ export function devlog(opts: DevlogOptions) {
   let message = opts.message ?? '';
   if (opts.file) {
     const githubErrorsBase = 'https://github.com/muxinc/elements/blob/main/errors/';
-    message += ` ${i18n`Read more: `}\n${githubErrorsBase}${opts.file}`;
+    message += ` ${i18n(`Read more: `)}\n${githubErrorsBase}${opts.file}`;
   }
   warn(message);
 }

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -99,7 +99,7 @@ export const content = (props: MuxTemplateProps) => html`
               href="${props.dialog.linkUrl}"
               target="_blank"
               rel="external noopener"
-              aria-label="${props.dialog.linkText ?? ''} ${i18n`(opens in a new window)`}"
+              aria-label="${props.dialog.linkText ?? ''} ${i18n(`(opens in a new window)`)}"
               >${props.dialog.linkText ?? props.dialog.linkUrl}</a
             >`
           : html``}

--- a/packages/mux-player/src/types.d.ts
+++ b/packages/mux-player/src/types.d.ts
@@ -1,4 +1,4 @@
-import type MuxVideoElement from '@mux-elements/mux-video';
+import type MuxVideoElement, { MediaError } from '@mux-elements/mux-video';
 
 export type MuxPlayerProps = Partial<MuxVideoElement> & {
   preferMse?: boolean;
@@ -41,4 +41,10 @@ export type DialogOptions = {
 export type DevlogOptions = {
   message?: string;
   file?: string;
+};
+
+export type ErrorEvent = {
+  player_error?: MediaError;
+  player_error_code?: number;
+  player_error_message?: string;
 };

--- a/packages/mux-player/src/utils.ts
+++ b/packages/mux-player/src/utils.ts
@@ -1,13 +1,16 @@
 // @ts-ignore
 import lang from '../lang/en.json';
 
+const DEFAULT_LOCALE = 'en';
+
 // NL example
 // lang = {
 //   "Network Error": "Netwerk Fout",
 // };
-export function i18n(strings: TemplateStringsArray): any {
-  // i18n template literals should not include expressions, ok to pass strings[0].
-  return new IntlMessageFormat(lang?.[strings[0]] ?? strings[0]);
+export function i18n(str: string, translate = true): any {
+  const message = translate ? lang?.[str] ?? str : str;
+  const locale = translate ? lang.code : DEFAULT_LOCALE;
+  return new IntlMessageFormat(message, locale);
 }
 
 /**
@@ -18,7 +21,7 @@ class IntlMessageFormat {
   message: string;
   locale: string;
 
-  constructor(message: string, locale = lang.code ?? 'en') {
+  constructor(message: string, locale = lang.code ?? DEFAULT_LOCALE) {
     this.message = message;
     this.locale = locale;
   }

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -68,6 +68,7 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
   protected __playerSoftwareVersion?: string;
   protected __playerSoftwareName?: string;
   protected __updateAutoplay?: UpdateAutoplay;
+  protected __errorTranslator?: Function;
 
   constructor() {
     super();
@@ -108,6 +109,14 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
 
   get mux(): Readonly<HTMLVideoElement['mux']> | undefined {
     return this.nativeEl.mux;
+  }
+
+  get errorTranslator() {
+    return this.__errorTranslator;
+  }
+
+  set errorTranslator(value: Function | undefined) {
+    this.__errorTranslator = value;
   }
 
   get src() {

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -10,6 +10,7 @@ import {
   Metadata,
   mux,
   MediaError,
+  getError,
 } from '@mux-elements/playback-core';
 import type { PlaybackEngine, Autoplay, UpdateAutoplay, ExtensionMimeTypeMap } from '@mux-elements/playback-core';
 import { getPlayerVersion } from './env';
@@ -109,6 +110,11 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
 
   get mux(): Readonly<HTMLVideoElement['mux']> | undefined {
     return this.nativeEl.mux;
+  }
+
+  // @ts-ignore
+  get error(): MediaError | null {
+    return getError(this.nativeEl) ?? null;
   }
 
   get errorTranslator() {

--- a/packages/playback-core/src/errors.ts
+++ b/packages/playback-core/src/errors.ts
@@ -1,10 +1,11 @@
 export class MediaError extends Error {
-  static MEDIA_ERR_CUSTOM: number = 0;
   static MEDIA_ERR_ABORTED: number = 1;
   static MEDIA_ERR_NETWORK: number = 2;
   static MEDIA_ERR_DECODE: number = 3;
   static MEDIA_ERR_SRC_NOT_SUPPORTED: number = 4;
   static MEDIA_ERR_ENCRYPTED: number = 5;
+  // @see https://docs.mux.com/guides/data/monitor-html5-video-element#customize-error-tracking-behavior
+  static MEDIA_ERR_CUSTOM: number = 100;
 
   static defaultMessages: Record<number, string> = {
     1: 'You aborted the media playback',
@@ -19,11 +20,11 @@ export class MediaError extends Error {
   fatal: boolean;
   data?: any;
 
-  constructor(message?: string, code: number = 0, fatal?: boolean) {
+  constructor(message?: string, code: number = MediaError.MEDIA_ERR_CUSTOM, fatal?: boolean) {
     super(message);
     this.name = 'MediaError';
     this.code = code;
-    this.fatal = fatal ?? code >= MediaError.MEDIA_ERR_NETWORK;
+    this.fatal = fatal ?? (code >= MediaError.MEDIA_ERR_NETWORK && code <= MediaError.MEDIA_ERR_ENCRYPTED);
 
     if (!this.message) {
       this.message = MediaError.defaultMessages[this.code] ?? '';

--- a/scripts/i18n-utils/i18n-utils.js
+++ b/scripts/i18n-utils/i18n-utils.js
@@ -9,7 +9,8 @@ const srcContents = fs.readFileSync(srcFile).toString();
 const baseLangContents = {};
 
 const strings = [];
-const regex = /\b(?:i18n`(.*?)`)/g;
+// @see https://regexr.com/6jtib
+const regex = /\b(?:i18n\(\s*['"`](.*?)['"`]\s*[,)])/g;
 let result;
 
 while ((result = regex.exec(srcContents)) !== null) {

--- a/types/mux.d.ts
+++ b/types/mux.d.ts
@@ -455,7 +455,7 @@ type EventParamsMap = {
   [events.SEEKED]: void;
   [events.REBUFFER_START]: void;
   [events.REBUFFER_END]: void;
-  [events.ERROR]: void;
+  [events.ERROR]: ErrorEvent;
   [events.ENDED]: void;
   [events.RENDITION_CHANGE]: RenditionChangeEvent;
   [events.ORIENTATION_CHANGE]: OrientationChangeEvent;


### PR DESCRIPTION
This change makes errors more uniform in mux-video by adding a `muxVideo.error` property and now the errorTranslator doesn't require a special `player_error` property because it can access that on the `mux-video` element.