### PR TITLE
fix: put progress bar above controls & fix secondary color

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -59,7 +59,7 @@
     <mux-player
       stream-type="on-demand"
       playback-id="g65IqSFtWdpGR100c2W8VUHrfIVWTNRen"
-      primary-color="#f97316"
+      primary-color="coral"
       metadata-video-id="video-id-is-dylan"
       metadata-video-title="DID IT WORK DYLAN?????"
       metadata-viewer-user-id="user-id-well-dylan"

--- a/packages/mux-player/src/helpers.ts
+++ b/packages/mux-player/src/helpers.ts
@@ -1,4 +1,4 @@
-import { stylePropsToString, toQuery, camelCase } from './utils';
+import { toQuery, camelCase } from './utils';
 import type MuxPlayerElement from '.';
 import { StreamTypes } from './constants';
 

--- a/packages/mux-player/src/helpers.ts
+++ b/packages/mux-player/src/helpers.ts
@@ -114,29 +114,3 @@ export const isInLiveWindow = (el: MuxPlayerElement) => {
   }
   return false;
 };
-
-export function getChromeStylesFromProps(props: any) {
-  const { primaryColor, secondaryColor, tertiaryColor } = props;
-
-  const primaryColorStyles = primaryColor
-    ? {
-        '--media-icon-color': primaryColor,
-        '--media-range-thumb-background': primaryColor,
-        '--media-range-bar-color': primaryColor,
-        color: primaryColor,
-      }
-    : {};
-
-  const secondaryColorStyles = secondaryColor
-    ? {
-        '--media-background-color': secondaryColor,
-        '--media-control-background': secondaryColor,
-        '--media-control-hover-background': secondaryColor,
-      }
-    : {};
-
-  return stylePropsToString({
-    ...primaryColorStyles,
-    ...secondaryColorStyles,
-  });
-}

--- a/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
+++ b/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
@@ -18,8 +18,6 @@ const MediaChromeSizes = {
   XS: 'extra-small',
 };
 
