### PR TITLE
fix: prevent dialog from focus if outside player

### DIFF
--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -18,7 +18,7 @@ import {
 import { template } from './template';
 import { render } from './html';
 import { getErrorLogs } from './errors';
-import { toNumberOrUndefined, i18n, parseJwt } from './utils';
+import { toNumberOrUndefined, i18n, parseJwt, containsComposed } from './utils';
 import * as logger from './logger';
 import type { MuxTemplateProps } from './types';
 
@@ -135,6 +135,7 @@ class MuxPlayerElement extends VideoApiElement {
     supportsAirPlay: false,
     supportsVolume: false,
     onCloseErrorDialog: () => this.#setState({ dialog: undefined, isDialogOpen: false }),
+    onInitFocusDialog: (e) => containsComposed(this, document.activeElement) || e.preventDefault(),
     onSeekToLive: () => seekToLive(this),
   };
 

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -18,7 +18,7 @@ import {
 import { template } from './template';
 import { render } from './html';
 import { getErrorLogs } from './errors';
-import { toNumberOrUndefined, i18n, parseJwt, containsComposed } from './utils';
+import { toNumberOrUndefined, i18n, parseJwt, containsComposedNode } from './utils';
 import * as logger from './logger';
 import type { MuxTemplateProps } from './types';
 
@@ -135,7 +135,10 @@ class MuxPlayerElement extends VideoApiElement {
     supportsAirPlay: false,
     supportsVolume: false,
     onCloseErrorDialog: () => this.#setState({ dialog: undefined, isDialogOpen: false }),
-    onInitFocusDialog: (e) => containsComposed(this, document.activeElement) || e.preventDefault(),
+    onInitFocusDialog: (e) => {
+      const isFocusedElementInPlayer = containsComposedNode(this, document.activeElement);
+      if (!isFocusedElementInPlayer) e.preventDefault();
+    },
     onSeekToLive: () => seekToLive(this),
   };
 

--- a/packages/mux-player/src/media-chrome/dialog.ts
+++ b/packages/mux-player/src/media-chrome/dialog.ts
@@ -138,9 +138,15 @@ function focus(el: MediaDialog) {
     document.activeElement.blur();
   }
 
-  if (target instanceof HTMLElement) {
-    target.focus({ preventScroll: true });
-  }
+  el.addEventListener(
+    'transitionend',
+    () => {
+      if (target instanceof HTMLElement) {
+        target.focus({ preventScroll: true });
+      }
+    },
+    { once: true }
+  );
 }
 
 function findFocusableElementWithin(hostElement: Element | ShadowRoot | null | undefined): Element | null | undefined {

--- a/packages/mux-player/src/media-chrome/dialog.ts
+++ b/packages/mux-player/src/media-chrome/dialog.ts
@@ -88,6 +88,7 @@ class MediaDialog extends HTMLElement {
 
   show() {
     this.setAttribute('open', '');
+    this.dispatchEvent(new CustomEvent('open', { composed: true, bubbles: true }));
     focus(this);
   }
 
@@ -117,6 +118,12 @@ class MediaDialog extends HTMLElement {
 }
 
 function focus(el: MediaDialog) {
+  const initFocus = new CustomEvent('initfocus', { composed: true, bubbles: true, cancelable: true });
+  el.dispatchEvent(initFocus);
+
+  // If `event.preventDefault()` was called in a listener prevent focusing.
+  if (initFocus.defaultPrevented) return;
+
   // Find element with `autofocus` attribute, or fall back to the first form/tabindex control.
   let target: Element | null | undefined = el.querySelector('[autofocus]:not([disabled])');
   if (!target && (el as HTMLElement).tabIndex >= 0) {
@@ -132,7 +139,7 @@ function focus(el: MediaDialog) {
   }
 
   if (target instanceof HTMLElement) {
-    target.focus();
+    target.focus({ preventScroll: true });
   }
 }
 

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -85,7 +85,12 @@ export const content = (props: MuxTemplateProps) => html`
     >
       Live
     </button>
-    <mxp-dialog no-auto-hide open="${props.isDialogOpen}" onclose="${props.onCloseErrorDialog}">
+    <mxp-dialog
+      no-auto-hide
+      open="${props.isDialogOpen}"
+      onclose="${props.onCloseErrorDialog}"
+      oninitfocus="${props.onInitFocusDialog}"
+    >
       ${props.dialog?.title ? html`<h3>${props.dialog.title}</h3>` : html``}
       <p>
         ${props.dialog?.message}

--- a/packages/mux-player/src/types.d.ts
+++ b/packages/mux-player/src/types.d.ts
@@ -17,6 +17,7 @@ export type MuxTemplateProps = Partial<MuxPlayerProps> & {
   isDialogOpen: boolean;
   defaultHiddenCaptions: boolean;
   onCloseErrorDialog: (evt: CustomEvent) => void;
+  onInitFocusDialog: (evt: CustomEvent) => void;
   dialog: DialogOptions;
   inLiveWindow: boolean;
   onSeekToLive: (_evt: Event) => void;

--- a/packages/mux-player/src/utils.ts
+++ b/packages/mux-player/src/utils.ts
@@ -89,8 +89,8 @@ export function parseJwt(token: string) {
   return JSON.parse(jsonPayload);
 }
 
-export const containsComposed = (rootNode: Node, childNode?: Node | Element | null): boolean => {
+export const containsComposedNode = (rootNode: Node, childNode?: Node | Element | null): boolean => {
   if (!rootNode || !childNode) return false;
   if (rootNode.contains(childNode)) return true;
-  return containsComposed(rootNode, (childNode.getRootNode() as ShadowRoot).host);
+  return containsComposedNode(rootNode, (childNode.getRootNode() as ShadowRoot).host);
 };

--- a/packages/mux-player/src/utils.ts
+++ b/packages/mux-player/src/utils.ts
@@ -88,3 +88,9 @@ export function parseJwt(token: string) {
   );
   return JSON.parse(jsonPayload);
 }
+
+export const containsComposed = (rootNode: Node, childNode?: Node | Element | null): boolean => {
+  if (!rootNode || !childNode) return false;
+  if (rootNode.contains(childNode)) return true;
+  return containsComposed(rootNode, (childNode.getRootNode() as ShadowRoot).host);
+};


### PR DESCRIPTION
Closes #94

this change fixes an issue where the focus would be moved to the player dialog even when the previous document focus was outside the player.