### PR TITLE
chore: use Node 16 LTS

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,17 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
-      # extract `engines.node` from package.json and save it to output
-      - name: Get Node.JS version from package.json
-        id: get-versions
-        run: echo ::set-output name=node::$(jq -r .engines.node ./package.json)
-      - name: Use Node.js ${{ steps.get-versions.outputs.node }}
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.get-versions.outputs.node }}
+          node-version: 16
           # this line is required for the setup-node action to be able to run the npm publish below.
           registry-url: 'https://registry.npmjs.org'
       - name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      # extract `engines.node` from package.json and save it to output
-      - name: Get Node.JS version from package.json
-        id: get-versions
-        run: echo ::set-output name=node::$(jq -r .engines.node ./package.json)
-      - name: Use Node.js ${{ steps.get-versions.outputs.node }}
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.get-versions.outputs.node }}
+          node-version: 16
           # this line is required for the setup-node action to be able to run the npm publish below.
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
@@ -30,15 +25,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      # extract `engines.node` from package.json and save it to output
-      - name: Get Node.JS version from package.json
-        id: get-versions
-        run: echo ::set-output name=node::$(jq -r .engines.node ./package.json)
-      - name: Use Node.js ${{ steps.get-versions.outputs.node }}
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.get-versions.outputs.node }}
+          node-version: 16
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn lint
@@ -47,15 +37,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      # extract `engines.node` from package.json and save it to output
-      - name: Get Node.JS version from package.json
-        id: get-versions
-        run: echo ::set-output name=node::$(jq -r .engines.node ./package.json)
-      - name: Use Node.js ${{ steps.get-versions.outputs.node }}
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.get-versions.outputs.node }}
+          node-version: 16
           cache: yarn
       # esbuild requires --ignore-scripts to NOT be added here.
       - run: yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/elements",
   "engines": {
-    "node": "^14.17.0",
+    "node": "^14.17.0 || ^16.13.0",
     "npm": "^7.17.0"
   },
   "version": "0.1.0",


### PR DESCRIPTION
update Node to version 16.

The extracting in GH action is removed because the 2 versions, I think it's also not really needed to be automated. if we upgrade again I'm pretty sure we will not miss updating it in the GH actions.