### PR TITLE
refactor: don't re-export playback-core items

### DIFF
--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -314,6 +314,4 @@ if (!globalThis.customElements.get('mux-audio')) {
   globalThis.MuxAudioElement = MuxAudioElement;
 }
 
-export { PlaybackEngine, PlaybackEngine as Hls, ExtensionMimeTypeMap as MimeTypes };
-
 export default MuxAudioElement;

--- a/packages/mux-player/src/errors.ts
+++ b/packages/mux-player/src/errors.ts
@@ -1,4 +1,4 @@
-import { MediaError } from '@mux-elements/mux-video';
+import { MediaError } from '@mux-elements/playback-core';
 // @ts-ignore
 import lang from '../lang/en.json';
 import { i18n, parseJwt } from './utils';

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -1,8 +1,8 @@
 // import playback-core here to make sure that the polyfill is loaded
-import '@mux-elements/playback-core';
+import { MediaError } from '@mux-elements/playback-core';
 // @ts-ignore
 import { MediaController } from 'media-chrome';
-import MuxVideoElement, { MediaError } from '@mux-elements/mux-video';
+import MuxVideoElement from '@mux-elements/mux-video';
 import type { Metadata } from '@mux-elements/playback-core';
 import MediaThemeMux from './media-theme-mux/media-theme-mux';
 import { StreamTypes } from './constants';
@@ -22,7 +22,6 @@ import { toNumberOrUndefined, i18n, parseJwt, containsComposedNode } from './uti
 import * as logger from './logger';
 import type { MuxTemplateProps } from './types';
 
-export { MediaError };
 export type Tokens = {
   playback?: string;
   thumbnail?: string;
@@ -762,7 +761,7 @@ class MuxPlayerElement extends VideoApiElement {
   }
 }
 
-export function getVideoAttribute(el: MuxPlayerElement, name: string) {
+function getVideoAttribute(el: MuxPlayerElement, name: string) {
   return el.video ? el.video.getAttribute(name) : el.getAttribute(name);
 }
 

--- a/packages/mux-player/test/errors.test.js
+++ b/packages/mux-player/test/errors.test.js
@@ -1,5 +1,6 @@
 import { fixture, assert } from '@open-wc/testing';
-import { MediaError } from '../src/index.ts';
+import '../src/index.ts';
+import { MediaError } from '@mux-elements/playback-core';
 import { getErrorLogs } from '../src/errors.ts';
 
 describe('errors', () => {
@@ -22,6 +23,8 @@ describe('errors', () => {
     );
 
     assert(fired !== true, 'the error handler was not fired');
+
+    return Promise.resolve();
   });
 
   it('does propagate fatal error events', async function () {
@@ -43,6 +46,8 @@ describe('errors', () => {
     );
 
     assert(fired === true, 'the error handler was fired');
+
+    return Promise.resolve();
   });
 
   it('default message for MediaError.MEDIA_ERR_ABORTED', function () {

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -403,6 +403,4 @@ if (!globalThis.customElements.get('mux-video')) {
   globalThis.MuxVideoElement = MuxVideoElement;
 }
 
-export { PlaybackEngine, PlaybackEngine as Hls, ExtensionMimeTypeMap as MimeTypes, MediaError };
-
 export default MuxVideoElement;


### PR DESCRIPTION
This is a follow-up from #191. One of the issues is that older bundlers have some trouble with esm that does both default export and named exports. In addition, we no longer need to re-export some of these since we can import directly from playback-core without worrying about duplication of modules in bundles.

This doesn't necessarily have to make it in, particularly since it's a potentially breaking change, though, unlikely that anyone depends on these changes.

One thing that this PR doesn't address is the fact that native CJS users still need to use `require('@mux-elements/mux-player).default`. Unfortunately, while we can fix the actual export, fixing the types so that they work for both esm and cjs without any more work is complicated. We should consider whether we should be doing default exports and if we should only do named exports.