### PR TITLE
feat: subtitles for M3U8 playlists, resume session, add cast-button

### DIFF
--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -52,7 +52,7 @@
     "@github/template-parts": "^0.5.3",
     "@mux-elements/mux-video": "0.5.4",
     "@mux-elements/playback-core": "0.5.2",
-    "media-chrome": "0.6.6"
+    "media-chrome": "0.6.7"
   },
   "devDependencies": {
     "@mux-elements/open-process": "0.1.0",

--- a/packages/mux-player/src/helpers.ts
+++ b/packages/mux-player/src/helpers.ts
@@ -80,9 +80,10 @@ export function getCcSubTracks(el: MuxPlayerElement) {
 
 export const getLiveTime = (el: MuxPlayerElement) => {
   const { media } = el;
-  return media?._hls?.liveSyncPosition ?? media?.seekable.length
-    ? media?.seekable.end(media.seekable.length - 1)
-    : undefined;
+  return (
+    media?._hls?.liveSyncPosition ??
+    (media?.seekable.length ? media?.seekable.end(media.seekable.length - 1) : undefined)
+  );
 };
 
 export const seekToLive = (el: MuxPlayerElement) => {

--- a/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
+++ b/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
@@ -158,6 +158,7 @@ export const VodChromeSmall = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar slot="top-chrome" style="justify-content: flex-end;">
     ${props.hasCaptions ? MediaCaptionsButton(props) : html``}
     ${MediaAirplayButton()}
+    <media-cast-button></media-cast-button>
     ${MediaPipButton()}
   </media-control-bar>
   <div slot="centered-chrome" class="mxp-center-controls">
@@ -194,6 +195,7 @@ export const VodChromeLarge = (props: ThemeMuxTemplateProps) => html`
     <media-playback-rate-button></media-playback-rate-button>
     ${props.hasCaptions ? MediaCaptionsButton(props) : html``}
     ${MediaAirplayButton()}
+    <media-cast-button></media-cast-button>
     ${MediaPipButton()}
     ${MediaFullscreenButton()}
     <div class="mxp-padding-2"></div>
@@ -210,6 +212,7 @@ export const LiveChromeSmall = (props: ThemeMuxTemplateProps) => html`
     <div class="mxp-spacer"></div>
     ${props.hasCaptions ? MediaCaptionsButton(props) : html``}
     ${MediaAirplayButton()}
+    <media-cast-button></media-cast-button>
     ${MediaPipButton()}
   </media-control-bar>
   <div slot="centered-chrome" class="mxp-center-controls">
@@ -237,6 +240,7 @@ export const LiveChromeLarge = (props: ThemeMuxTemplateProps) => html`
     <div class="mxp-spacer"></div>
     ${props.hasCaptions ? MediaCaptionsButton(props) : html``}
     ${MediaAirplayButton()}
+    <media-cast-button></media-cast-button>
     ${MediaPipButton()}
     ${MediaFullscreenButton()}
   </media-control-bar>
@@ -250,6 +254,7 @@ export const DvrChromeSmall = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar slot="top-chrome" style="justify-content: flex-end;">
     ${props.hasCaptions ? MediaCaptionsButton(props) : html``}
     ${MediaAirplayButton()}
+    <media-cast-button></media-cast-button>
     ${MediaPipButton()}
   </media-control-bar>
   <div slot="centered-chrome" class="mxp-center-controls">
@@ -284,6 +289,7 @@ export const DvrChromeLarge = (props: ThemeMuxTemplateProps) => html`
     <div class="mxp-spacer"></div>
     ${props.hasCaptions ? MediaCaptionsButton(props) : html``}
     ${MediaAirplayButton()}
+    <media-cast-button></media-cast-button>
     ${MediaPipButton()}
     ${MediaFullscreenButton()}
     <div class="mxp-padding-2"></div>

--- a/shared/castable-video/castable-video.js
+++ b/shared/castable-video/castable-video.js
@@ -206,7 +206,7 @@ const CastableVideoMixin = (superclass) =>
          * it would be possible to pass this unique id w/ `LoadRequest.customData`
          * and verify against CastableVideo.#currentMedia.customData below.
          */
-        if (this.castSrc === CastableVideo.#currentMedia.media.contentId) {
+        if (this.castSrc === CastableVideo.#currentMedia?.media.contentId) {
           CastableVideo.#castElement = this;
 
           Object.entries(this.#remoteListeners).forEach(([event, listener]) => {

--- a/shared/castable-video/package.json
+++ b/shared/castable-video/package.json
@@ -26,5 +26,9 @@
       "ecmaVersion": 2022,
       "sourceType": "module"
     }
+  },
+  "devDependencies": {
+    "eslint": "^7.11.0",
+    "prettier": "^2.3.2"
   }
 }

--- a/shared/castable-video/package.json
+++ b/shared/castable-video/package.json
@@ -12,5 +12,19 @@
   "repository": "https://github.com/muxinc/elements",
   "author": "Mux, Inc.",
   "license": "MIT",
-  "private": true
+  "private": true,
+  "eslintConfig": {
+    "env": {
+      "browser": true,
+      "es6": true,
+      "node": true
+    },
+    "extends": [
+      "eslint:recommended"
+    ],
+    "parserOptions": {
+      "ecmaVersion": 2022,
+      "sourceType": "module"
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9816,10 +9816,10 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-media-chrome@0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-0.6.6.tgz#6e14442c68cd6ca2c5d2f0e2b48791509fa5e62d"
-  integrity sha512-2xlYbwR4dddVtFdJK40FiXAXlYsKtyWTNbnC+mGrtKGk3AvdIbXME8F8Z6Cvlv2iVnLyYsEuugc8q8j2uFYrWQ==
+media-chrome@0.6.7:
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-0.6.7.tgz#d8150442697583605c2b2aaccd8d075929f46319"
+  integrity sha512-ebL8uuiM4O9LG1ZHF65OIVruvEj9GWTTgrsoQWTeWbGml+/Bn0WnSy5J1dRXrD3VzlSNsItoV+A1zD6bWjZ6bw==
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
This change adds support for text tracks loaded from M3U8 and simplifies the logic around text tracks.

The trackId's are now always retrieved from the remote player and the remote tracks matched with the local tracks.

- [x] tested changing sources (playbackId's) while casting and works
- [x] test wifi on/off toggling
- [x] fix resuming the cast session when the session persists after browser refresh
- [x] just noticed a bug when resuming a session the loading spinner keeps spinning! not locally, only on Vercel

### Non-blocking enhancements

- [ ] POLISH - ideally the mouseover shadow overlay stays visible while casting AND maybe the cast receiver name can be shown while casting
- [ ] currently when starting to cast playback-core (hls.js) will still start loading segments, should it be disabled while casting?
- [ ] the possible edge case @gkatsev mentioned that no local `<track>` corresponds with the remote tracks and toggling tracks off and on would break

