### PR TITLE
Mux elements scope deprecation

### DIFF
--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -21,13 +21,13 @@ jobs:
           # this line is required for the setup-node action to be able to run the npm publish below.
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
-      - run: npm deprecate @mux-elements/mux-audio "This package has moved to the @mux/mux-audio scope. See #_#_INSERT_URL_HERE_#_# for more information."
-      - run: npm deprecate @mux-elements/mux-video "This package has moved to the @mux/mux-video scope. See #_#_INSERT_URL_HERE_#_# for more information."
-      - run: npm deprecate @mux-elements/mux-player "This package has moved to the @mux/mux-player scope. See #_#_INSERT_URL_HERE_#_# for more information."
-      - run: npm deprecate @mux-elements/mux-audio-react "This package has moved to the @mux/mux-audio-react scope. See #_#_INSERT_URL_HERE_#_# for more information."
-      - run: npm deprecate @mux-elements/mux-video-react "This package has moved to the @mux/mux-video-react scope. See #_#_INSERT_URL_HERE_#_# for more information."
-      - run: npm deprecate @mux-elements/mux-player-react "This package has moved to the @mux/mux-player-react scope. See #_#_INSERT_URL_HERE_#_# for more information."
-      - run: npm deprecate @mux-elements/mux-uploader "This package has moved to the @mux/mux-uploader scope. See #_#_INSERT_URL_HERE_#_# for more information."
-      - run: npm deprecate @mux-elements/playback-core "This package has moved to the @mux/playback-core scope. See #_#_INSERT_URL_HERE_#_# for more information."
+      - run: npm deprecate @mux-elements/mux-audio "This package has moved to the @mux/mux-audio scope. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information."
+      - run: npm deprecate @mux-elements/mux-video "This package has moved to the @mux/mux-video scope. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information."
+      - run: npm deprecate @mux-elements/mux-player "This package has moved to the @mux/mux-player scope. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information."
+      - run: npm deprecate @mux-elements/mux-audio-react "This package has moved to the @mux/mux-audio-react scope. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information."
+      - run: npm deprecate @mux-elements/mux-video-react "This package has moved to the @mux/mux-video-react scope. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information."
+      - run: npm deprecate @mux-elements/mux-player-react "This package has moved to the @mux/mux-player-react scope. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information."
+      - run: npm deprecate @mux-elements/mux-uploader "This package has moved to the @mux/mux-uploader scope. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information."
+      - run: npm deprecate @mux-elements/playback-core "This package has moved to the @mux/playback-core scope. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information."
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -1,0 +1,33 @@
+name: deprecate
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  deprecate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      # extract `engines.node` from package.json and save it to output
+      - name: Get Node.JS version from package.json
+        id: get-versions
+        run: echo ::set-output name=node::$(jq -r .engines.node ./package.json)
+      - name: Use Node.js ${{ steps.get-versions.outputs.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.get-versions.outputs.node }}
+          # this line is required for the setup-node action to be able to run the npm publish below.
+          registry-url: 'https://registry.npmjs.org'
+          cache: yarn
+      - run: npm deprecate @mux-elements/mux-audio "This package has moved to the @mux/mux-audio scope. See #_#_INSERT_URL_HERE_#_# for more information."
+      - run: npm deprecate @mux-elements/mux-video "This package has moved to the @mux/mux-video scope. See #_#_INSERT_URL_HERE_#_# for more information."
+      - run: npm deprecate @mux-elements/mux-player "This package has moved to the @mux/mux-player scope. See #_#_INSERT_URL_HERE_#_# for more information."
+      - run: npm deprecate @mux-elements/mux-audio-react "This package has moved to the @mux/mux-audio-react scope. See #_#_INSERT_URL_HERE_#_# for more information."
+      - run: npm deprecate @mux-elements/mux-video-react "This package has moved to the @mux/mux-video-react scope. See #_#_INSERT_URL_HERE_#_# for more information."
+      - run: npm deprecate @mux-elements/mux-player-react "This package has moved to the @mux/mux-player-react scope. See #_#_INSERT_URL_HERE_#_# for more information."
+      - run: npm deprecate @mux-elements/mux-uploader "This package has moved to the @mux/mux-uploader scope. See #_#_INSERT_URL_HERE_#_# for more information."
+      - run: npm deprecate @mux-elements/playback-core "This package has moved to the @mux/playback-core scope. See #_#_INSERT_URL_HERE_#_# for more information."
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -21,6 +21,11 @@ export type Props = Omit<
 > &
   MuxMediaProps;
 
+console.warn(`
+We have recently transitioned the package name from @mux-elements/<element name> to @mux/<element name>.
+Please update your imports or scripts. See #_#_INSERT_URL_HERE_#_# for more information.
+`);
+
 const playerSoftwareVersion = getPlayerVersion();
 const playerSoftwareName = 'mux-audio-react';
 

