### PR TITLE
feat: add ability to choose a Media Theme via attribute

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -75,6 +75,7 @@
      -->
 
     <mux-player
+      theme="media-theme-simple"
       stream-type="on-demand"
       playback-id="026vljfeZ99KwUPRbl5YHVdCTSrBsPfxjkyM3PSlfWGw"
       primary-color="coral"
@@ -129,6 +130,31 @@
         .addEventListener("click", () => {
           window.CastableVideoElement.exitCast();
         });
+
+      const template = document.createElement('template');
+      template.innerHTML = `
+        <style>
+        </style>
+        <media-controller>
+          <slot name="media" slot="media"></slot>
+          <media-time-range></media-time-range>
+          <media-control-bar>
+            <media-play-button></media-play-button>
+          </media-control-bar>
+        </media-controller>
+      `;
+
+      class MediaThemeSimple extends HTMLElement {
+        constructor() {
+          super();
+          this.attachShadow({ mode: 'open' });
+          this.shadowRoot.appendChild(template.content.cloneNode(true));
+        }
+      }
+
+      if (!customElements.get('media-theme-simple')) {
+        customElements.define('media-theme-simple', MediaThemeSimple);
+      }
     </script>
 
     <a href="../">Browse Elements</a>

--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -75,7 +75,6 @@
      -->
 
     <mux-player
-      theme="media-theme-simple"
       stream-type="on-demand"
       playback-id="026vljfeZ99KwUPRbl5YHVdCTSrBsPfxjkyM3PSlfWGw"
       primary-color="coral"
@@ -130,31 +129,6 @@
         .addEventListener("click", () => {
           window.CastableVideoElement.exitCast();
         });
-
-      const template = document.createElement('template');
-      template.innerHTML = `
-        <style>
-        </style>
-        <media-controller>
-          <slot name="media" slot="media"></slot>
-          <media-time-range></media-time-range>
-          <media-control-bar>
-            <media-play-button></media-play-button>
-          </media-control-bar>
-        </media-controller>
-      `;
-
-      class MediaThemeSimple extends HTMLElement {
-        constructor() {
-          super();
-          this.attachShadow({ mode: 'open' });
-          this.shadowRoot.appendChild(template.content.cloneNode(true));
-        }
-      }
-
-      if (!customElements.get('media-theme-simple')) {
-        customElements.define('media-theme-simple', MediaThemeSimple);
-      }
     </script>
 
     <a href="../">Browse Elements</a>

