### PR TITLE
Expose mux-video as `media` for consistency, prefix _hls

### DIFF
--- a/examples/nextjs-with-typescript/pages/mux-audio.tsx
+++ b/examples/nextjs-with-typescript/pages/mux-audio.tsx
@@ -1,0 +1,91 @@
+// @ts-nocheck
+import Link from "next/link";
+import "@mux-elements/mux-audio";
+import { useState } from "react";
+
+// const INITIAL_DEBUG = true;
+const INITIAL_DEBUG = false;
+const INITIAL_MUTED = false;
+const INITIAL_AUTOPLAY = false;
+const INITIAL_PLAYBACK_ID = "g65IqSFtWdpGR100c2W8VUHrfIVWTNRen";
+
+function MuxAudioWCPage() {
+  // const mediaElRef = useRef(null);
+  const [playbackId, setPlaybackId] = useState(INITIAL_PLAYBACK_ID);
+  const [muted, setMuted] = useState(INITIAL_MUTED);
+  const [debug, setDebug] = useState(INITIAL_DEBUG);
+  const [autoplay, setAutoplay] = useState(INITIAL_AUTOPLAY);
+  const debugObj = debug ? { debug: "" } : {};
+  const mutedObj = muted ? { muted: "" } : {};
+  const autoplayObj = autoplay ? { autoplay } : {};
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexFlow: "column",
+        height: "100%",
+        width: "100%",
+      }}
+    >
+      <h1>mux-audio Demo</h1>
+      <div>
+        <mux-audio
+          // style={{ aspectRatio: "16 / 9" }}
+          playback-id={playbackId}
+          // onPlayerReady={() => console.log("ready!")}
+          {...debugObj}
+          {...mutedObj}
+          {...autoplayObj}
+          // stream-type="live"
+          // primary-color="#ec407a"
+          // secondary-color="#64b5f6"
+          // tertiary-color="#b4004e"
+          // startTime={12}
+          controls
+        ></mux-audio>
+      </div>
+      <div>
+        <div>
+          <label htmlFor="autoplay-control">Muted Autoplay</label>
+          <input
+            id="autoplay-control"
+            type="checkbox"
+            onChange={() => setAutoplay(!autoplay ? "muted" : false)}
+            checked={autoplay}
+          />
+        </div>
+        <div>
+          <label htmlFor="muted-control">Muted</label>
+          <input
+            id="muted-control"
+            type="checkbox"
+            onChange={() => setMuted(!muted)}
+            checked={muted}
+          />
+        </div>
+        <div>
+          <label htmlFor="debug-control">Debug</label>
+          <input
+            id="debug-control"
+            type="checkbox"
+            onChange={() => setDebug(!debug)}
+            checked={debug}
+          />
+        </div>
+        <div>
+          <label htmlFor="playback-id-control">Playback Id</label>
+          <input
+            id="playback-id-control"
+            onBlur={({ currentTarget }) => setPlaybackId(currentTarget.value)}
+            defaultValue={playbackId}
+          />
+        </div>
+      </div>
+      <h3 className="title">
+        <Link href="/">Browse Elements</Link>
+      </h3>
+    </div>
+  );
+}
+
+export default MuxAudioWCPage;

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -79,6 +79,14 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
     return playerSoftwareVersion;
   }
 
+  /**
+   * @deprecated please use ._hls instead
+   */
+  get hls() {
+    console.warn('<mux-audio>.hls is deprecated, please use ._hls instead');
+    return this._hls;
+  }
+
   get _hls() {
     return this.__hls;
   }

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -79,7 +79,7 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
     return playerSoftwareVersion;
   }
 
-  get hls() {
+  get _hls() {
     return this.__hls;
   }
 
@@ -271,8 +271,8 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
             'Cannot toggle debug mode of mux data after initialization. Make sure you set all metadata to override before setting the src.'
           );
         }
