### PR TITLE
fix(mux-uploader / mux-uploader-react): Error event collisions

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxUploader.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxUploader.tsx
@@ -6,9 +6,12 @@ import { useState, ChangeEvent } from "react";
 const onUploadStart = console.log.bind(null, 'uploadStart');
 const onChunkAttempt = console.log.bind(null, "chunkAttempt");
 const onChunkSuccess = console.log.bind(null, "chunkSuccess");
-const onError = console.log.bind(null, "error");
 const onProgress = console.log.bind(null, "progress");
 const onSuccess = console.log.bind(null, "success");
+
+const onUploadError = ({ detail }) => {
+  console.log(detail.message);
+}
 
 function MuxUploaderPage() {
   const [url, setUrl] = useState("");
@@ -36,7 +39,7 @@ function MuxUploaderPage() {
             onChunkAttempt={onChunkAttempt}
             onChunkSuccess={onChunkSuccess}
             onSuccess={onSuccess}
-            onError={onError}
+            onUploadError={onUploadError}
             onProgress={onProgress}
           />
       </div>

--- a/packages/mux-uploader-react/README.md
+++ b/packages/mux-uploader-react/README.md
@@ -94,6 +94,6 @@ const MuxUploaderWithMuxUploaderDropExample = () => {
 | `onUploadStart`  | Fired when the upload begins.                                                                                                                                        |
 | `onChunkAttempt` | Invoked immediately before a chunk upload is attempted.                                                                                                              |
 | `onChunkSuccess` | Invoked when an indvidual chunk is successfully uploaded. Sample response: `{ detail: { chunk: Integer, attempts: Integer, response: XhrResponse } }`                |
-| `onError`        | Invoked when an error occurs in the chunked upload process.                                                                                                          |
+| `onUploadError`  | Invoked when an error occurs in the chunked upload process.                                                                                                          |
 | `onProgress`     | Invoked continuously with incremental upload progress. This returns the current percentage of the file that's been uploaded. Sample response: `{ detail: [0..100] }` |
 | `onSuccess`      | Invoked when the entire file has successfully completed uploading.                                                                                                   |

--- a/packages/mux-uploader-react/src/index.tsx
+++ b/packages/mux-uploader-react/src/index.tsx
@@ -40,7 +40,7 @@ export type MuxUploaderProps = {
   onUploadStart?: GenericEventListener<MuxUploaderElementEventMap['uploadstart']>;
   onChunkAttempt?: GenericEventListener<MuxUploaderElementEventMap['chunkattempt']>;
   onChunkSuccess?: GenericEventListener<MuxUploaderElementEventMap['chunksuccess']>;
-  onError?: GenericEventListener<MuxUploaderElementEventMap['error']>;
+  onUploadError?: GenericEventListener<MuxUploaderElementEventMap['uploaderror']>;
   onProgress?: GenericEventListener<MuxUploaderElementEventMap['progress']>;
   onSuccess?: GenericEventListener<MuxUploaderElementEventMap['success']>;
 } & Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>, 'ref'>;
@@ -76,7 +76,7 @@ const useUploader = (
     onUploadStart,
     onChunkAttempt,
     onChunkSuccess,
-    onError,
+    onUploadError,
     onProgress,
     onSuccess,
     formatProgress,
@@ -88,7 +88,7 @@ const useUploader = (
   useEventCallbackEffect('uploadstart', ref, onUploadStart);
   useEventCallbackEffect('chunkattempt', ref, onChunkAttempt);
   useEventCallbackEffect('chunksuccess', ref, onChunkSuccess);
-  useEventCallbackEffect('error', ref, onError);
+  useEventCallbackEffect('uploaderror', ref, onUploadError);
   useEventCallbackEffect('progress', ref, onProgress);
   useEventCallbackEffect('success', ref, onSuccess);
   return [remainingProps];

--- a/packages/mux-uploader/README.md
+++ b/packages/mux-uploader/README.md
@@ -133,7 +133,7 @@ This also means you can implement your own drag and drop (or other) components f
 | `uploadstart`  | Fired when the upload begins.                                                                                                                                      |
 | `chunkattempt` | Fired immediately before a chunk upload is attempted.                                                                                                              |
 | `chunksuccess` | Fired when an indvidual chunk is successfully uploaded. Sample response: `{ detail: { chunk: Integer, attempts: Integer, response: XhrResponse } }`                |
-| `error`        | Fired when an error occurs in the chunked upload process.                                                                                                          |
+| `uploaderror`  | Fired when an error occurs in the chunked upload process.                                                                                                          |
 | `progress`     | Fired continuously with incremental upload progress. This returns the current percentage of the file that's been uploaded. Sample response: `{ detail: [0..100] }` |
 | `success`      | Fired when the entire file has successfully completed uploading.                                                                                                   |
 

--- a/packages/mux-uploader/src/index.ts
+++ b/packages/mux-uploader/src/index.ts
@@ -229,8 +229,8 @@ type ErrorDetail = {
   attempts?: number;
 };
 
-// NOTE: error and progress events are already determined on HTMLElement but have inconsistent types. Should consider renaming events (CJP)
-export interface MuxUploaderElementEventMap extends Omit<HTMLElementEventMap, 'error' | 'progress'> {
+// NOTE: Progress event is already determined on HTMLElement but have inconsistent types. Should consider renaming events (CJP)
+export interface MuxUploaderElementEventMap extends Omit<HTMLElementEventMap, 'progress'> {
   uploadstart: CustomEvent<{ file: File; chunkSize: number }>;
   chunkattempt: CustomEvent<{
     chunkNumber: number;
@@ -242,7 +242,7 @@ export interface MuxUploaderElementEventMap extends Omit<HTMLElementEventMap, 'e
     // Note: This should be more explicitly typed in Upchunk. (TD).
     response: any;
   }>;
-  error: CustomEvent<ErrorDetail>;
+  uploaderror: CustomEvent<ErrorDetail>;
   progress: CustomEvent<number>;
   success: CustomEvent<undefined | null>;
 }
@@ -473,7 +473,7 @@ class MuxUploaderElement extends HTMLElement implements MuxUploaderElement {
       }
       this.setAttribute('upload-error', '');
       console.error(invalidUrlMessage);
-      this.dispatchEvent(new CustomEvent('error', { detail: { message: invalidUrlMessage } }));
+      this.dispatchEvent(new CustomEvent('uploaderror', { detail: { message: invalidUrlMessage } }));
       // Bail early if no endpoint.
       return;
     } else {
@@ -511,7 +511,7 @@ class MuxUploaderElement extends HTMLElement implements MuxUploaderElement {
       }
 
       console.error(event.detail.message);
-      this.dispatchEvent(new CustomEvent('error', event));
+      this.dispatchEvent(new CustomEvent('uploaderror', event));
     });
 
     upload.on('progress', (event) => {


### PR DESCRIPTION
## Description

A user was getting this Typescript error when using `onError`:

<img width="1117" alt="Screen Shot 2022-08-09 at 3 53 04 PM" src="https://user-images.githubusercontent.com/22087604/184022625-e62ce558-c6d9-4832-8647-b2dedce62944.png">

After some digging, it turns out...

- [React elements](https://reactjs.org/docs/events.html) have an event handler called `onError` 💡 
- [HTML elements](https://developer.mozilla.org/en-US/docs/Web/API/Element/error_event) have an event handler called `error` 💡 

This PR renames both...
- `mux-uploader`'s custom event dispatch name from `error` to `uploaderror`; and ↔️ 
- `MuxUploader`'s error handler from `onError` to `onUploadError` ↔️ 
- Updates related `README`s and example(s) ✅ 

...which _should_ resolve the Typescript error and prevent collisions 🌈 

## Testing

- [x] Locally on the `next.js` app ✨ 