--- a/packages/mux-player/src/helpers.ts
+++ b/packages/mux-player/src/helpers.ts
@@ -56,6 +56,13 @@ export const getStoryboardURLFromPlaybackId = (
   })}`;
 };
 
+export function castThemeName(themeName?: string): string | undefined {
+  if (themeName && /^media-theme-[\w-]+$/.test(themeName)) {
+    return themeName;
+  }
+  return undefined;
+}
+
 const attrToPropNameMap: Record<string, string> = {
   crossorigin: 'crossOrigin',
   playsinline: 'playsInline',

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -2,7 +2,6 @@
 import '@mux/playback-core';
 // @ts-ignore
 import { MediaController } from 'media-chrome';
-import MediaThemeMux from './media-theme-mux/media-theme-mux';
 import MuxVideoElement, { MediaError } from '@mux/mux-video';
 import { Metadata, StreamTypes } from '@mux/playback-core';
 import VideoApiElement, { initVideoApi } from './video-api';
@@ -83,6 +82,7 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
     // it's used if/when it's been explicitly set "from the outside"
     // (See template.ts for additional context) (CJP)
     poster: el.getAttribute('poster'),
+    theme: el.getAttribute('theme'),
     thumbnailTime: !el.tokens.thumbnail && el.thumbnailTime,
     autoplay: el.autoplay,
     crossOrigin: el.crossOrigin,
@@ -173,19 +173,25 @@ class MuxPlayerElement extends VideoApiElement {
     // Fixes a bug in React where mux-player's CE children were not upgraded yet.
     // These lines ensure the rendered mux-video and media-controller are upgraded,
     // even before they are connected to the main document.
-    customElements.upgrade(this.theme as Node);
-    if (!(this.theme instanceof MediaThemeMux)) {
-      logger.error('<media-theme-mux> failed to upgrade!');
+    try {
+      customElements.upgrade(this.theme as Node);
+      if (!(this.theme instanceof HTMLElement)) throw '';
+    } catch (error) {
+      logger.error(`<${this.theme?.localName}> failed to upgrade!`);
     }
 
-    customElements.upgrade(this.media as Node);
-    if (!(this.media instanceof MuxVideoElement)) {
+    try {
+      customElements.upgrade(this.media as Node);
+      if (!(this.media instanceof MuxVideoElement)) throw '';
+    } catch (error) {
       logger.error('<mux-video> failed to upgrade!');
     }
 
-    customElements.upgrade(this.mediaController as Node);
-    if (!(this.mediaController instanceof MediaController)) {
-      logger.error('<media-controller> failed to upgrade!');
+    try {
+      customElements.upgrade(this.mediaController as Node);
+      if (!(this.mediaController instanceof MediaController)) throw '';
+    } catch (error) {
+      logger.error(`<media-controller> failed to upgrade!`);
     }
 
     initVideoApi(this);

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -21,8 +21,6 @@ export type Tokens = {
   storyboard?: string;
 };
 
-type MediaController = Element & { media: HTMLVideoElement };
-
 const streamTypeValues = Object.values(StreamTypes);
 
 const SMALL_BREAKPOINT = 700;

--- a/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
+++ b/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
@@ -18,7 +18,6 @@ type ThemeMuxTemplateProps = {
   audio: boolean;
   playerSize: string | null;
   defaultHiddenCaptions: boolean;
-  hasCaptions: boolean;
   forwardSeekOffset: string | null;
   backwardSeekOffset: string | null;
 };
@@ -30,7 +29,6 @@ export default class MediaThemeMux extends MediaTheme {
       'stream-type',
       'player-size',
       'default-hidden-captions',
-      'has-captions',
       'forward-seek-offset',
       'backward-seek-offset',
     ];
@@ -46,7 +44,6 @@ export default class MediaThemeMux extends MediaTheme {
       streamType: this.getAttribute('stream-type'),
       playerSize: this.getAttribute('player-size'),
       defaultHiddenCaptions: this.hasAttribute('default-hidden-captions'),
-      hasCaptions: this.hasAttribute('has-captions'),
       forwardSeekOffset: this.getAttribute('forward-seek-offset'),
       backwardSeekOffset: this.getAttribute('backward-seek-offset'),
     };

--- a/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
+++ b/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
@@ -1,4 +1,4 @@
-import 'media-chrome';
+import { MediaTheme } from 'media-chrome';
 import { html, render } from '../html';
 import '../media-chrome/time-display';
 
@@ -14,26 +14,63 @@ const MediaChromeSizes = {
 };
 
 type ThemeMuxTemplateProps = {
-  streamType: string;
+  streamType: string | null;
   audio: boolean;
-  playerSize: string;
+  playerSize: string | null;
   defaultHiddenCaptions: boolean;
-  forwardSeekOffset: number;
-  backwardSeekOffset: number;
+  hasCaptions: boolean;
+  forwardSeekOffset: string | null;
+  backwardSeekOffset: string | null;
 };
 
-const template = (props: ThemeMuxTemplateProps) => html`
-  <style>
-    ${cssStr}
-  </style>
+export default class MediaThemeMux extends MediaTheme {
+  static get observedAttributes() {
+    return [
+      'audio',
+      'stream-type',
+      'player-size',
+      'default-hidden-captions',
+      'has-captions',
+      'forward-seek-offset',
+      'backward-seek-offset',
+    ];
+  }
 
-  <media-controller audio="${props.audio || false}" class="size-${props.playerSize}">
-    <slot name="media" slot="media"></slot>
-    <media-loading-indicator slot="centered-chrome" no-auto-hide></media-loading-indicator>
-    ${ChromeRenderer(props)}
-    <slot></slot>
-  </media-controller>
-`;
+  attributeChangedCallback() {
+    this.render();
+  }
+
+  render() {
+    const props = {
+      audio: this.hasAttribute('audio'),
+      streamType: this.getAttribute('stream-type'),
+      playerSize: this.getAttribute('player-size'),
+      defaultHiddenCaptions: this.hasAttribute('default-hidden-captions'),
+      hasCaptions: this.hasAttribute('has-captions'),
+      forwardSeekOffset: this.getAttribute('forward-seek-offset'),
+      backwardSeekOffset: this.getAttribute('backward-seek-offset'),
+    };
+
+    render(
+      html`
+        <style>
+          ${cssStr}
+        </style>
+        <media-controller audio="${props.audio || false}" class="size-${props.playerSize}">
+          <slot name="media" slot="media"></slot>
+          <media-loading-indicator slot="centered-chrome" no-auto-hide></media-loading-indicator>
+          ${ChromeRenderer(props)}
+          <slot></slot>
+        </media-controller>
+      `,
+      this.shadowRoot as Node
+    );
+  }
+}
+
+if (!customElements.get('media-theme-mux')) {
+  customElements.define('media-theme-mux', MediaThemeMux);
+}
 
 const ChromeRenderer = (props: ThemeMuxTemplateProps) => {
   const { streamType, playerSize, audio } = props;
@@ -41,7 +78,7 @@ const ChromeRenderer = (props: ThemeMuxTemplateProps) => {
     switch (streamType) {
       case StreamTypes.LIVE:
       case StreamTypes.LL_LIVE: {
-        return AudioLiveChrome(props);
+        return AudioLiveChrome();
       }
       case StreamTypes.DVR:
       case StreamTypes.LL_DVR: {
@@ -179,7 +216,7 @@ export const AudioDvrChrome = (props: ThemeMuxTemplateProps) => html`
   </media-control-bar>
 `;
 
-export const AudioLiveChrome = (_props: ThemeMuxTemplateProps) => html`
+export const AudioLiveChrome = () => html`
   <media-control-bar>
     ${MediaPlayButton()}
     <slot name="seek-to-live-button"></slot>
@@ -351,45 +388,3 @@ export const DvrChromeLarge = (props: ThemeMuxTemplateProps) => html`
     <div class="mxp-padding-2"></div>
   </media-control-bar>
 `;
-
-function getProps(el: MediaThemeMux, state?: any): ThemeMuxTemplateProps {
-  return {
-    audio: el.hasAttribute('audio'),
-    streamType: el.getAttribute('stream-type'),
-    playerSize: el.getAttribute('player-size'),
-    defaultHiddenCaptions: el.hasAttribute('default-hidden-captions'),
-    forwardSeekOffset: el.getAttribute('forward-seek-offset'),
-    backwardSeekOffset: el.getAttribute('backward-seek-offset'),
-    ...state,
-  };
-}
-
-class MediaThemeMux extends HTMLElement {
-  static get observedAttributes() {
-    return [
-      'audio',
-      'stream-type',
-      'player-size',
-      'default-hidden-captions',
-      'forward-seek-offset',
-      'backward-seek-offset',
-    ];
-  }
-
-  constructor() {
-    super();
-
-    this.attachShadow({ mode: 'open' });
-    render(template(getProps(this)), this.shadowRoot as Node);
-  }
-
-  attributeChangedCallback() {
-    render(template(getProps(this)), this.shadowRoot as Node);
-  }
-}
-
-if (!customElements.get('media-theme-mux')) {
-  customElements.define('media-theme-mux', MediaThemeMux);
-}
-
-export default MediaThemeMux;

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -1,7 +1,12 @@
 import './media-theme-mux/media-theme-mux';
 import './dialog';
-import { getSrcFromPlaybackId, getPosterURLFromPlaybackId, getStoryboardURLFromPlaybackId } from './helpers';
-import { html } from './html';
+import {
+  castThemeName,
+  getSrcFromPlaybackId,
+  getPosterURLFromPlaybackId,
+  getStoryboardURLFromPlaybackId,
+} from './helpers';
+import { html, unsafeStatic } from './html';
 // @ts-ignore
 import cssStr from './styles.css';
 import { i18n, stylePropsToString } from './utils';
@@ -17,14 +22,16 @@ export const template = (props: MuxTemplateProps) => html`
 `;
 
 export const content = (props: MuxTemplateProps) => html`
-  <media-theme-mux
+  <${unsafeStatic(castThemeName(props.theme) ?? 'media-theme-mux')}
     audio="${props.audio || false}"
-    style="${stylePropsToString({
-      '--primary-color': props.primaryColor,
-      '--secondary-color': props.secondaryColor,
-      '--mux-time-range-padding': props.secondaryColor ? '0' : null,
-      '--media-range-track-border-radius': props.secondaryColor ? '0' : null,
-    }) ?? false}"
+    style="${
+      stylePropsToString({
+        '--primary-color': props.primaryColor,
+        '--secondary-color': props.secondaryColor,
+        '--mux-time-range-padding': props.secondaryColor ? '0' : null,
+        '--media-range-track-border-radius': props.secondaryColor ? '0' : null,
+      }) ?? false
+    }"
     class="size-${props.playerSize}"
     stream-type="${props.streamType}"
     player-size="${props.playerSize}"