-        if (!!this.hls) {
-          this.hls.config.debug = debug;
+        if (!!this._hls) {
+          this._hls.config.debug = debug;
         }
         break;
       case Attributes.METADATA_URL:

--- a/packages/mux-player/src/helpers.ts
+++ b/packages/mux-player/src/helpers.ts
@@ -72,13 +72,13 @@ export const hasVolumeSupportAsync = async (mediaEl: HTMLMediaElement | undefine
 };
 
 export function getCcSubTracks(el: MuxPlayerElement) {
-  return Array.from(el.video?.textTracks ?? []).filter(({ kind }) => kind === 'subtitles' || kind === 'captions');
+  return Array.from(el.media?.textTracks ?? []).filter(({ kind }) => kind === 'subtitles' || kind === 'captions');
 }
 
 export const getLiveTime = (el: MuxPlayerElement) => {
-  const { video } = el;
-  return video?.hls?.liveSyncPosition ?? video?.seekable.length
-    ? video?.seekable.end(video.seekable.length - 1)
+  const { media } = el;
+  return media?._hls?.liveSyncPosition ?? media?.seekable.length
+    ? media?.seekable.end(media.seekable.length - 1)
     : undefined;
 };
 
@@ -99,7 +99,7 @@ export const LIVE_HOLDBACK_MOE = 0.5;
 export const isInLiveWindow = (el: MuxPlayerElement) => {
   const { streamType } = el;
   const liveTime = getLiveTime(el);
-  const currentTime = el.video?.currentTime;
+  const currentTime = el.media?.currentTime;
   if (liveTime == undefined || currentTime == undefined) {
     return false;
   }

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -157,8 +157,8 @@ class MuxPlayerElement extends VideoApiElement {
       logger.error('<media-theme-mux> failed to upgrade!');
     }
 
-    customElements.upgrade(this.video as Node);
-    if (!(this.video instanceof MuxVideoElement)) {
+    customElements.upgrade(this.media as Node);
+    if (!(this.media instanceof MuxVideoElement)) {
       logger.error('<mux-video> failed to upgrade!');
     }
 
@@ -168,16 +168,16 @@ class MuxPlayerElement extends VideoApiElement {
     }
 
     this.querySelectorAll(':scope > track').forEach((track) => {
-      this.video?.append(track.cloneNode());
+      this.media?.append(track.cloneNode());
     });
 
     /**
      * @todo determine sensible defaults for preloading buffer
      * @see https://github.com/muxinc/elements/issues/51
      */
-    // if (this.video?.hls) {
+    // if (this.media?.hls) {
     //   // Temporarily here to load less segments on page load, remove later!!!!
-    //   this.video.hls.config.maxMaxBufferLength = 2;
+    //   this.media.hls.config.maxMaxBufferLength = 2;
     // }
 
     this.#setUpErrors();
@@ -250,10 +250,10 @@ class MuxPlayerElement extends VideoApiElement {
         );
       }
     };
-    this.video?.addEventListener('progress', updateLiveWindow);
-    this.video?.addEventListener('waiting', updateLiveWindow);
-    this.video?.addEventListener('timeupdate', updateLiveWindow);
-    this.video?.addEventListener('emptied', updateLiveWindow);
+    this.media?.addEventListener('progress', updateLiveWindow);
+    this.media?.addEventListener('waiting', updateLiveWindow);
+    this.media?.addEventListener('timeupdate', updateLiveWindow);
+    this.media?.addEventListener('emptied', updateLiveWindow);
   }
 
   #setUpErrors() {
