### PR TITLE
fix(mux-uploader-react): Clean up typescript defs.

### DIFF
--- a/packages/mux-uploader-react/src/index.tsx
+++ b/packages/mux-uploader-react/src/index.tsx
@@ -11,6 +11,7 @@ import useObjectPropEffect from './useObjectPropEffect';
 export type MuxUploaderRefAttributes = MuxUploaderElement;
 
 export type MuxUploaderProps = {
+  id?: string;
   endpoint?: string;
   type?: string;
   status?: boolean;
@@ -34,7 +35,7 @@ export type MuxUploaderProps = {
   onError?: EventListener;
   onProgress?: EventListener;
   onSuccess?: EventListener;
-} & Partial<MuxUploaderRefAttributes>;
+};
 
 const MuxUploaderInternal = React.forwardRef<MuxUploaderRefAttributes, MuxUploaderProps>(
   ({ children, ...props }, ref) => {


### PR DESCRIPTION
Was applying wrong types to the react props for MuxUploader (tl;dr - HTMLElement ref typedef crud instead of react crud)