@@ -52,40 +59,48 @@ export const content = (props: MuxTemplateProps) => html`
       env-key="${props.envKey ?? false}"
       stream-type="${props.streamType ?? false}"
       custom-domain="${props.customDomain ?? false}"
-      src="${!!props.src
-        ? props.src
-        : props.playbackId
-        ? getSrcFromPlaybackId(props.playbackId, { domain: props.customDomain, token: props.tokens.playback })
-        : false}"
-      poster="${!!props.poster
-        ? props.poster
-        : props.playbackId && !props.audio
-        ? getPosterURLFromPlaybackId(props.playbackId, {
-            domain: props.customDomain,
-            thumbnailTime: props.thumbnailTime ?? props.startTime,
-            token: props.tokens.thumbnail,
-          })
-        : false}"
-      cast-src="${!!props.src
-        ? props.src
-        : props.playbackId
-        ? getSrcFromPlaybackId(props.playbackId, { domain: props.customDomain, token: props.tokens.playback })
-        : false}"
+      src="${
+        !!props.src
+          ? props.src
+          : props.playbackId
+          ? getSrcFromPlaybackId(props.playbackId, { domain: props.customDomain, token: props.tokens.playback })
+          : false
+      }"
+      poster="${
+        !!props.poster
+          ? props.poster
+          : props.playbackId && !props.audio
+          ? getPosterURLFromPlaybackId(props.playbackId, {
+              domain: props.customDomain,
+              thumbnailTime: props.thumbnailTime ?? props.startTime,
+              token: props.tokens.thumbnail,
+            })
+          : false
+      }"
+      cast-src="${
+        !!props.src
+          ? props.src
+          : props.playbackId
+          ? getSrcFromPlaybackId(props.playbackId, { domain: props.customDomain, token: props.tokens.playback })
+          : false
+      }"
       cast-stream-type="${[StreamTypes.LIVE, StreamTypes.LL_LIVE].includes(props.streamType as any) ? 'live' : false}"
     >
-      ${props.playbackId &&
-      !props.audio &&
-      ![StreamTypes.LIVE, StreamTypes.LL_LIVE, StreamTypes.DVR, StreamTypes.LL_DVR].includes(props.streamType as any)
-        ? html`<track
-            label="thumbnails"
-            default
-            kind="metadata"
-            src="${getStoryboardURLFromPlaybackId(props.playbackId, {
-              domain: props.customDomain,
-              token: props.tokens.storyboard,
-            })}"
-          />`
-        : html``}
+      ${
+        props.playbackId &&
+        !props.audio &&
+        ![StreamTypes.LIVE, StreamTypes.LL_LIVE, StreamTypes.DVR, StreamTypes.LL_DVR].includes(props.streamType as any)
+          ? html`<track
+              label="thumbnails"
+              default
+              kind="metadata"
+              src="${getStoryboardURLFromPlaybackId(props.playbackId, {
+                domain: props.customDomain,
+                token: props.tokens.storyboard,
+              })}"
+            />`
+          : html``
+      }
     </mux-video>
     <button
       slot="seek-to-live-button"
@@ -110,16 +125,18 @@ export const content = (props: MuxTemplateProps) => html`
       ${props.dialog?.title ? html`<h3>${props.dialog.title}</h3>` : html``}
       <p>
         ${props.dialog?.message}