@@ -291,13 +291,13 @@ class MuxPlayerElement extends VideoApiElement {
     // from video.onerror. This allows us to simulate errors from the outside.
     this.addEventListener('error', onError);
 
-    this.video?.addEventListener('error', (event: Event) => {
+    this.media?.addEventListener('error', (event: Event) => {
       let { detail: error }: { detail: any } = event as CustomEvent;
 
       // If it is a hls.js error event there will be an error object in the event.
       // If it is a native video error event there will be no error object.
       if (!error) {
-        const { message, code } = this.video?.error ?? {};
+        const { message, code } = this.media?.error ?? {};
         error = new MediaError(message, code);
       }
 
@@ -314,8 +314,8 @@ class MuxPlayerElement extends VideoApiElement {
 
   #setUpCaptionsButton() {
     const onTrackCountChange = () => this.#render();
-    this.video?.textTracks?.addEventListener('addtrack', onTrackCountChange);
-    this.video?.textTracks?.addEventListener('removetrack', onTrackCountChange);
+    this.media?.textTracks?.addEventListener('addtrack', onTrackCountChange);
+    this.media?.textTracks?.addEventListener('removetrack', onTrackCountChange);
   }
 
   #setUpCaptionsMovement() {
@@ -415,7 +415,7 @@ class MuxPlayerElement extends VideoApiElement {
         this.#setState({ supportsAirPlay });
       };
 
-      this.video?.addEventListener('webkitplaybacktargetavailabilitychanged', onPlaybackTargetAvailability);
+      this.media?.addEventListener('webkitplaybacktargetavailabilitychanged', onPlaybackTargetAvailability);
     }
   }
 
@@ -479,11 +479,11 @@ class MuxPlayerElement extends VideoApiElement {
   }
 
   get hls() {
-    return this.video?.hls;
+    return this.media?.hls;
   }
 
   get mux() {
-    return this.video?.mux;
+    return this.media?.mux;
   }
 
   /**
@@ -683,14 +683,14 @@ class MuxPlayerElement extends VideoApiElement {
    * Get the metadata object for Mux Data.
    */
   get metadata(): Readonly<Metadata> | undefined {
-    return this.video?.metadata;
+    return this.media?.metadata;
   }
 
   /**
    * Set the metadata object for Mux Data.
    */
   set metadata(val: Readonly<Metadata> | undefined) {
-    if (this.video) this.video.metadata = val;
+    if (this.media) this.media.metadata = val;
   }
 
   /**
@@ -759,7 +759,7 @@ class MuxPlayerElement extends VideoApiElement {
 }
 
 export function getVideoAttribute(el: MuxPlayerElement, name: string) {
-  return el.video ? el.video.getAttribute(name) : el.getAttribute(name);
+  return el.media ? el.media.getAttribute(name) : el.getAttribute(name);
 }
 
 /** @TODO Refactor once using `globalThis` polyfills */

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -478,6 +478,14 @@ class MuxPlayerElement extends VideoApiElement {
     return this.#state.inLiveWindow;
   }
 
+  /**
+   * @deprecated please use ._hls instead
+   */
+  get hls() {
+    logger.warn('<mux-player>.hls is deprecated, please use ._hls instead');
+    return this._hls;
+  }
+
   get _hls() {
     return this.media?._hls;
   }

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -175,9 +175,9 @@ class MuxPlayerElement extends VideoApiElement {
      * @todo determine sensible defaults for preloading buffer
      * @see https://github.com/muxinc/elements/issues/51
      */
-    // if (this.media?.hls) {
+    // if (this.media?._hls) {
     //   // Temporarily here to load less segments on page load, remove later!!!!
-    //   this.media.hls.config.maxMaxBufferLength = 2;
+    //   this.media._hls.config.maxMaxBufferLength = 2;
     // }
 
     this.#setUpErrors();
@@ -478,8 +478,8 @@ class MuxPlayerElement extends VideoApiElement {
     return this.#state.inLiveWindow;
   }
 
-  get hls() {
-    return this.media?.hls;
+  get _hls() {
+    return this.media?._hls;
   }
 
   get mux() {

--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -61,7 +61,7 @@ class VideoApiElement extends HTMLElement {
     super();
 
     this.querySelectorAll(':scope > track').forEach((track) => {
-      this.video?.append(track.cloneNode());
+      this.media?.append(track.cloneNode());
     });
 
     // Watch for child adds/removes and update the native element if necessary
@@ -71,12 +71,12 @@ class VideoApiElement extends HTMLElement {
         if (mutation.type === 'childList') {
           // Child being removed
           mutation.removedNodes.forEach((node) => {
-            const track = this.video?.querySelector(`track[src="${(node as HTMLTrackElement).src}"]`);
-            if (track) this.video?.removeChild(track);
+            const track = this.media?.querySelector(`track[src="${(node as HTMLTrackElement).src}"]`);
+            if (track) this.media?.removeChild(track);
           });
 
           mutation.addedNodes.forEach((node) => {
-            this.video?.append(node.cloneNode());
+            this.media?.append(node.cloneNode());
           });
         }
       }
@@ -89,22 +89,22 @@ class VideoApiElement extends HTMLElement {
   attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string) {
     switch (attrName) {
       case CustomVideoAttributes.MUTED: {
-        if (this.video) {
-          this.video.muted = newValue != null;
+        if (this.media) {
+          this.media.muted = newValue != null;
         }
         return;
       }
       case CustomVideoAttributes.VOLUME: {
         const val = +newValue;
-        if (this.video && !Number.isNaN(val)) {
-          this.video.volume = val;
+        if (this.media && !Number.isNaN(val)) {
+          this.media.volume = val;
         }
         return;
       }
       case CustomVideoAttributes.PLAYBACKRATE: {
         const val = +newValue;
-        if (this.video && !Number.isNaN(val)) {
-          this.video.playbackRate = val;
+        if (this.media && !Number.isNaN(val)) {
+          this.media.playbackRate = val;
         }
         return;
       }
@@ -117,7 +117,7 @@ class VideoApiElement extends HTMLElement {
     options?: boolean | EventListenerOptions
   ) {
     if (AllowedVideoEvents.includes(type)) {
-      this.video?.addEventListener(type, listener, options);
+      this.media?.addEventListener(type, listener, options);
       return;
     }
     super.addEventListener(type, listener, options);
@@ -129,21 +129,21 @@ class VideoApiElement extends HTMLElement {
     options?: boolean | EventListenerOptions
   ) {
     if (AllowedVideoEvents.includes(type)) {
-      this.video?.removeEventListener(type, listener, options);
+      this.media?.removeEventListener(type, listener, options);
       return;
     }
     super.removeEventListener(type, listener, options);
   }
 
   play() {
-    return this.video?.play();
+    return this.media?.play();
   }
 
   pause() {
-    this.video?.pause();
+    this.media?.pause();
   }
 
-  get video(): MuxVideoElement | null | undefined {
+  get media(): MuxVideoElement | null | undefined {
     return this.shadowRoot?.querySelector('mux-video');
   }
 
@@ -158,50 +158,50 @@ class VideoApiElement extends HTMLElement {
   }
 
   get paused() {
-    return this.video?.paused ?? true;
+    return this.media?.paused ?? true;
   }
 
   get duration() {
-    return this.video?.duration ?? NaN;
+    return this.media?.duration ?? NaN;
   }
 
   get ended() {
-    return this.video?.ended ?? false;
+    return this.media?.ended ?? false;
   }
 
   get buffered() {
-    return this.video?.buffered;
+    return this.media?.buffered;
   }
 
   get readyState() {
-    return this.video?.readyState ?? 0;
+    return this.media?.readyState ?? 0;
   }
 
   get videoWidth() {
-    return this.video?.videoWidth;
+    return this.media?.videoWidth;
   }
 
   get videoHeight() {
-    return this.video?.videoHeight;
+    return this.media?.videoHeight;
   }
 
   get currentTime() {
-    return this.video?.currentTime ?? 0;
+    return this.media?.currentTime ?? 0;
   }
 
   set currentTime(val) {
-    if (this.video) {
-      this.video.currentTime = Number(val);
+    if (this.media) {
+      this.media.currentTime = Number(val);
     }
   }
 
   get volume() {
-    return this.video?.volume ?? 1;
+    return this.media?.volume ?? 1;
   }
 
   set volume(val) {
-    if (this.video) {
-      this.video.volume = Number(val);
+    if (this.media) {
+      this.media.volume = Number(val);
     }
   }
 
@@ -222,12 +222,12 @@ class VideoApiElement extends HTMLElement {
   }
 
   get playbackRate() {
-    return this.video?.playbackRate ?? 1;
+    return this.media?.playbackRate ?? 1;
   }
 
   set playbackRate(val) {
-    if (this.video) {
-      this.video.playbackRate = Number(val);
+    if (this.media) {
+      this.media.playbackRate = Number(val);
     }
   }
 
@@ -306,7 +306,7 @@ class VideoApiElement extends HTMLElement {
 }
 
 function getVideoAttribute(el: VideoApiElement, name: string) {
-  return el.video ? el.video.getAttribute(name) : el.getAttribute(name);
+  return el.media ? el.media.getAttribute(name) : el.getAttribute(name);
 }
 
 export default VideoApiElement;

--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -1,4 +1,5 @@
 import type MuxVideoElement from '@mux-elements/mux-video';
+import * as logger from './logger';
 
 const AllowedVideoAttributes = {
   AUTOPLAY: 'autoplay',
@@ -145,6 +146,14 @@ class VideoApiElement extends HTMLElement {
 
   get media(): MuxVideoElement | null | undefined {
     return this.shadowRoot?.querySelector('mux-video');
+  }
+
+  /**
+   * @deprecated please use .media instead
+   */
+  get video(): MuxVideoElement | null | undefined {
+    logger.warn('<mux-player>.video is deprecated, please use .media instead');
+    return this.media;
   }
 
   get hasPlayed() {

--- a/packages/mux-player/test/errors.test.js
+++ b/packages/mux-player/test/errors.test.js
@@ -15,7 +15,7 @@ describe('errors', () => {
       fired = true;
     });
 
-    player.video.dispatchEvent(
+    player.media.dispatchEvent(
       new CustomEvent('error', {
         detail: { code: 0, data: {} },
       })
@@ -36,7 +36,7 @@ describe('errors', () => {
       fired = true;
     });
 
-    player.video.dispatchEvent(
+    player.media.dispatchEvent(
       new CustomEvent('error', {
         detail: { code: MediaError.MEDIA_ERR_DECODE, fatal: true },
       })

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -76,7 +76,7 @@ describe('<mux-player>', () => {
     const player = await fixture(`<mux-player
       autoplay
     ></mux-player>`);
-    const muxVideo = player.video;
+    const muxVideo = player.media;
 
     assert.equal(player.autoplay, true);
     assert.equal(muxVideo.autoplay, true);
@@ -93,7 +93,7 @@ describe('<mux-player>', () => {
     const player = await fixture(`<mux-player
       muted
     ></mux-player>`);
-    const muxVideo = player.video;
+    const muxVideo = player.media;
 
     assert.equal(player.muted, true);
     assert.equal(muxVideo.muted, true);
@@ -110,7 +110,7 @@ describe('<mux-player>', () => {
   //   const player = await fixture(`<mux-player
   //     playsinline
   //   ></mux-player>`);
-  //   const muxVideo = player.video;
+  //   const muxVideo = player.media;
 
   //   assert.equal(player.playsInline, true);
   //   assert.equal(muxVideo.playsInline, true);
@@ -134,7 +134,7 @@ describe('<mux-player>', () => {
     const player = await fixture(`<mux-player
       loop
     ></mux-player>`);
-    const muxVideo = player.video;
+    const muxVideo = player.media;
 
     assert.equal(player.loop, true);
     assert.equal(muxVideo.loop, true);
@@ -151,7 +151,7 @@ describe('<mux-player>', () => {
   //   const player = await fixture(`<mux-player
   //     crossorigin="anonymous"
   //   ></mux-player>`);
-  //   const muxVideo = player.video;
+  //   const muxVideo = player.media;
 
   //   assert.equal(player.crossOrigin, "anonymous");
   //   assert.equal(muxVideo.crossOrigin, "anonymous");
@@ -179,7 +179,7 @@ describe('<mux-player>', () => {
     const player = await fixture(`<mux-player
       preload="metadata"
     ></mux-player>`);
-    const muxVideo = player.video;
+    const muxVideo = player.media;
 
     assert.equal(player.preload, 'metadata');
     assert.equal(muxVideo.preload, 'metadata');
@@ -196,7 +196,7 @@ describe('<mux-player>', () => {
     const player = await fixture(`<mux-player
       poster="https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=0"
     ></mux-player>`);
-    const muxVideo = player.video;
+    const muxVideo = player.media;
 
     assert.equal(
       player.poster,
@@ -230,7 +230,7 @@ describe('<mux-player>', () => {
     const player = await fixture(`<mux-player
       src="https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8"
     ></mux-player>`);
-    const muxVideo = player.video;
+    const muxVideo = player.media;
 
     assert.equal(player.src, 'https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8');
     assert.equal(muxVideo.src, 'https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8');
@@ -261,7 +261,7 @@ describe('<mux-player>', () => {
       metadata-viewer-user-id="${viewer_user_id}"
     ></mux-player>`);
 
-    const actual = player.video.metadata;
+    const actual = player.media.metadata;
     const expected = { video_id, video_title, viewer_user_id };
     assert.include(actual, expected, 'has expected metadata entries from attrs');
   });
@@ -273,7 +273,7 @@ describe('<mux-player>', () => {
       muted
     ></mux-player>`);
 
-    const muxVideo = player.video;
+    const muxVideo = player.media;
     const nativeVideo = muxVideo.shadowRoot.querySelector('video');
 
     assert(player.muted, 'player.muted is true');
@@ -302,7 +302,7 @@ describe('<mux-player>', () => {
 
     assert.equal(player.getAttribute('volume'), '0.4');
 
-    const muxVideo = player.video;
+    const muxVideo = player.media;
     const nativeVideo = muxVideo.shadowRoot.querySelector('video');
 
     assert.equal(player.volume, 0.4, 'player.volume is 0.4');
@@ -325,7 +325,7 @@ describe('<mux-player>', () => {
 
     assert.equal(player.getAttribute('playbackrate'), '2');
 
-    const muxVideo = player.video;
+    const muxVideo = player.media;
     const nativeVideo = muxVideo.shadowRoot.querySelector('video');
 
     assert.equal(player.playbackRate, 2, 'player.playbackRate is 2');
@@ -349,7 +349,7 @@ describe('<mux-player>', () => {
       storyboard-token="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE5NjE2MDE3NzcsImF1ZCI6InMiLCJzdWIiOiJib3MyYlBWM3FiRmdwVlBhUTkwMFhkNVVjZE02V1hUbXowMldaU3owMW5KMDB0WSJ9.aVd0dsOJUVeQko3BWd9YEhL41Eytf_ZfaBeNzHSSUqU_gREa_jJEVTlRfuiE4g71cKJLSiVTKP7f-F7Txh6DlL8E2SkonfIPB2H0f_3DQxYLso2E8qI4zuJkyxKORbQFLAEB_vSE-2lMbrHXfdpQhv6SrVyu6di9ku0LpFpoyz-_7fVJICr8nhlsqOGt66AYcaa99TXoZ582FWzBaePmWw-WWKYsLvtNjLS9UoxbdVaBRwNylohvhh-i1Y9dNilyNooJ7O8Cj4GuMjeh1pCj0BOrGagxrWrswm3HjUVNUqFq5JCWnJCxgjjwiV4RLZg_4z7gkBXyX7H2-i1dKA3Cpw"
     ></mux-player>`);
 
-    const muxVideo = player.video;
+    const muxVideo = player.media;
     const storyboardTrack = muxVideo.shadowRoot.querySelector("track[label='thumbnails']");
 
     assert.equal(

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -94,7 +94,7 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
     this.__playerSoftwareVersion = value;
   }
 
-  get hls() {
+  get _hls() {
     return this.__hls;
   }
 
@@ -304,7 +304,7 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
   // play() {
   //   if (this.readyState === 0 && this.networkState < 2) {
   //     this.load();
-  //     this.hls.on(Hls.Events.MANIFEST_PARSED,function() {
+  //     this._hls.on(Hls.Events.MANIFEST_PARSED,function() {
   //     video.play();
   //
   //     return this.nativeEl.play();
@@ -350,8 +350,8 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
             'Cannot toggle debug mode of mux data after initialization. Make sure you set all metadata to override before setting the src.'
           );
         }
-        if (!!this.hls) {
-          this.hls.config.debug = debug;
+        if (!!this._hls) {
+          this._hls.config.debug = debug;
         }
         break;
       case Attributes.METADATA_URL:

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -94,6 +94,14 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
     this.__playerSoftwareVersion = value;
   }
 
+  /**
+   * @deprecated please use ._hls instead
+   */
+  get hls() {
+    console.warn('<mux-video>.hls is deprecated, please use ._hls instead');
+    return this._hls;
+  }
+
   get _hls() {
     return this.__hls;
   }


### PR DESCRIPTION
With this PR, the recommended approach going forward for getting `mux-video` from `mux-player` is via `.media`. `.video` is still available for backwards compatibility.
The `.hls` property got renamed to `_hls` to discourage its use outside of elements.