### PR TITLE
feat: add CSS parts for controls

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -29,6 +29,13 @@
         aspect-ratio: 16 / 9;
       }
 
+/*      mux-player::part(button),
+      mux-player::part(range),
+      mux-player::part(display),
+      mux-player::part(backdrop) {
+        display: none;
+      }*/
+
       .buttons {
         width: 100%;
         display: flex;

--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -29,11 +29,19 @@
         aspect-ratio: 16 / 9;
       }
 
-/*      mux-player::part(button),
-      mux-player::part(range),
-      mux-player::part(display),
-      mux-player::part(backdrop) {
+      /*
+      mux-player::part(play button) {
         display: none;
+      }
+
+      mux-player::part(button),
+      mux-player::part(range),
+      mux-player::part(display) {
+        display: none;
+      }
+
+      mux-player::part(vertical-layer) {
+        background-color: transparent;
       }*/
 
       .buttons {

--- a/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
+++ b/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
@@ -22,6 +22,26 @@ type ThemeMuxTemplateProps = {
   backwardSeekOffset: string | null;
 };
 
+export const parts = {
+  backdrop: 'controls backdrop',
+  centerPlay: 'center play button',
+  centerSeekBackward: 'center seek-backward button',
+  centerSeekForward: 'center seek-forward button',
+  play: 'play button',
+  seekBackward: 'seek-backward button',
+  seekForward: 'seek-forward button',
+  mute: 'mute button',
+  captions: 'captions button',
+  airplay: 'airplay button',
+  pip: 'pip button',
+  fullscreen: 'fullscreen button',
+  cast: 'cast button',
+  playbackRate: 'playbackrate button',
+  volumeRange: 'volume range',
+  timeRange: 'time range',
+  timeDisplay: 'time display',
+};
+
 export default class MediaThemeMux extends MediaTheme {
   static get observedAttributes() {
     return [
@@ -55,6 +75,7 @@ export default class MediaThemeMux extends MediaTheme {
         </style>
         <media-controller audio="${props.audio || false}" class="size-${props.playerSize}">
           <slot name="media" slot="media"></slot>
+          <div slot="top-chrome" class="backdrop" part="${parts.backdrop}"></div>
           <media-loading-indicator slot="centered-chrome" no-auto-hide></media-loading-indicator>
           ${ChromeRenderer(props)}
           <slot></slot>
@@ -127,30 +148,32 @@ const ChromeRenderer = (props: ThemeMuxTemplateProps) => {
 };
 
 // prettier-ignore
-const MediaPlayButton = () => html`
-  <media-play-button>
+const MediaPlayButton = ({ part = parts.play } = {}) => html`
+  <media-play-button part="${part}">
     ${icons.Play()}
     ${icons.Pause()}
   </media-play-button>
 `;
 
 // prettier-ignore
-const MediaSeekBackwardButton = (props: Partial<ThemeMuxTemplateProps>) => html`
-  <media-seek-backward-button seek-offset="${props.backwardSeekOffset}">
-    ${icons.SeekBackward({ value: props.backwardSeekOffset })}
+type SeekBackwardButtonProps = { backwardSeekOffset: string, part?: string };
+const MediaSeekBackwardButton = ({ backwardSeekOffset, part = parts.seekBackward }: SeekBackwardButtonProps) => html`
+  <media-seek-backward-button seek-offset="${backwardSeekOffset}" part="${part}">
+    ${icons.SeekBackward({ value: backwardSeekOffset })}
   </media-seek-backward-button>
 `;
 
 // prettier-ignore
-const MediaSeekForwardButton = (props: Partial<ThemeMuxTemplateProps>) => html`
-  <media-seek-forward-button seek-offset="${props.forwardSeekOffset}">
-    ${icons.SeekForward({ value: props.forwardSeekOffset })}
+type SeekForwardButtonProps = { forwardSeekOffset: string, part?: string };
+const MediaSeekForwardButton = ({ forwardSeekOffset, part = parts.seekForward }: SeekForwardButtonProps) => html`
+  <media-seek-forward-button seek-offset="${forwardSeekOffset}" part="${part}">
+    ${icons.SeekForward({ value: forwardSeekOffset })}
   </media-seek-forward-button>
 `;
 
 // prettier-ignore
 const MediaMuteButton = () => html`
-  <media-mute-button>
+  <media-mute-button part="${parts.mute}">
     ${icons.VolumeHigh()}
     ${icons.VolumeMedium()}
     ${icons.VolumeLow()}
@@ -160,71 +183,100 @@ const MediaMuteButton = () => html`
 
 // prettier-ignore
 const MediaCaptionsButton = (props: ThemeMuxTemplateProps) => html`
-<media-captions-button default-showing="${!props.defaultHiddenCaptions}" >
+<media-captions-button default-showing="${!props.defaultHiddenCaptions}" part="${parts.captions}">
   ${icons.CaptionsOff()}
   ${icons.CaptionsOn()}
 </media-captions-button>`;
 
 // prettier-ignore
 const MediaAirplayButton = () => html`
-<media-airplay-button>
+<media-airplay-button part="${parts.airplay}">
   ${icons.Airplay()}
 </media-airplay-button>`;
 
 // prettier-ignore
 const MediaPipButton = () => html`
-<media-pip-button>
+<media-pip-button part="${parts.pip}">
   ${icons.PipEnter()}
   ${icons.PipExit()}
 </media-pip-button>`;
 
 // prettier-ignore
 const MediaFullscreenButton = () => html`
-<media-fullscreen-button>
+<media-fullscreen-button part="${parts.fullscreen}">
   ${icons.FullscreenEnter()}
   ${icons.FullscreenExit()}
 </media-fullscreen-button>`;
 
 // prettier-ignore
 const MediaCastButton = () => html`
-<media-cast-button>
+<media-cast-button part="${parts.cast}">
   ${icons.CastEnter()}
   ${icons.CastExit()}
 </media-cast-button>`;
 
+// prettier-ignore
+const MediaPlaybackRateButton = () => html`
+<media-playback-rate-button part="${parts.playbackRate}">
+</media-playback-rate-button>`;
+
+// prettier-ignore
+const MediaVolumeRange = () => html`
+<media-volume-range part="${parts.volumeRange}">
+</media-volume-range>`;
+
+// prettier-ignore
+const MediaTimeRange = () => html`
+<media-time-range part="${parts.timeRange}">
+</media-time-range>`;
+
+// prettier-ignore
+const TimeDisplay = () => html`
+<mxp-time-display part="${parts.timeDisplay}">
+</mxp-time-display>`;
+
+// prettier-ignore
 export const AudioVodChrome = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar>
-    ${MediaPlayButton()} ${MediaSeekBackwardButton(props)} ${MediaSeekForwardButton(props)}
-    <mxp-time-display></mxp-time-display>
-    <media-time-range></media-time-range>
+    ${MediaPlayButton()}
+    ${MediaSeekBackwardButton(props as SeekBackwardButtonProps)}
+    ${MediaSeekForwardButton(props as SeekForwardButtonProps)}
+    ${TimeDisplay()}
+    ${MediaTimeRange()}
     ${MediaMuteButton()}
-    <media-volume-range></media-volume-range>
-    <media-playback-rate-button></media-playback-rate-button>
-    ${MediaAirplayButton()} ${MediaCastButton()}
+    ${MediaVolumeRange()}
+    ${MediaPlaybackRateButton()}
+    ${MediaAirplayButton()}
+    ${MediaCastButton()}
   </media-control-bar>
 `;
 
+// prettier-ignore
 export const AudioDvrChrome = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar>
     ${MediaPlayButton()}
     <slot name="seek-to-live-button"></slot>
-    ${MediaSeekBackwardButton(props)} ${MediaSeekForwardButton(props)}
-    <mxp-time-display></mxp-time-display>
-    <media-time-range></media-time-range>
+    ${MediaSeekBackwardButton(props as SeekBackwardButtonProps)}
+    ${MediaSeekForwardButton(props as SeekForwardButtonProps)}
+    ${TimeDisplay()}
+    ${MediaTimeRange()}
     ${MediaMuteButton()}
-    <media-volume-range></media-volume-range>
-    <media-playback-rate-button></media-playback-rate-button>
-    ${MediaAirplayButton()} ${MediaCastButton()}
+    ${MediaVolumeRange()}
+    ${MediaPlaybackRateButton()}
+    ${MediaAirplayButton()}
+    ${MediaCastButton()}
   </media-control-bar>
 `;
 
+// prettier-ignore
 export const AudioLiveChrome = () => html`
   <media-control-bar>
     ${MediaPlayButton()}
     <slot name="seek-to-live-button"></slot>
     ${MediaMuteButton()}
-    <media-volume-range></media-volume-range>
-    ${MediaAirplayButton()} ${MediaCastButton()}
+    ${MediaVolumeRange()}
+    ${MediaAirplayButton()}
+    ${MediaCastButton()}
   </media-control-bar>
 `;
 
@@ -238,7 +290,7 @@ export const VodChromeExtraSmall = (props: ThemeMuxTemplateProps) => html`
     ${MediaPipButton()}
   </media-control-bar>
   <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaPlayButton()}
+    ${MediaPlayButton({ part: parts.centerPlay })}
   </div>
   <media-control-bar>
     ${MediaMuteButton()}
@@ -256,17 +308,17 @@ export const VodChromeSmall = (props: ThemeMuxTemplateProps) => html`
     ${MediaPipButton()}
   </media-control-bar>
   <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaSeekBackwardButton(props)}
-    ${MediaPlayButton()}
-    ${MediaSeekForwardButton(props)}
+    ${MediaSeekBackwardButton({ ...props, part: parts.centerSeekBackward } as SeekBackwardButtonProps)}
+    ${MediaPlayButton({ part: parts.centerPlay })}
+    ${MediaSeekForwardButton({ ...props, part: parts.centerSeekForward } as SeekForwardButtonProps)}
   </div>
-  <media-time-range></media-time-range>
+  ${MediaTimeRange()}
   <media-control-bar>
-    <mxp-time-display></mxp-time-display>
+    ${TimeDisplay()}
     ${MediaMuteButton()}
-    <media-volume-range></media-volume-range>
+    ${MediaVolumeRange()}
     <div class="mxp-spacer"></div>
-    <media-playback-rate-button></media-playback-rate-button>
+    ${MediaPlaybackRateButton()}
     ${MediaFullscreenButton()}
     <div class="mxp-padding-2"></div>
   </media-control-bar>
@@ -275,18 +327,18 @@ export const VodChromeSmall = (props: ThemeMuxTemplateProps) => html`
 // prettier-ignore
 export const VodChromeLarge = (props: ThemeMuxTemplateProps) => html`
   <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaPlayButton()}
+    ${MediaPlayButton({ part: parts.centerPlay })}
   </div>
-  <media-time-range></media-time-range>
+  ${MediaTimeRange()}
   <media-control-bar>
     ${MediaPlayButton()}
-    ${MediaSeekBackwardButton(props)}
-    ${MediaSeekForwardButton(props)}
-    <mxp-time-display></mxp-time-display>
+    ${MediaSeekBackwardButton(props as SeekBackwardButtonProps)}
+    ${MediaSeekForwardButton(props as SeekForwardButtonProps)}
+    ${TimeDisplay()}
     ${MediaMuteButton()}
-    <media-volume-range></media-volume-range>
+    ${MediaVolumeRange()}
     <div class="mxp-spacer"></div>
-    <media-playback-rate-button></media-playback-rate-button>
+    ${MediaPlaybackRateButton()}
     ${MediaCaptionsButton(props)}
     ${MediaAirplayButton()}
     ${MediaCastButton()}
@@ -310,11 +362,11 @@ export const LiveChromeSmall = (props: ThemeMuxTemplateProps) => html`
     ${MediaPipButton()}
   </media-control-bar>
   <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaPlayButton()}
+    ${MediaPlayButton({ part: parts.centerPlay })}
   </div>
   <media-control-bar>
     ${MediaMuteButton()}
-    <media-volume-range></media-volume-range>
+    ${MediaVolumeRange()}
     <div class="mxp-spacer"></div>
     ${MediaFullscreenButton()}
   </media-control-bar>
@@ -326,11 +378,11 @@ export const LiveChromeLarge = (props: ThemeMuxTemplateProps) => html`
     <slot name="seek-to-live-button"></slot>
   </media-control-bar>
   <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaPlayButton()}
+    ${MediaPlayButton({ part: parts.centerPlay })}
   </div>
   <media-control-bar>
     ${MediaMuteButton()}
-    <media-volume-range></media-volume-range>
+    ${MediaVolumeRange()}
     <div class="mxp-spacer"></div>
     ${MediaCaptionsButton(props)}
     ${MediaAirplayButton()}
@@ -352,14 +404,14 @@ export const DvrChromeSmall = (props: ThemeMuxTemplateProps) => html`
     ${MediaPipButton()}
   </media-control-bar>
   <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaSeekBackwardButton(props)}
-    ${MediaPlayButton()}
-    ${MediaSeekForwardButton(props)}
+    ${MediaSeekBackwardButton({ ...props, part: parts.centerSeekBackward } as SeekBackwardButtonProps)}
+    ${MediaPlayButton({ part: parts.centerPlay })}
+    ${MediaSeekForwardButton({ ...props, part: parts.centerSeekForward } as SeekForwardButtonProps)}
   </div>
-  <media-time-range></media-time-range>
+  ${MediaTimeRange()}
   <media-control-bar>
     ${MediaMuteButton()}
-    <media-volume-range></media-volume-range>
+    ${MediaVolumeRange()}
     <slot name="seek-to-live-button"></slot>
     <div class="mxp-spacer"></div>
     ${MediaFullscreenButton()}
@@ -370,15 +422,15 @@ export const DvrChromeSmall = (props: ThemeMuxTemplateProps) => html`
 // prettier-ignore
 export const DvrChromeLarge = (props: ThemeMuxTemplateProps) => html`
   <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaPlayButton()}
+    ${MediaPlayButton({ part: parts.centerPlay })}
   </div>
-  <media-time-range></media-time-range>
+  ${MediaTimeRange()}
   <media-control-bar>
     ${MediaPlayButton()}
-    ${MediaSeekBackwardButton(props)}
-    ${MediaSeekForwardButton(props)}
+    ${MediaSeekBackwardButton(props as SeekBackwardButtonProps)}
+    ${MediaSeekForwardButton(props as SeekForwardButtonProps)}
     ${MediaMuteButton()}
-    <media-volume-range></media-volume-range>
+    ${MediaVolumeRange()}
     <slot name="seek-to-live-button"></slot>
     <div class="mxp-spacer"></div>
     ${MediaCaptionsButton(props)}

--- a/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
+++ b/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
@@ -23,7 +23,7 @@ type ThemeMuxTemplateProps = {
 };
 
 export const parts = {
-  backdrop: 'controls backdrop',
+  mediaChrome: 'layer media-layer poster-layer vertical-layer centered-layer',
   centerPlay: 'center play button',
   centerSeekBackward: 'center seek-backward button',
   centerSeekForward: 'center seek-forward button',
@@ -73,9 +73,12 @@ export default class MediaThemeMux extends MediaTheme {
         <style>
           ${cssStr}
         </style>
-        <media-controller audio="${props.audio || false}" class="size-${props.playerSize}">
+        <media-controller
+          audio="${props.audio || false}"
+          class="size-${props.playerSize}"
+          exportparts="${parts.mediaChrome.split(' ').join(', ')}"
+        >
           <slot name="media" slot="media"></slot>
-          <div slot="top-chrome" class="backdrop" part="${parts.backdrop}"></div>
           <media-loading-indicator slot="centered-chrome" no-auto-hide></media-loading-indicator>
           ${ChromeRenderer(props)}
           <slot></slot>

--- a/packages/mux-player/src/media-theme-mux/styles.css
+++ b/packages/mux-player/src/media-theme-mux/styles.css
@@ -49,7 +49,7 @@
   background: transparent;
 }
 
-:host([audio]) .backdrop {
+:host([audio]) media-controller::part(vertical-layer) {
   background: transparent;
 }
 
@@ -102,7 +102,6 @@ media-controller {
 
 media-control-bar {
   --media-button-icon-width: 18px;
-  z-index: 1;
 }
 
 media-control-bar :is([role='button'], [role='switch'], button) {
@@ -129,14 +128,13 @@ media-control-bar :is([role='button'], [role='switch'], button) {
   background-color: var(--media-control-background, rgba(20, 20, 30, 0.7));
 }
 
-.backdrop {
-  pointer-events: none;
+media-controller::part(vertical-layer) {
+  transition: background-color 1s;
+}
+
+media-controller:is([media-paused], :not([user-inactive]))::part(vertical-layer) {
   background-color: rgba(0, 0, 0, 0.6);
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  transition: background-color 0.25s;
 }
 
 .mxp-center-controls {

--- a/packages/mux-player/src/media-theme-mux/styles.css
+++ b/packages/mux-player/src/media-theme-mux/styles.css
@@ -49,7 +49,7 @@
   background: transparent;
 }
 
-:host([audio]) media-controller::part(vertical-layer) {
+:host([audio]) .backdrop {
   background: transparent;
 }
 
@@ -102,6 +102,7 @@ media-controller {
 
 media-control-bar {
   --media-button-icon-width: 18px;
+  z-index: 1;
 }
 
 media-control-bar :is([role='button'], [role='switch'], button) {
@@ -128,13 +129,14 @@ media-control-bar :is([role='button'], [role='switch'], button) {
   background-color: var(--media-control-background, rgba(20, 20, 30, 0.7));
 }
 
-media-controller::part(vertical-layer) {
-  transition: background-color 1s;
-}
-
-media-controller:is([media-paused], :not([user-inactive]))::part(vertical-layer) {
+.backdrop {
+  pointer-events: none;
   background-color: rgba(0, 0, 0, 0.6);
-  transition: background-color 0.25s;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 
 .mxp-center-controls {

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -22,7 +22,7 @@ export const template = (props: MuxTemplateProps) => html`
 `;
 
 const flatCSSParts = Object.values(parts).flatMap((group) => group.split(' '));
-const forwardUniqueCSSParts = [...new Set(flatCSSParts)];
+const forwardUniqueCSSParts = [...new Set(flatCSSParts)].join(', ');
 
 export const content = (props: MuxTemplateProps) => html`
   <${unsafeStatic(castThemeName(props.theme) ?? 'media-theme-mux')}
@@ -39,7 +39,7 @@ export const content = (props: MuxTemplateProps) => html`
     default-hidden-captions="${props.defaultHiddenCaptions}"
     forward-seek-offset="${props.forwardSeekOffset}"
     backward-seek-offset="${props.backwardSeekOffset}"
-    exportparts="${forwardUniqueCSSParts}"
+    exportparts="seek-live, ${forwardUniqueCSSParts}"
   >
     <mux-video
       slot="media"

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -1,4 +1,4 @@
-import './media-theme-mux/media-theme-mux';
+import { parts } from './media-theme-mux/media-theme-mux';
 import './dialog';
 import {
   castThemeName,
@@ -21,6 +21,9 @@ export const template = (props: MuxTemplateProps) => html`
   ${content(props)}
 `;
 
+const flatCSSParts = Object.values(parts).flatMap((group) => group.split(' '));
+const forwardUniqueCSSParts = [...new Set(flatCSSParts)];
+
 export const content = (props: MuxTemplateProps) => html`
   <${unsafeStatic(castThemeName(props.theme) ?? 'media-theme-mux')}
     audio="${props.audio || false}"
@@ -36,6 +39,7 @@ export const content = (props: MuxTemplateProps) => html`
     default-hidden-captions="${props.defaultHiddenCaptions}"
     forward-seek-offset="${props.forwardSeekOffset}"
     backward-seek-offset="${props.backwardSeekOffset}"
+    exportparts="${forwardUniqueCSSParts}"
   >
     <mux-video
       slot="media"
@@ -102,6 +106,8 @@ export const content = (props: MuxTemplateProps) => html`
     </mux-video>
     <button
       slot="seek-to-live-button"
+      part="seek-live button"
+      class="mxp-seek-to-live-button"
       aria-disabled="${props.inLiveWindow}"
       onclick="${function (this: HTMLButtonElement, evt: Event) {
         props.onSeekToLive?.(evt);
@@ -110,7 +116,6 @@ export const content = (props: MuxTemplateProps) => html`
           (this as HTMLButtonElement).dispatchEvent(playRequestEvt);
         }
       }}"
-      class="mxp-seek-to-live-button"
     >
       Live
     </button>

--- a/packages/mux-player/test/template.test.js
+++ b/packages/mux-player/test/template.test.js
@@ -11,7 +11,7 @@ describe('<mux-player> template render', () => {
     render(content({}), div);
     assert.equal(
       minify(div.innerHTML),
-      '<media-theme-mux class="size-" stream-type="" player-size="" default-hidden-captions="" forward-seek-offset="" backward-seek-offset=""><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version=""></mux-video><button slot="seek-to-live-button" aria-disabled="" class="mxp-seek-to-live-button">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><p></p></mxp-dialog></media-theme-mux>'
+      '<media-theme-mux class="size-" stream-type="" player-size="" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="controls,backdrop,center,play,button,seek-backward,seek-forward,mute,captions,airplay,pip,fullscreen,cast,playbackrate,volume,range,time,display"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version=""></mux-video><button slot="seek-to-live-button" part="seek-live button" class="mxp-seek-to-live-button" aria-disabled="">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><p></p></mxp-dialog></media-theme-mux>'
     );
   });
 
@@ -29,7 +29,7 @@ describe('<mux-player> template render', () => {
     div.querySelectorAll('svg').forEach((svg) => svg.remove());
     assert.equal(
       minify(div.innerHTML),
-      '<media-theme-mux class="size-extra-small" stream-type="on-demand" player-size="extra-small" default-hidden-captions="" forward-seek-offset="" backward-seek-offset=""><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><button slot="seek-to-live-button" aria-disabled="" class="mxp-seek-to-live-button">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme-mux>'
+      '<media-theme-mux class="size-extra-small" stream-type="on-demand" player-size="extra-small" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="controls,backdrop,center,play,button,seek-backward,seek-forward,mute,captions,airplay,pip,fullscreen,cast,playbackrate,volume,range,time,display"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><button slot="seek-to-live-button" part="seek-live button" class="mxp-seek-to-live-button" aria-disabled="">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme-mux>'
     );
   });
 
@@ -45,7 +45,7 @@ describe('<mux-player> template render', () => {
     div.querySelectorAll('svg').forEach((svg) => svg.remove());
     assert.equal(
       minify(div.innerHTML),
-      '<media-theme-mux class="size-large" stream-type="on-demand" player-size="large" default-hidden-captions="" forward-seek-offset="" backward-seek-offset=""><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><button slot="seek-to-live-button" aria-disabled="" class="mxp-seek-to-live-button">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><p></p></mxp-dialog></media-theme-mux>'
+      '<media-theme-mux class="size-large" stream-type="on-demand" player-size="large" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="controls,backdrop,center,play,button,seek-backward,seek-forward,mute,captions,airplay,pip,fullscreen,cast,playbackrate,volume,range,time,display"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><button slot="seek-to-live-button" part="seek-live button" class="mxp-seek-to-live-button" aria-disabled="">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><p></p></mxp-dialog></media-theme-mux>'
     );
   });
 
@@ -64,7 +64,7 @@ describe('<mux-player> template render', () => {
     div.querySelectorAll('svg').forEach((svg) => svg.remove());
     assert.equal(
       minify(div.innerHTML),
-      '<media-theme-mux class="size-large" stream-type="on-demand" player-size="large" default-hidden-captions="" forward-seek-offset="" backward-seek-offset=""><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><button slot="seek-to-live-button" aria-disabled="" class="mxp-seek-to-live-button">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme-mux>'
+      '<media-theme-mux class="size-large" stream-type="on-demand" player-size="large" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="controls,backdrop,center,play,button,seek-backward,seek-forward,mute,captions,airplay,pip,fullscreen,cast,playbackrate,volume,range,time,display"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><button slot="seek-to-live-button" part="seek-live button" class="mxp-seek-to-live-button" aria-disabled="">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme-mux>'
     );
   });
 });

--- a/packages/mux-player/test/template.test.js
+++ b/packages/mux-player/test/template.test.js
@@ -7,11 +7,13 @@ const minify = (html) => html.trim().replace(/>\s+</g, '><');
 describe('<mux-player> template render', () => {
   const div = document.createElement('div');
 
+  const exportParts = `seek-live, layer, media-layer, poster-layer, vertical-layer, centered-layer, center, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playbackrate, volume, range, time, display`;
+
   it('default template without props', function () {
     render(content({}), div);
     assert.equal(
       minify(div.innerHTML),
-      '<media-theme-mux class="size-" stream-type="" player-size="" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="controls,backdrop,center,play,button,seek-backward,seek-forward,mute,captions,airplay,pip,fullscreen,cast,playbackrate,volume,range,time,display"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version=""></mux-video><button slot="seek-to-live-button" part="seek-live button" class="mxp-seek-to-live-button" aria-disabled="">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><p></p></mxp-dialog></media-theme-mux>'
+      `<media-theme-mux class="size-" stream-type="" player-size="" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version=""></mux-video><button slot="seek-to-live-button" part="seek-live button" class="mxp-seek-to-live-button" aria-disabled="">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><p></p></mxp-dialog></media-theme-mux>`
     );
   });
 
@@ -29,7 +31,7 @@ describe('<mux-player> template render', () => {
     div.querySelectorAll('svg').forEach((svg) => svg.remove());
     assert.equal(
       minify(div.innerHTML),
-      '<media-theme-mux class="size-extra-small" stream-type="on-demand" player-size="extra-small" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="controls,backdrop,center,play,button,seek-backward,seek-forward,mute,captions,airplay,pip,fullscreen,cast,playbackrate,volume,range,time,display"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><button slot="seek-to-live-button" part="seek-live button" class="mxp-seek-to-live-button" aria-disabled="">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme-mux>'
+      `<media-theme-mux class="size-extra-small" stream-type="on-demand" player-size="extra-small" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><button slot="seek-to-live-button" part="seek-live button" class="mxp-seek-to-live-button" aria-disabled="">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme-mux>`
     );
   });
 
@@ -45,7 +47,7 @@ describe('<mux-player> template render', () => {
     div.querySelectorAll('svg').forEach((svg) => svg.remove());
     assert.equal(
       minify(div.innerHTML),
-      '<media-theme-mux class="size-large" stream-type="on-demand" player-size="large" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="controls,backdrop,center,play,button,seek-backward,seek-forward,mute,captions,airplay,pip,fullscreen,cast,playbackrate,volume,range,time,display"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><button slot="seek-to-live-button" part="seek-live button" class="mxp-seek-to-live-button" aria-disabled="">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><p></p></mxp-dialog></media-theme-mux>'
+      `<media-theme-mux class="size-large" stream-type="on-demand" player-size="large" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><button slot="seek-to-live-button" part="seek-live button" class="mxp-seek-to-live-button" aria-disabled="">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><p></p></mxp-dialog></media-theme-mux>`
     );
   });
 
@@ -64,7 +66,7 @@ describe('<mux-player> template render', () => {
     div.querySelectorAll('svg').forEach((svg) => svg.remove());
     assert.equal(
       minify(div.innerHTML),
-      '<media-theme-mux class="size-large" stream-type="on-demand" player-size="large" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="controls,backdrop,center,play,button,seek-backward,seek-forward,mute,captions,airplay,pip,fullscreen,cast,playbackrate,volume,range,time,display"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><button slot="seek-to-live-button" part="seek-live button" class="mxp-seek-to-live-button" aria-disabled="">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme-mux>'
+      `<media-theme-mux class="size-large" stream-type="on-demand" player-size="large" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><button slot="seek-to-live-button" part="seek-live button" class="mxp-seek-to-live-button" aria-disabled="">\n      Live\n    </button><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme-mux>`
     );
   });
 });


### PR DESCRIPTION
this change adds the first step for easily hiding/showing the controls w/ CSS parts.

the controls backdrop is isolated in a separate div element to make it possible to assign a CSS part to.