### PR TITLE
ci: fix upgrading canary deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
       - run: yarn install --frozen-lockfile
+      # build the packages for feature branches only
       - run: yarn build:packages
+        if: ${{ github.ref != 'refs/heads/main' }}
+      # on the main branch the `prepublishOnly` hook will trigger package builds
       - run: npm run publish-release -- canary
         if: ${{ github.ref == 'refs/heads/main' }}
         env:

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -60,7 +60,7 @@ function release {
 
   # update all workspaces from the workspace root (../..) with the new version
   # make sure publish.sh is called in topological order, `lerna ls --toposort` does this
-  DEPENDANT_PKGS=$(npx lerna ls --graph --all --toposort |
+  DEPENDANT_PKGS=$(npx lerna ls --graph --toposort --scope @mux/* |
     jq -r "to_entries[] | select(.value[] | contains(\"$PKG_NAME\")) | .key")
   scope=""
   for name in ${DEPENDANT_PKGS}; do
@@ -116,7 +116,7 @@ function canary {
 
   # update all workspaces from the workspace root (../..) with the new version
   # make sure publish.sh is called in topological order, `lerna ls --toposort` does this
-  DEPENDANT_PKGS=$(npx lerna ls --graph --all --toposort |
+  DEPENDANT_PKGS=$(npx lerna ls --graph --toposort --scope @mux/* |
     jq -r "to_entries[] | select(.value[] | contains(\"$PKG_NAME\")) | .key")
   scope=""
   for name in ${DEPENDANT_PKGS}; do


### PR DESCRIPTION
Fixes the upgrading of the dependencies after a new canary was released of a package.

### todo

- [x] fix build number
potential fix by @gkatsev 
```bash
jq '. - map(select(contains("alpha") or contains("beta"))) | map(split(".")[3] | split("-")[0] | tonumber) | sort | last'
```