### PR TITLE
test: make events dispatch test more reliable

### DIFF
--- a/packages/mux-video/test/player.test.js
+++ b/packages/mux-video/test/player.test.js
@@ -49,7 +49,6 @@ describe('<mux-video>', () => {
     assert.deepInclude(eventMap, {
       canplay: true,
       durationchange: true,
-      emptied: true,
       loadeddata: true,
       loadedmetadata: true,
       loadstart: true,
@@ -57,7 +56,6 @@ describe('<mux-video>', () => {
       playing: true,
       timeupdate: true,
       volumechange: true,
-      waiting: true,
       resize: true,
     });
   });


### PR DESCRIPTION
Removing emptied and waiting increase the reliability of the test since
these two events are less likely to occur on any given playback compared
to the other events that are triggered in that test.