-const Spacer = () => html`<div class="mxp-spacer"></div>`;
-
 type ThemeMuxTemplateProps = {
   streamType: string;
   playerSize: string;
@@ -127,7 +125,7 @@ const MediaFullscreenButton = () => html`
 export const VodChromeExtraSmall = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar slot="top-chrome">
     ${props.hasCaptions ? MediaCaptionsButton(props) : html``}
-    ${Spacer()}
+    <div class="mxp-spacer"></div>
     ${MediaAirplayButton()}
     ${MediaPipButton()}
   </media-control-bar>
@@ -136,7 +134,7 @@ export const VodChromeExtraSmall = (props: ThemeMuxTemplateProps) => html`
   </div>
   <media-control-bar>
     ${MediaMuteButton()}
-    ${Spacer()}
+    <div class="mxp-spacer"></div>
     ${MediaFullscreenButton()}
   </media-control-bar>
 `;
@@ -158,9 +156,10 @@ export const VodChromeSmall = (props: ThemeMuxTemplateProps) => html`
     <mxp-time-display></mxp-time-display>
     ${MediaMuteButton()}
     <media-volume-range></media-volume-range>
-    ${Spacer()}
+    <div class="mxp-spacer"></div>
     <media-playback-rate-button></media-playback-rate-button>
     ${MediaFullscreenButton()}
+    <div class="mxp-padding-2"></div>
   </media-control-bar>
 `;
 
@@ -177,12 +176,13 @@ export const VodChromeLarge = (props: ThemeMuxTemplateProps) => html`
     <mxp-time-display></mxp-time-display>
     ${MediaMuteButton()}
     <media-volume-range></media-volume-range>
-    ${Spacer()}
+    <div class="mxp-spacer"></div>
     <media-playback-rate-button></media-playback-rate-button>
     ${props.hasCaptions ? MediaCaptionsButton(props) : html``}
     ${MediaAirplayButton()}
     ${MediaPipButton()}
     ${MediaFullscreenButton()}
+    <div class="mxp-padding-2"></div>
   </media-control-bar>
 `;
 
@@ -193,7 +193,7 @@ export const LiveChromeExtraSmall = VodChromeExtraSmall;
 export const LiveChromeSmall = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar slot="top-chrome">
     <slot name="seek-to-live-button"></slot>
-    ${Spacer()}
+    <div class="mxp-spacer"></div>
     ${props.hasCaptions ? MediaCaptionsButton(props) : html``}
     ${MediaAirplayButton()}
     ${MediaPipButton()}
@@ -204,7 +204,7 @@ export const LiveChromeSmall = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar>
     ${MediaMuteButton()}
     <media-volume-range></media-volume-range>
-    ${Spacer()}
+    <div class="mxp-spacer"></div>
     ${MediaFullscreenButton()}
   </media-control-bar>
 `;
@@ -220,7 +220,7 @@ export const LiveChromeLarge = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar>
     ${MediaMuteButton()}
     <media-volume-range></media-volume-range>
-    ${Spacer()}
+    <div class="mxp-spacer"></div>
     ${props.hasCaptions ? MediaCaptionsButton(props) : html``}
     ${MediaAirplayButton()}
     ${MediaPipButton()}

--- a/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
+++ b/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
@@ -153,11 +153,12 @@ export const VodChromeSmall = (props: ThemeMuxTemplateProps) => html`
     ${MediaPlayButton()}
     ${MediaSeekForwardButton(props)}
   </div>
+  <media-time-range></media-time-range>
   <media-control-bar>
-    <media-time-range></media-time-range>
     <mxp-time-display></mxp-time-display>
     ${MediaMuteButton()}
     <media-volume-range></media-volume-range>
+    ${Spacer()}
     <media-playback-rate-button></media-playback-rate-button>
     ${MediaFullscreenButton()}
   </media-control-bar>
@@ -168,14 +169,15 @@ export const VodChromeLarge = (props: ThemeMuxTemplateProps) => html`
   <div slot="centered-chrome" class="mxp-center-controls">
     ${MediaPlayButton()}
   </div>
+  <media-time-range></media-time-range>
   <media-control-bar>
     ${MediaPlayButton()}
     ${MediaSeekBackwardButton(props)}
     ${MediaSeekForwardButton(props)}
-    <media-time-range></media-time-range>
     <mxp-time-display></mxp-time-display>
     ${MediaMuteButton()}
     <media-volume-range></media-volume-range>
+    ${Spacer()}
     <media-playback-rate-button></media-playback-rate-button>
     ${props.hasCaptions ? MediaCaptionsButton(props) : html``}
     ${MediaAirplayButton()}

--- a/packages/mux-player/src/media-theme-mux/styles.css
+++ b/packages/mux-player/src/media-theme-mux/styles.css
@@ -1,4 +1,13 @@
 :host {
+  color: var(--primary-color);
+  --media-icon-color: var(--primary-color);
+  --media-range-thumb-background: var(--primary-color);
+  --media-range-bar-color: var(--primary-color);
+  --media-control-background: var(--secondary-color, transparent);
+  --media-control-hover-background: var(--secondary-color, transparent);
+  --media-time-buffered-color: rgba(255, 255, 255, 0.7);
+  --media-range-track-background-color: rgba(255, 255, 255, 0.5);
+  --media-range-track-border-radius: 3px;
   display: inline-block;
   width: 100%;
   height: 100%;
@@ -17,17 +26,14 @@ media-pip-button[media-pip-unavailable] {
 }
 
 media-controller {
-  --media-control-background: transparent;
-  --media-control-hover-background: transparent;
-  --media-range-track-background-color: rgba(255, 255, 255, 0.5);
-  --media-range-track-border-radius: 3px;
   width: 100%;
   height: 100%;
 }
 
 media-time-range {
+  z-index: 10;
   width: 100%;
-  height: 6px;
+  height: 4px;
 }
 
 media-control-bar {
@@ -50,6 +56,14 @@ media-control-bar :is([role='button'], [role='switch'], button) {
   background-color: var(--media-control-background, rgba(20, 20, 30, 0.7));
 }
 
+/* Add a small space on the right to have the play button and
+ * fullscreen button aligned in relation to the progress bar. */
+.size-large .mxp-padding-2 {
+  width: 2px;
+  height: 100%;
+  background-color: var(--media-control-background, rgba(20, 20, 30, 0.7));
+}
+
 media-controller::part(vertical-layer) {
   transition: background-color 1s;
 }
@@ -60,7 +74,6 @@ media-controller:is([media-paused], :not([user-inactive]))::part(vertical-layer)
 }
 
 .mxp-center-controls {
-  --media-background-color: transparent;
   --media-button-icon-width: 100%;
   --media-button-icon-height: auto;
   pointer-events: none;

--- a/packages/mux-player/src/media-theme-mux/styles.css
+++ b/packages/mux-player/src/media-theme-mux/styles.css
@@ -25,6 +25,11 @@ media-controller {
   height: 100%;
 }
 
+media-time-range {
+  width: 100%;
+  height: 6px;
+}
+
 media-control-bar {
   --media-button-icon-width: 18px;
 }

--- a/packages/mux-player/src/media-theme-mux/styles.css
+++ b/packages/mux-player/src/media-theme-mux/styles.css
@@ -33,7 +33,7 @@ media-controller {
 media-time-range {
   z-index: 10;
   width: 100%;
-  height: 4px;
+  height: 22px;
 }
 
 media-control-bar {

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -1,15 +1,10 @@
 import './media-theme-mux/media-theme-mux';
 import './dialog';
-import {
-  getChromeStylesFromProps,
-  getSrcFromPlaybackId,
-  getPosterURLFromPlaybackId,
-  getStoryboardURLFromPlaybackId,
-} from './helpers';
+import { getSrcFromPlaybackId, getPosterURLFromPlaybackId, getStoryboardURLFromPlaybackId } from './helpers';
 import { html } from './html';
 // @ts-ignore
 import cssStr from './styles.css';
-import { i18n } from './utils';
+import { i18n, stylePropsToString } from './utils';
 
 import type { MuxTemplateProps } from './types';
 import { StreamTypes } from './constants';
@@ -23,7 +18,10 @@ export const template = (props: MuxTemplateProps) => html`
 
 export const content = (props: MuxTemplateProps) => html`
   <media-theme-mux
-    style="${getChromeStylesFromProps(props) ?? false}"
+    style="${stylePropsToString({
+      '--primary-color': props.primaryColor,
+      '--secondary-color': props.secondaryColor,
+    }) ?? false}"
     class="size-${props.playerSize}"
     stream-type="${props.streamType}"
     player-size="${props.playerSize}"

--- a/packages/mux-player/src/utils.ts
+++ b/packages/mux-player/src/utils.ts
@@ -40,6 +40,7 @@ class IntlMessageFormat {
 export function stylePropsToString(props: any) {
   let style = '';
   Object.entries(props).forEach(([key, value]) => {
+    if (value == null) return;
     style += `${kebabCase(key)}: ${value}; `;
   });
   return style ? style.trim() : undefined;


### PR DESCRIPTION
This change puts the progress bar above the controls and fixes the secondary color that broke with the theme change.

Added `--primary-color` and `--secondary-color` vars to the Mux theme.