-        ${props.dialog?.linkUrl
-          ? html`<a
-              href="${props.dialog.linkUrl}"
-              target="_blank"
-              rel="external noopener"
-              aria-label="${props.dialog.linkText ?? ''} ${i18n(`(opens in a new window)`)}"
-              >${props.dialog.linkText ?? props.dialog.linkUrl}</a
-            >`
-          : html``}
+        ${
+          props.dialog?.linkUrl
+            ? html`<a
+                href="${props.dialog.linkUrl}"
+                target="_blank"
+                rel="external noopener"
+                aria-label="${props.dialog.linkText ?? ''} ${i18n(`(opens in a new window)`)}"
+                >${props.dialog.linkText ?? props.dialog.linkUrl}</a
+              >`
+            : html``
+        }
       </p>
     </mxp-dialog>
-  </media-theme-mux>
+  </${unsafeStatic(castThemeName(props.theme) ?? 'media-theme-mux')}>
 `;

--- a/packages/mux-player/src/types.d.ts
+++ b/packages/mux-player/src/types.d.ts
@@ -6,6 +6,7 @@ export type MuxPlayerProps = Partial<MuxVideoElement> & {
 
 export type MuxTemplateProps = Partial<MuxPlayerProps> & {
   audio: boolean;
+  theme?: string;
   playerSize: string;
   showLoading: boolean;
   thumbnailTime: number;

--- a/types/media-chrome.d.ts
+++ b/types/media-chrome.d.ts
@@ -1,0 +1,6 @@
+declare module 'media-chrome' {
+  export class MediaTheme extends HTMLElement {}
+  export class MediaController extends HTMLElement {
+    media: HTMLVideoElement;
+  }
+}


### PR DESCRIPTION
this change adds the ability to use a different theme via a simple `theme="media-theme-goldshine"` attribute ✨ 

it required some changes to the html tagged template renderer. 
added support for unsafe static values that can make part of the HTML string to be process by the template parser.

![SCR-20220624-kk4](https://user-images.githubusercontent.com/360826/175657769-0ef42867-1b7a-4458-89ba-61a8c4e29c72.jpeg)

