### PR TITLE
docs(mux-uploader): Update README to replace copy pasta from mux-player.

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-uploader-full.html
+++ b/examples/vanilla-ts-esm/public/mux-uploader-full.html
@@ -102,7 +102,7 @@
             <h2>Enter your upload GCS url:</h1>
             <input type="text" class="direct-upload-url" placeholder="https://storage.googleapis.com/..." />
             <div class="button-container">
-              <mux-uploader type="bar" id="uploader-controller" status>
+              <mux-uploader type="bar" status>
                 <mux-uploader-drop slot="dropzone" text="Upload to stream.new" fullscreen overlay></mux-uploader-drop>
               </mux-uploader>
               <button class="second-button">Some other sample button</button>

--- a/examples/vanilla-ts-esm/public/mux-uploader-widget.html
+++ b/examples/vanilla-ts-esm/public/mux-uploader-widget.html
@@ -96,7 +96,7 @@
       <div class="dashboard">
         <div class="widget"></div>
         <div class="widget">
-          <mux-uploader type="bar" id="uploader-controller" disable-drop status>
+          <mux-uploader type="bar" disable-drop status>
           </mux-uploader>
         </div>
         <div class="widget"></div>

--- a/packages/mux-uploader/README.md
+++ b/packages/mux-uploader/README.md
@@ -59,10 +59,36 @@ If you are using ECMAScript modules, you can also load the `mux-uploader.mjs` fi
 
 ```html
 <body>
-  <p></p>
+  <!-- Upload button by itself with default drag an drop scoped to the space it takes up. Displays upload progress in text as percentage.-->
+  <mux-uploader url="authenticated-url" type="bar" status></mux-uploader>
 
-  <mux-uploader url="authenticated-url" id="uploader"></mux-uploader>
+  <!-- Upload button by itself with drag an drop disabled. Does not display text percentage.-->
+  <mux-uploader url="authenticated-url" type="bar" disable-drop></mux-uploader>
+
+  <!-- Upload button with access to additional drag and drop features via slots i.e. fullscreen drag and drop with text overlay (work-in-progress).-->
+  <mux-uploader url="authenticated-url">
+    <mux-uploader-drop slot="dropzone" text="Upload to stream.new" fullscreen overlay></mux-uploader-drop>
+  </mux-uploader>
 </body>
+```
+
+## Drag and Drop
+
+The `mux-uploader`, whether you use `mux-uploader-drop` and its additional features or not i.e. fullscreen and text overlay, has basic drag and drop functionality available to it by default. If you'd rather shop your own drag and drop solution, you can disable the default drag and drop on `mux-uploader` and dispatch a custom `file-ready` event when you need to upload. `mux-uploader` will handle the upload upon receiving the event.
+
+```html
+<script>
+  const muxUploader = document.querySelector('mux-uploader');
+
+  // Dispatch custom event to trigger upload
+  muxUploader.dispatchEvent(
+    new CustomEvent('file-ready', {
+      composed: true,
+      bubbles: true,
+      detail: file,
+    })
+  );
+</script>
 ```
 
 ### Attributes
