### PR TITLE
Update README and README_INTERNAL

### DIFF
--- a/README_INTERNAL.md
+++ b/README_INTERNAL.md
@@ -34,5 +34,6 @@ and Github Actions for continuously publishing Mux elements.
 
 - Update stream.new
 - Update the player on docs.mux.com
+- Update the player on mux.com
 - Update the Mux Player guide in the docs (document any new functionality, add release notes at the bottom)
 - Post in #player to let product team know

--- a/packages/mux-player/README.md
+++ b/packages/mux-player/README.md
@@ -44,13 +44,13 @@ require('@mux-elements/mux-player');
 Alternatively, use the CDN hosted version of this package:
 
 ```html
-<script src="https://unpkg.com/@mux-elements/mux-player@0.1.0-beta.4"></script>
+<script src="https://unpkg.com/@mux-elements/mux-player"></script>
 ```
 
 If you are using ECMAScript modules, you can also load the `mux-player.mjs` file with `type=module`:
 
 ```html
-<script type="module" src="https://unpkg.com/@mux-elements/mux-player@0.1.0-beta.4/dist/mux-player.mjs"></script>
+<script type="module" src="https://unpkg.com/@mux-elements/mux-player/dist/mux-player.mjs"></script>
 ```
 
 ## Features and benefits


### PR DESCRIPTION
- Having the version in the unpkg URL is good, but it just falls out of date so easily that I think it's harming us.

The downside is that if someone copy/pasta's this into their app, we will be updating their player when we release new versions without them knowing. There's some risk in that which I don't love, but I think it's better than always showing an old version in the README.