### PR TITLE
fix: CustomVideo.nativeEl being null in some cases

### DIFF
--- a/examples/nextjs-with-typescript/pages/index.tsx
+++ b/examples/nextjs-with-typescript/pages/index.tsx
@@ -47,6 +47,11 @@ function HomePage() {
         </li>
         <li>
           <h3>
+            <Link href="/mux-audio">Mux Audio (Web Component) Demo</Link>
+          </h3>
+        </li>
+        <li>
+          <h3>
             <Link href="/mux-player">Mux Player (Web Component) Demo</Link>
           </h3>
         </li>

--- a/packages/mux-audio/src/CustomAudioElement.js
+++ b/packages/mux-audio/src/CustomAudioElement.js
@@ -78,8 +78,24 @@ class CustomAudioElement extends HTMLElement {
     if (this.#isInit) return;
     this.#isInit = true;
 
-    this.shadowRoot.appendChild(template.content.cloneNode(true));
+    this.shadowRoot.append(template.content.cloneNode(true));
     const nativeEl = (this.nativeEl = this.shadowRoot.querySelector('audio'));
+
+    // The audio events are dispatched on the CustomAudioElement instance.
+    // This makes it possible to add event listeners before the element is upgraded.
+    AudioEvents.forEach((type) => {
+      nativeEl.addEventListener(type, (evt) => {
+        this.dispatchEvent(new CustomEvent(evt.type, { detail: evt.detail }));
+      });
+    });
+
+    const slotEl = this.shadowRoot.querySelector('slot');
+    slotEl.addEventListener('slotchange', () => {
+      slotEl.assignedElements().forEach((el) => {
+        if (!['track', 'source'].includes(el.localName)) return;
+        nativeEl.append(el);
+      });
+    });
 
     // Initialize all the attribute properties
     // This is required before attributeChangedCallback is called after construction
@@ -96,21 +112,6 @@ class CustomAudioElement extends HTMLElement {
     if (nativeEl.defaultMuted) {
       nativeEl.muted = true;
     }
-
-    // The audio events are dispatched on the CustomAudioElement instance.
-    // This makes it possible to add event listeners before the element is upgraded.
-    AudioEvents.forEach((type) => {
-      nativeEl.addEventListener(type, (evt) => {
-        this.dispatchEvent(new CustomEvent(evt.type, { detail: evt.detail }));
-      });
-    });
-
-    const slotEl = this.shadowRoot.querySelector('slot');
-    slotEl.addEventListener('slotchange', () => {
-      slotEl.assignedElements().forEach((el) => {
-        nativeEl.appendChild(el);
-      });
-    });
   }
 
   // observedAttributes is required to trigger attributeChangedCallback

--- a/packages/mux-audio/src/CustomAudioElement.js
+++ b/packages/mux-audio/src/CustomAudioElement.js
@@ -59,10 +59,25 @@ template.innerHTML = `
 `;
 
 class CustomAudioElement extends HTMLElement {
+  #isInit;
+
   constructor() {
     super();
-
     this.attachShadow({ mode: 'open' });
+
+    // If the custom element is defined before the <custom-video> HTML is parsed
+    // no attributes will be available in the constructor (construction process).
+    // Wait until initializing attributes in the attributeChangedCallback.
+    // If this element is connected to the DOM, the attributes will be available.
+    if (this.isConnected) {
+      this.#init();
+    }
+  }
+
+  #init() {
+    if (this.#isInit) return;
+    this.#isInit = true;
+
     this.shadowRoot.appendChild(template.content.cloneNode(true));
     const nativeEl = (this.nativeEl = this.shadowRoot.querySelector('audio'));
 
@@ -135,6 +150,9 @@ class CustomAudioElement extends HTMLElement {
   // We need to handle sub-class custom attributes differently from
   // attrs meant to be passed to the internal native el.
   attributeChangedCallback(attrName, oldValue, newValue) {
+    // Initialize right after construction when the attributes become available.
+    this.#init();
+
     this.forwardAttribute(attrName, oldValue, newValue);
   }
 
@@ -177,7 +195,9 @@ class CustomAudioElement extends HTMLElement {
     }
   }
 
-  connectedCallback() {}
+  connectedCallback() {
+    this.#init();
+  }
 }
 
 // Map all native element properties to the custom element

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -251,6 +251,8 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
   }
 
   attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string | null) {
+    super.attributeChangedCallback(attrName, oldValue, newValue);
+
     switch (attrName) {
       case 'src':
         const hadSrc = !!oldValue;
@@ -295,8 +297,6 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
       default:
         break;
     }
-
-    super.attributeChangedCallback(attrName, oldValue, newValue);
   }
 
   disconnectedCallback() {

--- a/packages/mux-video/src/CustomVideoElement.js
+++ b/packages/mux-video/src/CustomVideoElement.js
@@ -66,7 +66,6 @@ template.innerHTML = `
 `;
 
 class CustomVideoElement extends HTMLElement {
-  #hasAttrCallback;
   #isInit;
 
   constructor() {
@@ -165,11 +164,8 @@ class CustomVideoElement extends HTMLElement {
   }
 
   attributeChangedCallback(attrName, oldValue, newValue) {
-    // Initialize the attributes right after construction when they become available.
-    if (!this.#hasAttrCallback && !this.isConnected) {
-      this.#hasAttrCallback = true;
-      this.#init();
-    }
+    // Initialize right after construction when the attributes become available.
+    this.#init();
 
     this.#forwardAttribute(attrName, oldValue, newValue);
   }
@@ -215,7 +211,9 @@ class CustomVideoElement extends HTMLElement {
     }
   }
 
-  connectedCallback() {}
+  connectedCallback() {
+    this.#init();
+  }
 }
 
 // Map all native element properties to the custom element

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -352,6 +352,8 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
   // }
 
   attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string | null) {
+    super.attributeChangedCallback(attrName, oldValue, newValue);
+
     switch (attrName) {
       case Attributes.PLAYER_SOFTWARE_NAME:
         this.playerSoftwareName = newValue ?? undefined;
@@ -406,8 +408,6 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
       default:
         break;
     }
-
-    super.attributeChangedCallback(attrName, oldValue, newValue);
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
fix #314

this change fixes a bug where `customVideo.nativeEl` or `customAudio.nativeEl` would be undefined in the playback core `initialize` function causing the set of the weakmap key to error.

nativeEl was undefined because the init flow of the custom media elements was not called yet.
moving the super.attributeChangedCallback to the top fixed this issue 