--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -23,7 +23,7 @@ export type Props = Omit<
 
 console.warn(`
 We have recently transitioned the package name from @mux-elements/<element name> to @mux/<element name>.
-Please update your imports or scripts. See #_#_INSERT_URL_HERE_#_# for more information.
+Please update your imports or scripts. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information.
 `);
 
 const playerSoftwareVersion = getPlayerVersion();

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -18,7 +18,7 @@ import CustomAudioElement, { AudioEvents } from './CustomAudioElement';
 
 console.warn(`
 We have recently transitioned the package name from @mux-elements/<element name> to @mux/<element name>.
-Please update your imports or scripts. See #_#_INSERT_URL_HERE_#_# for more information.
+Please update your imports or scripts. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information.
 `);
 
 /** @TODO make the relationship between name+value smarter and more deriveable (CJP) */

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -16,6 +16,11 @@ import { getPlayerVersion } from './env';
 // this must be imported after playback-core for the polyfill to be included
 import CustomAudioElement, { AudioEvents } from './CustomAudioElement';
 
+console.warn(`
+We have recently transitioned the package name from @mux-elements/<element name> to @mux/<element name>.
+Please update your imports or scripts. See #_#_INSERT_URL_HERE_#_# for more information.
+`);
+
 /** @TODO make the relationship between name+value smarter and more deriveable (CJP) */
 type AttributeNames = {
   ENV_KEY: 'env-key';

--- a/packages/mux-uploader/src/index.ts
+++ b/packages/mux-uploader/src/index.ts
@@ -3,7 +3,7 @@ import './mux-uploader-drop';
 
 console.warn(`
 We have recently transitioned the package name from @mux-elements/mux-uploader to @mux/mux-uploader.
-Please update your imports or scripts. See #_#_INSERT_URL_HERE_#_# for more information.
+Please update your imports or scripts. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information.
 `);
 
 const styles = `

--- a/packages/mux-uploader/src/index.ts
+++ b/packages/mux-uploader/src/index.ts
@@ -1,6 +1,11 @@
 import * as UpChunk from '@mux/upchunk';
 import './mux-uploader-drop';
 
+console.warn(`
+We have recently transitioned the package name from @mux-elements/mux-uploader to @mux/mux-uploader.
+Please update your imports or scripts. See #_#_INSERT_URL_HERE_#_# for more information.
+`);
+
 const styles = `
 :host {
   font-family: var(--uploader-font-family, Arial);

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -21,7 +21,7 @@ export type Props = Omit<
 
 console.warn(`
 We have recently transitioned the package name from @mux-elements/<element name> to @mux/<element name>.
-Please update your imports or scripts. See #_#_INSERT_URL_HERE_#_# for more information.
+Please update your imports or scripts. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information.
 `);
 
 const playerSoftwareVersion = getPlayerVersion();

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -19,6 +19,11 @@ export type Props = Omit<
 > &
   MuxMediaProps;
 
+console.warn(`
+We have recently transitioned the package name from @mux-elements/<element name> to @mux/<element name>.
+Please update your imports or scripts. See #_#_INSERT_URL_HERE_#_# for more information.
+`);
+
 const playerSoftwareVersion = getPlayerVersion();
 const playerSoftwareName = 'mux-video-react';
 

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -19,7 +19,7 @@ import CustomVideoElement, { VideoEvents } from './CustomVideoElement';
 
 console.warn(`
 We have recently transitioned the package name from @mux-elements/<element name> to @mux/<element name>.
-Please update your imports or scripts. See #_#_INSERT_URL_HERE_#_# for more information.
+Please update your imports or scripts. See https://www.mux.com/blog/mux-elements-are-getting-a-new-old-home-on-npm-mux for more information.
 `);
 
 /** @TODO make the relationship between name+value smarter and more deriveable (CJP) */

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -17,6 +17,11 @@ import { getPlayerVersion } from './env';
 // this must be imported after playback-core for the polyfill to be included
 import CustomVideoElement, { VideoEvents } from './CustomVideoElement';
 
+console.warn(`
+We have recently transitioned the package name from @mux-elements/<element name> to @mux/<element name>.
+Please update your imports or scripts. See #_#_INSERT_URL_HERE_#_# for more information.
+`);
+
 /** @TODO make the relationship between name+value smarter and more deriveable (CJP) */
 type AttributeNames = {
   ENV_KEY: 'env-key';


### PR DESCRIPTION
When we are ready to take the plunge, we can push this branch upstream, which should allow us to then dispatch the `cd.yml` workflow on this branch to publish the `console.warn` update and then run the `deprecate.yml` workflow to deprecate the old packages on npm.

In the packages, I used `console.warn` instead of `console.error` because a `console.error` could potentially fail a build. In addition, it's logged only in the following packages to minimize the chance that there are multiple logs:
- `mux-audio`
- `mux-video`
- `mux-audio-react`
- `mux-video-react`
- `mux-uploader`
