### PR TITLE
fix: fullscreen controls layout

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -19,6 +19,7 @@
         display: block;
         aspect-ratio: 16 / 9;
         background-color: #000;
+        line-height: 0;
       }
 
       .buttons {
@@ -72,14 +73,6 @@
 
     <script>
       let player = document.querySelector("mux-player");
-
-      player.addEventListener('loadedmetadata', (e) => {
-        console.log(111, e)
-      });
-
-      document.addEventListener('play', (e) => {
-        console.log(222, e);
-      }, { capture: true });
 
       document
         .querySelector(".dialog-show-btn")

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -104,7 +104,7 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
     forwardSeekOffset: el.forwardSeekOffset,
     backwardSeekOffset: el.backwardSeekOffset,
     defaultHiddenCaptions: el.defaultHiddenCaptions,
-    playerSize: getPlayerSize(el),
+    playerSize: getPlayerSize(el.mediaController ?? el),
     hasCaptions: !!getCcSubTracks(el).length,
     // NOTE: In order to guarantee all expected metadata props are set "from the outside" when used
     // and to guarantee they'll all be set *before* the playback id is set, using attr values here (CJP)
@@ -218,14 +218,14 @@ class MuxPlayerElement extends VideoApiElement {
   }
 
   #renderChrome() {
-    if (this.#state.playerSize != getPlayerSize(this)) {
-      this.#setState({ playerSize: getPlayerSize(this) });
+    if (this.#state.playerSize != getPlayerSize(this.mediaController ?? this)) {
+      this.#setState({ playerSize: getPlayerSize(this.mediaController ?? this) });
     }
   }
 
   #initResizing() {
     this.#resizeObserver = new ResizeObserver(() => this.#renderChrome());
-    this.#resizeObserver.observe(this);
+    this.#resizeObserver.observe(this.mediaController ?? this);
   }
 
   #deinitResizing() {


### PR DESCRIPTION
Fixes an issue where the controls layout could be incorrect in fullscreen if the mux-player embed was small enough.

The controls mode was dependent on the mux-player dimensions when it should be dependent on the media-controller because this is the element that actually goes fullscreen.

