### PR TITLE
ci: add SHA hash to canary versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "lerna run build",
     "prepare": "husky install",
     "deploy": "lerna publish from-package --no-private --no-verify-access --conventional-commits --conventional-prerelease=@mux-elements/mux-player,@mux-elements/mux-player-react",
-    "deploy:canary": "lerna publish --canary --preid canary --dist-tag canary --no-private --no-verify-access",
+    "deploy:canary": "lerna run deploy:canary --scope @mux-elements/*",
     "version:update": "lerna version --exact --no-private --conventional-commits --conventional-prerelease=@mux-elements/mux-player,@mux-elements/mux-player-react",
     "create-release-notes": "lerna run create-release-notes --scope @mux-elements/*"
   },

--- a/packages/mux-audio-react/package.json
+++ b/packages/mux-audio-react/package.json
@@ -28,7 +28,7 @@
     "build": "npm-run-all --parallel build:types 'build:cjs -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
-    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-audio-react versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-audio-react versions --json | jq -r '. - map(select(contains(\"alpha\") or contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "peerDependencies": {

--- a/packages/mux-audio-react/package.json
+++ b/packages/mux-audio-react/package.json
@@ -28,6 +28,7 @@
     "build": "npm-run-all --parallel build:types 'build:cjs -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-audio-react versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "peerDependencies": {

--- a/packages/mux-audio/package.json
+++ b/packages/mux-audio/package.json
@@ -44,7 +44,7 @@
     "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify' 'build:esm-module -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
-    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-audio versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-audio versions --json | jq -r '. - map(select(contains(\"alpha\") or contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "dependencies": {

--- a/packages/mux-audio/package.json
+++ b/packages/mux-audio/package.json
@@ -44,6 +44,7 @@
     "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify' 'build:esm-module -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-audio versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "dependencies": {

--- a/packages/mux-player-react/package.json
+++ b/packages/mux-player-react/package.json
@@ -28,6 +28,7 @@
     "build": "npm-run-all --parallel build:types 'build:cjs -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-player-react versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "peerDependencies": {

--- a/packages/mux-player-react/package.json
+++ b/packages/mux-player-react/package.json
@@ -28,7 +28,7 @@
     "build": "npm-run-all --parallel build:types 'build:cjs -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
-    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-player-react versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-player-react versions --json | jq -r '. - map(select(contains(\"alpha\") or contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "peerDependencies": {

--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -46,6 +46,7 @@
     "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify' 'build:esm-module -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-player versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "dependencies": {

--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -46,7 +46,7 @@
     "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify' 'build:esm-module -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
-    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-player versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-player versions --json | jq -r '. - map(select(contains(\"alpha\") or contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "dependencies": {

--- a/packages/mux-video-react/package.json
+++ b/packages/mux-video-react/package.json
@@ -28,6 +28,7 @@
     "build": "npm-run-all --parallel build:types 'build:cjs -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-video-react versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "peerDependencies": {

--- a/packages/mux-video-react/package.json
+++ b/packages/mux-video-react/package.json
@@ -28,7 +28,7 @@
     "build": "npm-run-all --parallel build:types 'build:cjs -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
-    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-video-react versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-video-react versions --json | jq -r '. - map(select(contains(\"alpha\") or contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "peerDependencies": {

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -44,6 +44,7 @@
     "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify' 'build:esm-module -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-video versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "dependencies": {

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -44,7 +44,7 @@
     "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify' 'build:esm-module -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
-    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-video versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/mux-video versions --json | jq -r '. - map(select(contains(\"alpha\") or contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "dependencies": {

--- a/packages/playback-core/package.json
+++ b/packages/playback-core/package.json
@@ -42,6 +42,7 @@
     "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify' 'build:esm-module -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/playback-core versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "dependencies": {

--- a/packages/playback-core/package.json
+++ b/packages/playback-core/package.json
@@ -42,7 +42,7 @@
     "build": "npm-run-all --parallel build:types 'build:esm -- --minify' 'build:iife -- --minify' 'build:cjs -- --minify' 'build:esm-module -- --minify'",
     "prebuild": "yarn clean",
     "prepublishOnly": "yarn build",
-    "deploy:canary": "npm version $(semver $(npm view @mux-elements/playback-core versions --json | jq -r '. - map(select(contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
+    "deploy:canary": "npm version $(semver $(npm view @mux-elements/playback-core versions --json | jq -r '. - map(select(contains(\"alpha\") or contains(\"beta\"))) | last' | sed -r 's/-[a-z0-9]{7}$//g') -i prerelease --preid canary)-$(git rev-parse --short HEAD) --git-tag-version false && npm publish --tag canary",
     "create-release-notes": "create-release-notes ./CHANGELOG.md"
   },
   "dependencies": {


### PR DESCRIPTION
didn't end up using `lerna exec` because I could not get the `LERNA_PACKAGE_NAME` to expand properly in a bash command substitution.

this adds the SHA hash to the canary versions. 
also filters out beta versions when getting the latests versions because that would mess up the counter.

