### PR TITLE
fix(playback-core): implement track/cue management in playback-core

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -4,6 +4,7 @@ import mux, { Options } from 'mux-embed';
 import Hls, { HlsConfig } from 'hls.js';
 import { AutoplayTypes, setupAutoplay } from './autoplay';
 import { MediaError } from './errors';
+import { setupTracks } from './tracks';
 import { isKeyOf } from './util';
 import type { Autoplay, UpdateAutoplay } from './autoplay';
 
@@ -243,31 +244,6 @@ export const setupMux = (
   }
 };
 
-export const createTextTrack = (
-  mediaEl: HTMLMediaElement,
-  kind: TextTrackKind,
-  label: string,
-  lang?: string,
-  id?: string
-): TextTrack | undefined => {
-  if (!mediaEl) {
-    return;
-  }
-  const trackEl = document.createElement('track');
-  trackEl.kind = kind;
-  trackEl.label = label;
-  if (lang) {
-    trackEl.srclang = lang;
-  }
-  if (id) {
-    trackEl.id = id;
-  }
-  trackEl.track.mode = 'disabled';
-  mediaEl.appendChild(trackEl);
-  trackEl.addEventListener('cuechange', console.log.bind(null, 'cue change', id));
-  return trackEl.track;
-};
-
 export const loadMedia = (
   props: Partial<Pick<MuxMediaProps, 'preferMse' | 'src' | 'type' | 'startTime' | 'streamType' | 'autoplay'>>,
   mediaEl?: HTMLMediaElement | null,
@@ -359,90 +335,8 @@ export const loadMedia = (
         })
       );
     });
-    hls.on(Hls.Events.NON_NATIVE_TEXT_TRACKS_FOUND, (_type, { tracks }) => {
-      tracks.forEach((trackObj) => {
-        const baseTrackObj = trackObj.subtitleTrack ?? trackObj.closedCaptions;
-        const idx = hls.subtitleTracks.findIndex(({ lang, name, type }) => {
-          return lang == baseTrackObj?.lang && name === trackObj.label && type.toLowerCase() === trackObj.kind;
-        });
-        createTextTrack(
-          mediaEl,
-          trackObj.kind as TextTrackKind,
-          trackObj.label,
-          baseTrackObj?.lang,
-          `${trackObj.kind}${idx}`
-        );
-      });
-    });
-    hls.on(Hls.Events.CUES_PARSED, (_type, { track, type, cues }) => {
-      const textTrack: TextTrack = Array.prototype.find.call(mediaEl.textTracks, (textTrack) => {
-        return textTrack.kind === type && textTrack.id === track;
-      });
-      if (!textTrack) return;
-      const disabled = textTrack.mode === 'disabled';
-      if (disabled) {
-        textTrack.mode = 'hidden';
-      }
-      cues.forEach((cue: VTTCue) => {
-        if (textTrack.cues?.getCueById(cue.id)) return;
-        textTrack.addCue(cue);
-      });
-      if (disabled) {
-        textTrack.mode = 'disabled';
-      }
-    });
-    const changeHandler = () => {
-      const showingTrack = Array.prototype.find.call(mediaEl.textTracks, (textTrack: TextTrack) => {
-        return textTrack.id && textTrack.mode === 'showing' && ['subtitles', 'captions'].includes(textTrack.kind);
-      }) as TextTrack;
-      if (
-        showingTrack &&
-        (hls.subtitleTrack < 0 ||
-          showingTrack?.id !== `${hls.subtitleTracks[hls.subtitleTrack].type.toLowerCase()}${hls.subtitleTrack}`)
-      ) {
-        const idx = hls.subtitleTracks.findIndex(({ lang, name, type }) => {
-          return (
-            lang == showingTrack.language && name === showingTrack.label && type.toLowerCase() === showingTrack.kind
-          );
-        });
-        hls.subtitleTrack = idx;
-      }
-    };
-    mediaEl.textTracks.addEventListener('change', changeHandler);
-    hls.on(Hls.Events.DESTROYING, () => {
-      const trackEls = mediaEl.querySelectorAll('track');
-      Array.prototype.forEach.call(trackEls, (trackEl: HTMLTrackElement) => {
-        if (!(trackEl.id && ['subtitles', 'captions'].includes(trackEl.kind))) return;
-        if (!hls.subtitleTracks.some(({ type }, idx) => trackEl.id === `${type.toLowerCase()}${idx}`)) return;
-        mediaEl.removeChild(trackEl);
-      });
-    });
 
