### PR TITLE
fix: fix 3x init of playback-core if `src` used

### DIFF
--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -302,14 +302,6 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
   disconnectedCallback() {
     this.unload();
   }
-
-  /** @TODO Followup - investigate why this is necessary (attributeChanged not invoked on initial load when setting playback-id) (CJP) */
-  connectedCallback() {
-    // Only auto-load if we have a src
-    if (this.src) {
-      this.load();
-    }
-  }
 }
 
 type MuxAudioElementType = typeof MuxAudioElement;

--- a/packages/mux-video/src/CustomVideoElement.js
+++ b/packages/mux-video/src/CustomVideoElement.js
@@ -39,9 +39,6 @@ const template = document.createElement('template');
 template.innerHTML = `
 <style>
   :host {
-    /* Supposed to reset styles. Need to understand the specific effects more */
-    all: initial;
-
     /* display:inline (like the native el) makes it so you can't fill
       the container with the native el */
     display: inline-block;
@@ -75,8 +72,10 @@ class CustomVideoElement extends HTMLElement {
     const nativeEl = (this.nativeEl = this.shadowRoot.querySelector('video'));
 
     // Initialize all the attribute properties
-    Array.prototype.forEach.call(this.attributes, (attrNode) => {
-      this.attributeChangedCallback(attrNode.name, null, attrNode.value);
+    // This is required before attributeChangedCallback is called after construction
+    // so the initial state of all the attributes are forwarded to the native element.
+    Array.from(this.attributes).forEach((attrNode) => {
+      this.forwardAttribute(attrNode.name, null, attrNode.value);
     });
 
     // Neither Chrome or Firefox support setting the muted attribute
@@ -141,6 +140,10 @@ class CustomVideoElement extends HTMLElement {
   // We need to handle sub-class custom attributes differently from
   // attrs meant to be passed to the internal native el.
   attributeChangedCallback(attrName, oldValue, newValue) {
+    this.forwardAttribute(attrName, oldValue, newValue);
+  }
+
+  forwardAttribute(attrName, oldValue, newValue) {
     // Find the matching prop for custom attributes
     const ownProps = Object.getOwnPropertyNames(Object.getPrototypeOf(this));
     const propName = arrayFindAnyCase(ownProps, attrName);

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -359,7 +359,8 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
         if (newValue === oldValue) {
           break;
         }
-        this.__updateAutoplay?.(newValue);
+        /** In case newValue is an empty string or null, use this.autoplay which translates to booleans (WL) */
+        this.__updateAutoplay?.(this.autoplay);
         break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */
@@ -394,23 +395,6 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
 
   disconnectedCallback() {
     this.unload();
-  }
-
-  /** @TODO Followup - investigate why this is necessary (attributeChanged not invoked on initial load when setting playback-id) (CJP) */
-  connectedCallback() {
-    // Only auto-load if we have a src
-    if (this.src) {
-      this.load();
-    }
-
-    // NOTE: This was carried over from hls-video-element. Is it needed for an edge case?
-    // Not preloading might require faking the play() promise
-    // so that you can call play(), call load() within that
-    // But wait until MANIFEST_PARSED to actually call play()
-    // on the nativeEl.
-    // if (this.preload === 'auto') {
-    //   this.load();
-    // }
   }
 }
 


### PR DESCRIPTION
Fixes an issue where playback-core was init 3 times on player load.