### PR TITLE
ci: add canary deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ steps.get-versions.outputs.node }}
+          # this line is required for the setup-node action to be able to run the npm publish below.
+          registry-url: 'https://registry.npmjs.org'
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn build:packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn build:packages
+      - run: yarn deploy:canary --yes
+        if: ${{ github.ref == 'refs/heads/main' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build": "lerna run build",
     "prepare": "husky install",
     "deploy": "lerna publish from-package --no-private --no-verify-access --conventional-commits --conventional-prerelease=@mux-elements/mux-player,@mux-elements/mux-player-react",
+    "deploy:canary": "lerna publish --canary --preid canary --dist-tag canary --no-private --no-verify-access",
     "version:update": "lerna version --exact --no-private --conventional-commits --conventional-prerelease=@mux-elements/mux-player,@mux-elements/mux-player-react",
     "create-release-notes": "lerna run create-release-notes --scope @mux-elements/*"
   },


### PR DESCRIPTION
this change will publish canary versions automatically when things get merged on the main branch.

e.g.

```
 - @mux-elements/mux-audio => 0.5.6-canary.0+df61ba9
 - @mux-elements/mux-player-react => 0.1.0-canary.0+df61ba9
 - @mux-elements/mux-player => 0.1.0-canary.0+df61ba9
 - @mux-elements/mux-video-react => 0.4.12-canary.0+df61ba9
 - @mux-elements/mux-video => 0.6.2-canary.0+df61ba9
 - @mux-elements/playback-core => 0.6.1-canary.0+df61ba9
```