-    const forceHiddenThumbnails = () => {
-      // Keeping this a forEach in case we want to expand the scope of this.
-      Array.from(mediaEl.textTracks).forEach((track) => {
-        if (['subtitles', 'caption'].includes(track.kind)) return;
-        if (track.label !== 'thumbnails') return;
-        if (!track.cues?.length) {
-          const trackEl = mediaEl.querySelector('track[label="thumbnails"]') as HTMLTrackElement;
-          // Force a reload of the cues if they've been removed
-          const src = trackEl?.getAttribute('src') ?? '';
-          trackEl?.removeAttribute('src');
-          setTimeout(() => {
-            trackEl?.setAttribute('src', src);
-          }, 0);
-        }
-        // Force hidden mode if it's not hidden
-        if (track.mode !== 'hidden') {
-          track.mode = 'hidden';
-        }
-      });
-    };
-
-    // hls.js will forcibly clear all cues from tracks on manifest loads or media attaches.
-    // This ensures that we re-load them after it's done that.
-    hls.once(Hls.Events.MANIFEST_LOADED, forceHiddenThumbnails);
-    hls.once(Hls.Events.MEDIA_ATTACHED, forceHiddenThumbnails);
+    setupTracks(mediaEl, hls);
 
     switch (mediaEl.preload) {
       case 'none':

--- a/packages/playback-core/src/tracks.ts
+++ b/packages/playback-core/src/tracks.ts
@@ -1,0 +1,132 @@
+import Hls from 'hls.js';
+import type { MediaPlaylist } from 'hls.js';
+
+export function setupTracks(
+  mediaEl: HTMLMediaElement,
+  hls: Pick<Hls, 'on' | 'once' | 'subtitleTracks' | 'subtitleTrack'>
+) {
+  hls.on(Hls.Events.NON_NATIVE_TEXT_TRACKS_FOUND, (_type, { tracks }) => {
+    tracks.forEach((trackObj) => {
+      const baseTrackObj = trackObj.subtitleTrack ?? trackObj.closedCaptions;
+      const idx = hls.subtitleTracks.findIndex(({ lang, name, type }) => {
+        return lang == baseTrackObj?.lang && name === trackObj.label && type.toLowerCase() === trackObj.kind;
+      });
+
+      createTextTrack(
+        mediaEl,
+        trackObj.kind as TextTrackKind,
+        trackObj.label,
+        baseTrackObj?.lang,
+        `${trackObj.kind}${idx}`
+      );
+    });
+  });
+
+  const changeHandler = () => {
+    if (!hls.subtitleTracks.length) return;
+
+    const showingTrack = Array.from(mediaEl.textTracks).find((textTrack) => {
+      return textTrack.id && textTrack.mode === 'showing' && ['subtitles', 'captions'].includes(textTrack.kind);
+    });
+
+    // If hls.subtitleTrack is -1 or its id changed compared to the one that is showing load the new subtitle track.
+    const hlsTrackId = `${hls.subtitleTracks[hls.subtitleTrack]?.type.toLowerCase()}${hls.subtitleTrack}`;
+    if (showingTrack && (hls.subtitleTrack < 0 || showingTrack?.id !== hlsTrackId)) {
+      const idx = hls.subtitleTracks.findIndex(({ lang, name, type }) => {
+        return lang == showingTrack.language && name === showingTrack.label && type.toLowerCase() === showingTrack.kind;
+      });
+      // After the subtitleTrack is set here, hls.js will load the playlist and CUES_PARSED events will be fired below.
+      hls.subtitleTrack = idx;
+    }
+
+    if (showingTrack && showingTrack?.id === hlsTrackId) {
+      // Refresh the cues after a texttrack mode change to fix a Chrome bug causing the captions not to render.
+      if (showingTrack.cues) {
+        Array.from(showingTrack.cues).forEach((cue) => {
+          showingTrack.addCue(cue);
+        });
+      }
+    }
+  };
+
+  mediaEl.textTracks.addEventListener('change', changeHandler);
+
+  hls.on(Hls.Events.CUES_PARSED, (_type, { track, type, cues }) => {
+    const textTrack = mediaEl.textTracks.getTrackById(track);
+    if (!textTrack) return;
+
+    const disabled = textTrack.mode === 'disabled';
+    if (disabled) {
+      textTrack.mode = 'hidden';
+    }
+
+    cues.forEach((cue: VTTCue) => {
+      if (textTrack.cues?.getCueById(cue.id)) return;
+      textTrack.addCue(cue);
+    });
+
+    if (disabled) {
+      textTrack.mode = 'disabled';
+    }
+  });
+
+  hls.on(Hls.Events.DESTROYING, () => {
+    mediaEl.textTracks.removeEventListener('change', changeHandler);
+
+    const trackEls = mediaEl.querySelectorAll('track');
+    trackEls.forEach((trackEl) => {
+      if (!(trackEl.id && ['subtitles', 'captions'].includes(trackEl.kind))) return;
+      if (!hls.subtitleTracks.some(({ type }, idx) => trackEl.id === `${type.toLowerCase()}${idx}`)) return;
+
+      mediaEl.removeChild(trackEl);
+    });
+  });
+
+  const forceHiddenThumbnails = () => {
+    // Keeping this a forEach in case we want to expand the scope of this.
+    Array.from(mediaEl.textTracks).forEach((track) => {
+      if (['subtitles', 'caption'].includes(track.kind)) return;
+      if (track.label !== 'thumbnails') return;
+      if (!track.cues?.length) {
+        const trackEl = mediaEl.querySelector('track[label="thumbnails"]');
+        // Force a reload of the cues if they've been removed
+        const src = trackEl?.getAttribute('src') ?? '';
+        trackEl?.removeAttribute('src');
+        setTimeout(() => {
+          trackEl?.setAttribute('src', src);
+        }, 0);
+      }
+      // Force hidden mode if it's not hidden
+      if (track.mode !== 'hidden') {
+        track.mode = 'hidden';
+      }
+    });
+  };
+
+  // hls.js will forcibly clear all cues from tracks on manifest loads or media attaches.
+  // This ensures that we re-load them after it's done that.
+  hls.once(Hls.Events.MANIFEST_LOADED, forceHiddenThumbnails);
+  hls.once(Hls.Events.MEDIA_ATTACHED, forceHiddenThumbnails);
+}
+
+function createTextTrack(
+  mediaEl: HTMLMediaElement,
+  kind: TextTrackKind,
+  label: string,
+  lang?: string,
+  id?: string
+): TextTrack | undefined {
+  const trackEl = document.createElement('track');
+  trackEl.kind = kind;
+  trackEl.label = label;
+  if (lang) {
+    // This attribute must be present if the element's kind attribute is in the subtitles state.
+    trackEl.srclang = lang;
+  }
+  if (id) {
+    trackEl.id = id;
+  }
+  trackEl.track.mode = 'disabled';
+  mediaEl.appendChild(trackEl);
+  return trackEl.track;
+}


### PR DESCRIPTION
- This change fixes the issue of removing text tracks when switching playback-id's 
- Fixes a weird bug in Chrome that happens when toggling the textTrack disabled -> showing and captions are not rendered anymore. Re-adding the cues to the textTrack does the trick.

~Hls.js also had strange behavior after toggling to disabled the getters `hls.subtitleTrack` and `hls.subtiteTracks` were not correct anymore, they changed to `-1` and an empty array respectively. Added a fix for that by using the events Hls.js provides and keeping track of state in playback-core.~

^^ was caused by the change event handler not being cleaned up. this is fixed now.