### PR TITLE
fix: stop tracking non-fatal errors in Mux data

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -452,7 +452,8 @@ function handleInternalError(event: Event) {
 
   const mediaEl = event.target as HTMLMediaElement;
   const error = event.detail;
-  if (!error) return;
+  // Prevent tracking non-fatal errors in Mux data.
+  if (!error || !error.fatal) return;
 
   const state = muxMediaState.get(mediaEl);
   if (state) state.error = error;


### PR DESCRIPTION
I forgot to prevent tracking of non-fatal errors in playback-core. this fixes that bug.
this should be the reason that we were seeing an inflated error percentage in Mux data.

however this is not the reason the error dialog was shown, this could only be caused by a "fatal" error as it's gated by a condition
https://github.com/muxinc/elements/blob/705491bafcc86d7b7f37d08faa6a248bfce8a109/packages/mux-player/src/index.ts#L281-L288