### PR TITLE
chore: try using yarn workspaces install w/ lazy

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -53,7 +53,7 @@ function release {
   done
   # update all workspaces from the workspace root (../..) with the new version
   # make sure publish.sh is called in topological order, `lerna run` does this
-  npx lerna-update-wizard --non-interactive --dependency $PKG_NAME@$VERSION ../..
+  npx lerna-update-wizard --non-interactive --lazy --dependency $PKG_NAME@$VERSION ../..
 };
 
 function canary {
@@ -78,7 +78,7 @@ function canary {
   done
   # update all workspaces from the workspace root (../..) with the new version
   # make sure publish.sh is called in topological order, `lerna run` does this
-  npx lerna-update-wizard --non-interactive --dependency $PKG_NAME@$VERSION ../..
+  npx lerna-update-wizard --non-interactive --lazy --dependency $PKG_NAME@$VERSION ../..
 }
 
 main "$@"


### PR DESCRIPTION
this change will use the `--lazy` flag for lerna-update-wizard 
https://github.com/Anifacted/lerna-update-wizard#yarn-workspaces--lazy-installation

which should help speed up the installation of the new canary dependencies.
what I could see is that the CI builds got stuck during or after lerna-update-wizard so this might fix that