@@ -72,19 +98,19 @@ If you are using ECMAScript modules, you can also load the `mux-uploader.mjs` fi
 | Attribute            | Type      | Description                                                                                                                                                                                                               | Default     |
 | -------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | `url`                | `string`  | The authenticated URL that your file will be uploaded to. Check out the [direct uploads docs](https://docs.mux.com/guides/video/upload-files-directly#1-create-an-authenticated-mux-url) for how to create one. Required. | `undefined` |
-| `id`                 | `string`  | An ID that allows `mux-uploader-drop` to locate `mux-uploader`. Required.                                                                                                                                                 | N/A         |
+| `id`                 | `string`  | An ID that allows `mux-uploader-drop` to locate `mux-uploader`. Not necessary unless the unlikely scenario you need to nest `mux-uploader` inside `mux-uploader-drop`.                                                    | N/A         |
 | `type`               | `"bar"`   | Specifies the visual type of progress bar. A radial type is in-progress.                                                                                                                                                  | "bar"       |
-| `upload-in-progress` | `boolean` | Toggles visual status of progress bar while upload is n progress.                                                                                                                                                         | false       |
-| `upload-error`       | `boolean` | Toggles visual status of progress bar when upload encounters an error.                                                                                                                                                    | false       |
-| `status`             | `boolean` | Toggles text status of progress bar, which is a percentage by default.                                                                                                                                                    | false       |
+| `upload-in-progress` | `boolean` | Toggles visual status of progress bar while upload is in progress. Can be targeted with CSS if you want to control styles while in progress i.e. mux-uploader[upload-in-progress].                                        | false       |
+| `upload-error`       | `boolean` | Toggles visual status of progress bar when upload encounters an error. Can be targeted with CSS if you want to control styles when an error occurs i.e. mux-uploader[upload-error].                                       | false       |
+| `status`             | `boolean` | Toggles text status visibility of progress bar. The text that is displayed is a percentage by default. If you prefer just the progress bar with no text upload status, don't include this attribute.                      | false       |
 
 #### `mux-uploader-drop`
 
-| Attribute       | Type       | Description                                            | Default |
-| --------------- | ---------- | ------------------------------------------------------ | ------- |
-| `fullscreen`    | `boolean`  | Toggles fullscreen drag and drop (work-in-progress).   | false   |
-| `overlay`       | `boolean`  | Toggles fullscreen overlay on dragover.                | false   |
-| `disable-drop ` | `booleann` | Toggles off drag and drop which is enabled by default. | false   |
+| Attribute       | Type      | Description                                            | Default |
+| --------------- | --------- | ------------------------------------------------------ | ------- |
+| `fullscreen`    | `boolean` | Toggles fullscreen drag and drop (work-in-progress).   | false   |
+| `overlay`       | `boolean` | Toggles fullscreen overlay on dragover.                | false   |
+| `disable-drop ` | `boolean` | Toggles off drag and drop which is enabled by default. | false   |
 
 ### Methods
 

--- a/packages/mux-uploader/README.md
+++ b/packages/mux-uploader/README.md
@@ -61,10 +61,7 @@ If you are using ECMAScript modules, you can also load the `mux-uploader.mjs` fi
 <body>
   <p></p>
 
-  <mux-uploader
-    url="authenticated-url"
-    id="uploader"
-  ></mux-player>
+  <mux-uploader url="authenticated-url" id="uploader"></mux-uploader>
 </body>
 ```
 
@@ -77,9 +74,9 @@ If you are using ECMAScript modules, you can also load the `mux-uploader.mjs` fi
 | `url`                | `string`  | The authenticated URL that your file will be uploaded to. Check out the [direct uploads docs](https://docs.mux.com/guides/video/upload-files-directly#1-create-an-authenticated-mux-url) for how to create one. Required. | `undefined` |
 | `id`                 | `string`  | An ID that allows `mux-uploader-drop` to locate `mux-uploader`. Required.                                                                                                                                                 | N/A         |
 | `type`               | `"bar"`   | Specifies the visual type of progress bar. A radial type is in-progress.                                                                                                                                                  | "bar"       |
-| `upload-in-progress` | `boolean` | The thumbnail token for signing the `poster` URL.                                                                                                                                                                         | false       |
-| `upload-error`       | `boolean` | The storyboard token for signing the storyboard URL.                                                                                                                                                                      | false       |
-| `status`             | `boolean` | This is an arbitrary title for your video that will be passed in as metadata into Mux Data. Adding a title will give you useful context in your Mux Data dashboard. (optional, but encouraged)                            | false       |
+| `upload-in-progress` | `boolean` | Toggles visual status of progress bar while upload is n progress.                                                                                                                                                         | false       |
+| `upload-error`       | `boolean` | Toggles visual status of progress bar when upload encounters an error.                                                                                                                                                    | false       |
+| `status`             | `boolean` | Toggles text status of progress bar, which is a percentage by default.                                                                                                                                                    | false       |
 
 #### `mux-uploader-drop`
 
@@ -97,7 +94,7 @@ If you are using ECMAScript modules, you can also load the `mux-uploader.mjs` fi
 
 ### Styling
 
-`mus-uploader` can be styled with CSS variables.
+`mux-uploader` can be styled with CSS variables.
 
 #### Elements
 

--- a/packages/mux-uploader/src/index.ts
+++ b/packages/mux-uploader/src/index.ts
@@ -185,6 +185,7 @@ template.innerHTML = `
 </div>
 
 <input type="file" />
+<!--TO-DO: Slots not receiving events or not having the right visual behaviour as the original elements. (TD).-->
 <slot name="custom-button"><button type="button">Upload video</button></slot>
 <slot name="custom-progress"><p class="upload-status" id="upload-status"></p></slot>
 
@@ -233,7 +234,6 @@ class MuxUploaderElement extends HTMLElement {
   statusMessage: HTMLElement | null | undefined;
   retryButton: HTMLElement | null | undefined;
   srOnlyText: HTMLElement | null | undefined;
-  _dropHandler: Function;
 
   constructor() {
     super();
@@ -250,8 +250,6 @@ class MuxUploaderElement extends HTMLElement {
     this.statusMessage = this.shadowRoot?.getElementById('status-message');
     this.retryButton = this.shadowRoot?.getElementById('retry-button');
     this.srOnlyText = this.shadowRoot?.getElementById('sr-only');
-
-    this._dropHandler = this.handleUpload.bind(this);
 
     this.progressBar?.setAttribute('aria-description', ariaDescription);
   }
@@ -275,7 +273,7 @@ class MuxUploaderElement extends HTMLElement {
 
   disconnectedCallback() {
     //@ts-ignore
-    this.removeEventListener('mux-drop', this._dropHandler, false);
+    this.removeEventListener('file-ready', this.handleUpload, false);
   }
 
   get url() {
@@ -337,7 +335,7 @@ class MuxUploaderElement extends HTMLElement {
 
   setupDropHandler() {
     //@ts-ignore
-    this.addEventListener('mux-drop', this._dropHandler);
+    this.addEventListener('file-ready', this.handleUpload);
   }
 
   resetState() {
@@ -348,6 +346,7 @@ class MuxUploaderElement extends HTMLElement {
   }
 
   setupFilePickerButton() {
+    // TO-DO: Troubleshoot click event when user clicks custom button. Currently not getting the slotted element. (TD).
     this.shadowRoot?.querySelector('slot[name=custom-button]')?.addEventListener('slotchange', () => {
       this.filePickerButton = this.shadowRoot?.querySelector('slot[name=custom-button]');
     });
@@ -365,7 +364,7 @@ class MuxUploaderElement extends HTMLElement {
 
       if (file) {
         this.dispatchEvent(
-          new CustomEvent('mux-drop', {
+          new CustomEvent('file-ready', {
             composed: true,
             bubbles: true,
             detail: file,

--- a/packages/mux-uploader/src/mux-uploader-drop.ts
+++ b/packages/mux-uploader/src/mux-uploader-drop.ts
@@ -155,7 +155,7 @@ class MuxUploaderDropElement extends HTMLElement {
       const uploaderController = this.muxUploader ?? this;
 
       uploaderController.dispatchEvent(
-        new CustomEvent('mux-drop', {
+        new CustomEvent('file-ready', {
           composed: true,
           bubbles: true,
           detail: file,


### PR DESCRIPTION
## Description

Some text from copying over `mux-player`'s markdown table was leftover 🍝 

Updated text to be relevant to `mux-uploader` 🌈 