### PR TITLE
fix: clear state on other src related attrs

### DIFF
--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -48,6 +48,10 @@ function getPlayerSize(el: Element) {
     : MediaChromeSizes.LG;
 }
 
+const VideoAttributes = {
+  SRC: 'src',
+};
+
 const MuxVideoAttributes = {
   ENV_KEY: 'env-key',
   DEBUG: 'debug',
@@ -451,7 +455,13 @@ class MuxPlayerElement extends VideoApiElement {
   attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string) {
     super.attributeChangedCallback(attrName, oldValue, newValue);
 
-    if (attrName === MuxVideoAttributes.PLAYBACK_ID && oldValue !== newValue) {
+    const shouldClearState = [
+      MuxVideoAttributes.PLAYBACK_ID,
+      VideoAttributes.SRC,
+      PlayerAttributes.PLAYBACK_TOKEN,
+    ].includes(attrName);
+
+    if (shouldClearState && oldValue !== newValue) {
       this.#state = { ...this.#state, ...initialState };
     }
 

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -411,6 +411,28 @@ describe('<mux-player> playbackId transitions', () => {
 
     assert.equal(player.shadowRoot.querySelector('mxp-dialog h3'), null);
   });
+
+  it('loads the new src and clears dialog state', async function () {
+    const player = await fixture(`<mux-player
+      src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8"
+      stream-type="on-demand"
+      muted
+    ></mux-player>`);
+
+    assert.equal(player.src, 'https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8');
+
+    player.dispatchEvent(
+      new CustomEvent('error', {
+        detail: { code: MediaError.MEDIA_ERR_NETWORK },
+      })
+    );
+
+    assert.equal(player.shadowRoot.querySelector('mxp-dialog h3').textContent, 'Network Error');
+
+    player.src = 'https://stream.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE.m3u8';
+
+    assert.equal(player.shadowRoot.querySelector('mxp-dialog h3'), null);
+  });
 });
 
 describe('seek to live behaviors', function () {


### PR DESCRIPTION
Clears state on `src` and `playback-token` changes