### PR TITLE
feat: use CSS vars to toggle off elements

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -2,7 +2,7 @@
 import Link from "next/link";
 import Script from 'next/script';
 import MuxPlayer from "@mux/mux-player-react";
-import { useRef, useState, useEffect, useCallback } from "react";
+import { useRef, useState } from "react";
 import mediaAssetsJSON from "@mux/assets/media-assets.json";
 
 const INITIAL_PRIMARY_COLOR = undefined;
@@ -16,7 +16,6 @@ const INITIAL_NOHOTKEYS = false;
 const INITIAL_DEFAULT_SHOW_REMAINING_TIME = true;
 const INITIAL_PLAYBACK_RATES = [0.25, 0.5, 1, 1.5, 2, 3];
 const INITIAL_ENV_KEY = "5e67cqdt7hgc9vkla7p0qch7q";
-const INITIAL_CONTROLS_CSS_VARS = [];
 const INITIAL_SELECTED_CSS_VARS = {};
 
 const toMetadataFromMediaAsset = (mediaAsset: typeof mediaAssetsJSON[0], mediaAssets: typeof mediaAssetsJSON) => {
@@ -63,12 +62,7 @@ function MuxPlayerPage() {
   const [autoplay, setAutoplay] = useState<"muted" | boolean>(INITIAL_AUTOPLAY);
   const [primaryColor, setPrimaryColor] = useState<string|undefined>(INITIAL_PRIMARY_COLOR);
   const [secondaryColor, setSecondaryColor] = useState<string|undefined>(INITIAL_SECONDARY_COLOR);
-  const [controlsCssVars, setControlsCssVars] = useState(INITIAL_CONTROLS_CSS_VARS);
   const [selectedCssVars, setSelectedCssVars] = useState(INITIAL_SELECTED_CSS_VARS);
-
-  useMutationObserver(mediaElRef.current?.theme.shadowRoot, useCallback(() => {
-    setControlsCssVars(getAvailableControlsCssVars(mediaElRef.current?.theme?.shadowRoot));
-  }, [setControlsCssVars]));
 
   return (
     <div>
@@ -224,11 +218,43 @@ function MuxPlayerPage() {
                 .map(({ value }) => [value, 'none']))
             )}
           >
-            {controlsCssVars.map((token, i) => {
-              return (
-                <option key={i} value={token}>{token}</option>
-              )
-            })}
+            <option value="--controls">--controls</option>
+            <option value="--top-controls">--top-controls</option>
+            <option value="--center-controls">--center-controls</option>
+            <option value="--bottom-controls">--bottom-controls</option>
+            <option value="--duration-display">--duration-display</option>
+            <option value="--bottom-duration-display">--bottom-duration-display</option>
+            <option value="--play-button">--play-button</option>
+            <option value="--center-play-button">--center-play-button</option>
+            <option value="--bottom-play-button">--bottom-play-button</option>
+            <option value="--time-range">--time-range</option>
+            <option value="--bottom-time-range">--bottom-time-range</option>
+            <option value="--seek-backward-button">--seek-backward-button</option>
+            <option value="--bottom-seek-backward-button">--bottom-seek-backward-button</option>
+            <option value="--seek-forward-button">--seek-forward-button</option>
+            <option value="--bottom-seek-forward-button">--bottom-seek-forward-button</option>
+            <option value="--time-display">--time-display</option>
+            <option value="--bottom-time-display">--bottom-time-display</option>
+            <option value="--mute-button">--mute-button</option>
+            <option value="--bottom-mute-button">--bottom-mute-button</option>
+            <option value="--volume-range">--volume-range</option>
+            <option value="--bottom-volume-range">--bottom-volume-range</option>
+            <option value="--playback-rate-button">--playback-rate-button</option>
+            <option value="--bottom-playback-rate-button">--bottom-playback-rate-button</option>
+            <option value="--captions-button">--captions-button</option>
+            <option value="--top-captions-button">--top-captions-button</option>
+            <option value="--bottom-captions-button">--bottom-captions-button</option>
+            <option value="--airplay-button">--airplay-button</option>
+            <option value="--top-airplay-button">--top-airplay-button</option>
+            <option value="--bottom-airplay-button">--bottom-airplay-button</option>
+            <option value="--cast-button">--cast-button</option>
+            <option value="--top-cast-button">--top-cast-button</option>
+            <option value="--bottom-cast-button">--bottom-cast-button</option>
+            <option value="--pip-button">--pip-button</option>
+            <option value="--top-pip-button">--top-pip-button</option>
+            <option value="--bottom-pip-button">--bottom-pip-button</option>
+            <option value="--fullscreen-button">--fullscreen-button</option>
+            <option value="--bottom-fullscreen-button">--bottom-fullscreen-button</option>
           </select>
         </div>
       </div>
@@ -239,45 +265,6 @@ function MuxPlayerPage() {
       </h3>
     </div>
   );
-}
-
-function getAvailableControlsCssVars(node) {
-  const cssVars: Record<string, any> = {
-    '--controls': 'none',
-    '--top-controls': 'none',
-    '--center-controls': 'none',
-    '--bottom-controls': 'none',
-    '--duration-display': 'none',
-    '--bottom-duration-display': 'none',
-  };
-  for (const element of node.querySelectorAll('*')) {
-    if (!element.localName.includes('-')) continue;
-    const matches = element.localName.match(/^([^-]+)-(.*)-(button|range|display)$/);
-    if (!matches) continue;
-    const section = element.closest('[slot="top-chrome"]') ? 'top'
-      : element.closest('[slot="centered-chrome"]') ? 'center' : 'bottom';
-    cssVars[`--${matches[2]}-${matches[3]}`] = 'none';
-    cssVars[`--${section}-${matches[2]}-${matches[3]}`] = 'none';
-  }
-  return Object.keys(cssVars);
-}
-
-const DEFAULT_OPTIONS = {
-  config: { attributes: true, childList: true, subtree: true },
-};
-function useMutationObserver(targetEl, cb, options = DEFAULT_OPTIONS) {
-  const [observer, setObserver] = useState(null);
-
-  useEffect(() => {
-    const obs = new MutationObserver(cb);
-    setObserver(obs);
-  }, [cb, options, setObserver]);
-
-  useEffect(() => {
-    const { config } = options;
-    observer?.observe(targetEl, config);
-    return () => observer?.disconnect();
-  }, [observer, targetEl, options]);
 }
 
 export default MuxPlayerPage;

--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import Link from "next/link";
 import Script from 'next/script';
-import MuxPlayer, { ControlListTokens } from "@mux/mux-player-react";
+import MuxPlayer from "@mux/mux-player-react";
 import { useRef, useState } from "react";
 import mediaAssetsJSON from "@mux/assets/media-assets.json";
 
@@ -71,6 +71,11 @@ function MuxPlayerPage() {
         <Script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1" />
         <MuxPlayer
           ref={mediaElRef}
+          style={{
+            '--top-controls': 'none',
+            '--center-play-button': 'none',
+            '--seek-backward-button': 'none',
+          } as React.CSSProperties}
           // style={{ aspectRatio: "16 / 9" }}
           // envKey={envKey}
           metadata={toMetadataFromMediaAsset(selectedAsset, mediaAssets)}
@@ -218,7 +223,7 @@ function MuxPlayerPage() {
                 .map(({ value }) => value).join(' ')
             )}
           >
-            {ControlListTokens.map((token, i) => {
+            {[].map((token, i) => {
               return (
                 <option key={i} value={token}>{token}</option>
               )

--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -247,6 +247,8 @@ function getAvailableControlsCssVars(node) {
     '--top-controls': 'none',
     '--center-controls': 'none',
     '--bottom-controls': 'none',
+    '--duration-display': 'none',
+    '--bottom-duration-display': 'none',
   };
   for (const element of node.querySelectorAll('*')) {
     if (!element.localName.includes('-')) continue;

--- a/packages/mux-player-react/README.md
+++ b/packages/mux-player-react/README.md
@@ -103,6 +103,70 @@ Enable the [Google Cast](https://developers.google.com/cast) button in the contr
 <script defer src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
 ```
 
+### Hiding controls
+
+By default, Mux Player will show all the controls available:
+
+To hide certain controls, use CSS variables like this:  
+`--play-button` will control the display of the play button. Set it to `none` to hide it completely.
+
+```css
+mux-player {
+  --play-button: none;
+}
+```
+
+CSS vars can also be passed inline
+
+```jsx
+<MuxPlayer style={{ '--play-button': 'none' }}></MuxPlayer>
+```
+
+#### Controls sections
+
+It's possible to target specific sections of the player by prefixing the CSS vars.  
+The following sections are available:
+
+- `top` the top control bar that shows on the small player size
+- `center` the center controls that show the seek forward/backward button and play button
+- `bottom` the bottom control bar
+
+```jsx
+<MuxPlayer style={{ '--center-controls': 'none', '--top-captions-button': 'none' }}></MuxPlayer>
+```
+
+#### Available CSS variables
+
+The below CSS selector shows all available CSS vars for hiding, each one can be prefixed with a section.
+
+```css
+mux-player {
+  /* Hide all controls at once */
+  --controls: none;
+
+  /* Target all sections by excluding the section prefix */
+  --play-button: none;
+  --seek-live-button: none;
+  --seek-backward-button: none;
+  --seek-forward-button: none;
+  --mute-button: none;
+  --captions-button: none;
+  --airplay-button: none;
+  --pip-button: none;
+  --fullscreen-button: none;
+  --cast-button: none;
+  --playback-rate-button: none;
+  --volume-range: none;
+  --time-range: none;
+  --time-display: none;
+  --duration-display: none;
+
+  /* Target a specific section by prefixing the CSS var with (top|center|bottom) */
+  --center-controls: none;
+  --bottom-play-button: none;
+}
+```
+
 ### CSS Parts
 
 Mux Player uses a [shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM)

--- a/packages/mux-player-react/README.md
+++ b/packages/mux-player-react/README.md
@@ -105,7 +105,7 @@ Enable the [Google Cast](https://developers.google.com/cast) button in the contr
 
 ### Hiding controls
 
-By default, Mux Player will show all the controls available:
+By default, Mux Player will show all the controls associated with the current player size and stream type.
 
 To hide certain controls, use CSS variables like this:  
 `--play-button` will control the display of the play button. Set it to `none` to hide it completely.

--- a/packages/mux-player-react/README.md
+++ b/packages/mux-player-react/README.md
@@ -132,24 +132,6 @@ Supported **parts**:
 CSS parts allow you to style each part individually with a selector like `::part(center play button)`
 or target multiple elements if the part is assigned to multiple elements internally, usage `::part(button)`.
 Every CSS property can be declared in the selector, this makes it a very powerfull API.
-If you need a simple API to hide a few single control elements have a look at the [`controlslist`](#controlslist) attribute.
-
-### controlslist
-
-Offers a way to hide the controls elements/buttons that are being shown by the player.  
-The `controlslist` attribute accepts a blocklist as a space separated string.
-
-Supported **tokens**:
-`notop`, `nobottom`, `nocenter`, `nocenterplay`, `nocenterseekbackward`, `nocenterseekforward`, `noplay`,
-`noseekbackward`, `noseekforward`, `nomute`, `nocaptions`, `noairplay`, `nopip`, `nocast`, `nofullscreen`,
-`noplaybackrate`, `novolumerange`, `notimerange`, `notimedisplay`, `noremoteplayback`, `noseeklive`, `noduration`
-
-```jsx
-<MuxPlayer
-  playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
-  controlslist="nocenter nocaptions noremoteplayback"
-></MuxPlayer>
-```
 
 ### Tokens
 
@@ -225,7 +207,6 @@ Example:
 | `poster`                   | `string` (URL)                                                     | Assigns a poster image URL. Will use the automatically generated poster based on your playback-id by default.                                                                                                                                                                                                                                                                                    | Derived       |
 | `beaconCollectionDomain`   | `string` (Domain name)                                             | Assigns a custom domain to be used for Mux Data collection.                                                                                                                                                                                                                                                                                                                                      | N/A           |
 | `customDomain`             | `string` (Domain name)                                             | Assigns a custom domain to be used for Mux Video. Will use the standard `mux.com` domain with your playback-id for poster, video, and thumbnail URLs by default.                                                                                                                                                                                                                                 | N/A           |
-| `controlslist`             | `string`                                                           | Offers a way to hide the controls elements/buttons that are being shown by the player. For more, see the section on [`controlslist`](#controlslist)                                                                                                                                                                                                                                              | N/A           |
 
 ### Callbacks
 

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import type { CSSProperties } from 'react';
 import type { StreamTypes } from '@mux/playback-core';
-import { MediaError, ControlListTokens } from '@mux/mux-player';
+import { MediaError } from '@mux/mux-player';
 import type MuxPlayerElement from '@mux/mux-player';
 import type { Tokens } from '@mux/mux-player';
 import { toNativeProps } from './common/utils';
@@ -10,7 +10,7 @@ import { useCombinedRefs } from './useCombinedRefs';
 import useObjectPropEffect, { defaultHasChanged } from './useObjectPropEffect';
 import { getPlayerVersion } from './env';
 
-export { MediaError, ControlListTokens };
+export { MediaError };
 
 type ValueOf<T> = T[keyof T];
 

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -49,7 +49,6 @@ type MuxMediaPropTypes = {
 };
 
 export type MuxPlayerProps = {
-  controlslist?: string;
   nohotkeys?: boolean;
   defaultHiddenCaptions?: boolean;
   playerSoftwareVersion?: string;

--- a/packages/mux-player/README.md
+++ b/packages/mux-player/README.md
@@ -142,24 +142,6 @@ Supported **parts**:
 CSS parts allow you to style each part individually with a selector like `::part(center play button)`
 or target multiple elements if the part is assigned to multiple elements internally, usage `::part(button)`.
 Every CSS property can be declared in the selector, this makes it a very powerfull API.
-If you need a simple API to hide a few single control elements have a look at the [`controlslist`](#controlslist) attribute.
-
-### controlslist
-
-Offers a way to hide the controls elements/buttons that are being shown by the player.  
-The `controlslist` attribute accepts a blocklist as a space separated string.
-
-Supported **tokens**:
-`notop`, `nobottom`, `nocenter`, `nocenterplay`, `nocenterseekbackward`, `nocenterseekforward`, `noplay`,
-`noseekbackward`, `noseekforward`, `nomute`, `nocaptions`, `noairplay`, `nopip`, `nocast`, `nofullscreen`,
-`noplaybackrate`, `novolumerange`, `notimerange`, `notimedisplay`, `noremoteplayback`, `noseeklive`, `noduration`
-
-```html
-<mux-player
-  playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
-  controlslist="nocenter nocaptions noremoteplayback"
-></mux-player>
-```
 
 ### prefer-mse
 
@@ -211,7 +193,6 @@ If you prefer to use the in-code MSE-based engine (currently hls.js) whenever po
 | `beacon-collection-domain`    | `string` (domain name)                                              | Assigns a custom domain to be used for Mux Data collection.                                                                                                                                                                                                                                                                                                                                      | N/A           |
 | `custom-domain`               | `string` (domain name)                                              | Assigns a custom domain to be used for Mux Video.                                                                                                                                                                                                                                                                                                                                                | N/A           |
 | `nohotkeys`                   | `boolean`                                                           | Toggles keyboard shortcut (hot keys) support when focus in inside the player                                                                                                                                                                                                                                                                                                                     | `false`       |
-| `controlslist`                | `string`                                                            | Offers a way to hide the controls elements/buttons that are being shown by the player. For more, see the section on [`controlslist`](#controlslist)                                                                                                                                                                                                                                              | N/A           |
 
 ### Methods
 
@@ -251,7 +232,6 @@ If you prefer to use the in-code MSE-based engine (currently hls.js) whenever po
 | `videoWidth` <sub><sup>Read only</sup></sub>  | Returns an unsigned integer value indicating the intrinsic width of the resource in CSS pixels, or 0 if no media is available yet.                                                                                                                                                                                  | `0`         |
 | `volume`                                      | Is a double indicating the audio volume, from 0.0 (silent) to 1.0 (loudest).                                                                                                                                                                                                                                        | `1`         |
 | `customDomain`                                | Is a `String` that assigns a custom domain to be used for Mux Video.                                                                                                                                                                                                                                                | `undefined` |
-| `controlsList`                                | Is a read-only `DOMTokenList` similar to `classList` which offers a way to hide the controls elements/buttons that are being shown by the player. For more, see the section on [`controlslist`](#controlslist)                                                                                                      | `''`        |
 
 ### Events
 

--- a/packages/mux-player/README.md
+++ b/packages/mux-player/README.md
@@ -119,7 +119,7 @@ Enable the [Google Cast](https://developers.google.com/cast) button in the contr
 
 ### Hiding controls
 
-By default, Mux Player will show all the controls available:
+By default, Mux Player will show all the controls associated with the current player size and stream type.
 
 To hide certain controls, use CSS variables like this:  
 `--play-button` will control the display of the play button. Set it to `none` to hide it completely.

--- a/packages/mux-player/README.md
+++ b/packages/mux-player/README.md
@@ -117,6 +117,70 @@ Enable the [Google Cast](https://developers.google.com/cast) button in the contr
 <script defer src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
 ```
 
+### Hiding controls
+
+By default, Mux Player will show all the controls available:
+
+To hide certain controls, use CSS variables like this:  
+`--play-button` will control the display of the play button. Set it to `none` to hide it completely.
+
+```css
+mux-player {
+  --play-button: none;
+}
+```
+
+CSS vars can also be passed inline
+
+```html
+<mux-player style="--play-button: none;"></mux-player>
+```
+
+#### Controls sections
+
+It's possible to target specific sections of the player by prefixing the CSS vars.  
+The following sections are available:
+
+- `top` the top control bar that shows on the small player size
+- `center` the center controls that show the seek forward/backward button and play button
+- `bottom` the bottom control bar
+
+```html
+<mux-player style="--center-controls: none; --top-captions-button: none;"></mux-player>
+```
+
+#### Available CSS variables
+
+The below CSS selector shows all available CSS vars for hiding, each one can be prefixed with a section.
+
+```css
+mux-player {
+  /* Hide all controls at once */
+  --controls: none;
+
+  /* Target all sections by excluding the section prefix */
+  --play-button: none;
+  --seek-live-button: none;
+  --seek-backward-button: none;
+  --seek-forward-button: none;
+  --mute-button: none;
+  --captions-button: none;
+  --airplay-button: none;
+  --pip-button: none;
+  --fullscreen-button: none;
+  --cast-button: none;
+  --playback-rate-button: none;
+  --volume-range: none;
+  --time-range: none;
+  --time-display: none;
+  --duration-display: none;
+
+  /* Target a specific section by prefixing the CSS var with (top|center|bottom) */
+  --center-controls: none;
+  --bottom-play-button: none;
+}
+```
+
 ### CSS Parts
 
 Mux Player uses a [shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM)
@@ -137,11 +201,11 @@ Instead, some components expose **parts** that can be targeted with the [CSS par
 Supported **parts**:
 `seek-live`, `layer`, `media-layer`, `poster-layer`, `vertical-layer`, `centered-layer`,
 `top`, `center`, `bottom`, `play`, `button`, `seek-backward`, `seek-forward`, `mute`,
-`captions`, `airplay`, `pip`, `cast`, `fullscreen`, `playbackrate`, `volume`, `range`, `time`, `display`
+`captions`, `airplay`, `pip`, `cast`, `fullscreen`, `playback-rate`, `volume`, `range`, `time`, `display`
 
 CSS parts allow you to style each part individually with a selector like `::part(center play button)`
 or target multiple elements if the part is assigned to multiple elements internally, usage `::part(button)`.
-Every CSS property can be declared in the selector, this makes it a very powerfull API.
+Every CSS property can be declared in the selector, this makes it a very powerful API.
 
 ### prefer-mse
 

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -5,15 +5,15 @@ import { MediaController } from 'media-chrome';
 import MuxVideoElement, { MediaError } from '@mux/mux-video';
 import { Metadata, StreamTypes, addTextTrack, removeTextTrack } from '@mux/playback-core';
 import VideoApiElement, { initVideoApi } from './video-api';
-import { getPlayerVersion, isInLiveWindow, seekToLive, toPropName, AttributeTokenList } from './helpers';
-import { template, ControlListTokens } from './template';
+import { getPlayerVersion, isInLiveWindow, seekToLive, toPropName } from './helpers';
+import { template } from './template';
 import { render } from './html';
 import { getErrorLogs } from './errors';
 import { toNumberOrUndefined, i18n, parseJwt, containsComposedNode } from './utils';
 import * as logger from './logger';
 import type { MuxTemplateProps, ErrorEvent } from './types';
 
-export { MediaError, ControlListTokens };
+export { MediaError };
 export type Tokens = {
   playback?: string;
   thumbnail?: string;
@@ -124,7 +124,6 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
     metadataVideoId: el.getAttribute(MuxVideoAttributes.METADATA_VIDEO_ID),
     metadataVideoTitle: el.getAttribute(MuxVideoAttributes.METADATA_VIDEO_TITLE),
     metadataViewerUserId: el.getAttribute(MuxVideoAttributes.METADATA_VIEWER_USER_ID),
-    controlsList: el.controlsList,
     ...state,
   };
 }
@@ -144,7 +143,6 @@ class MuxPlayerElement extends VideoApiElement {
   #isInit = false;
   #tokens = {};
   #userInactive = true;
-  #controlsList = new AttributeTokenList(this, 'controlslist');
   #resizeObserver?: ResizeObserver;
   #state: Partial<MuxTemplateProps> = {
     ...initialState,
@@ -504,9 +502,6 @@ class MuxPlayerElement extends VideoApiElement {
     super.attributeChangedCallback(attrName, oldValue, newValue);
 
     switch (attrName) {
-      case PlayerAttributes.CONTROLSLIST:
-        this.#controlsList.value = newValue;
-        break;
       case PlayerAttributes.THUMBNAIL_TIME: {
         if (newValue != null && this.tokens.thumbnail) {
           logger.warn(
@@ -602,10 +597,6 @@ class MuxPlayerElement extends VideoApiElement {
 
   get mux() {
     return this.media?.mux;
-  }
-
-  get controlsList() {
-    return this.#controlsList;
   }
 
   /**

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -62,6 +62,7 @@ const MuxVideoAttributes = {
 };
 
 const PlayerAttributes = {
+  STYLE: 'style',
   DEFAULT_HIDDEN_CAPTIONS: 'default-hidden-captions',
   PRIMARY_COLOR: 'primary-color',
   SECONDARY_COLOR: 'secondary-color',

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -73,7 +73,6 @@ const PlayerAttributes = {
   THUMBNAIL_TIME: 'thumbnail-time',
   AUDIO: 'audio',
   NOHOTKEYS: 'nohotkeys',
-  CONTROLSLIST: 'controlslist',
   PLAYBACK_RATES: 'playbackrates',
   DEFAULT_SHOW_REMAINING_TIME: 'default-show-remaining-time',
 };

--- a/packages/mux-player/src/media-chrome/time-display.ts
+++ b/packages/mux-player/src/media-chrome/time-display.ts
@@ -65,26 +65,27 @@ class MxpTimeDisplay extends HTMLElement {
 
     // Temporary fix until CSS vars are available in the time-display Media Chrome
     // component to target each time variant: current, remaining, duration.
-    this.#displayInterval = setInterval(() => {
-      if (getComputedStyle(this).getPropertyValue('--media-duration-display').trim() === 'none') {
-        this.timeDisplayEl?.removeAttribute('show-duration');
-      } else {
-        this.timeDisplayEl?.setAttribute('show-duration', '');
-      }
-    }, 200);
+    this.#displayInterval = setInterval(this.#toggleDuration.bind(this), 200);
+    requestAnimationFrame(() => this.#toggleDuration());
   }
 
   disconnectedCallback() {
     clearInterval(this.#displayInterval);
   }
 
+  #toggleDuration() {
+    const isDurationDisplayNone = getComputedStyle(this).getPropertyValue('--media-duration-display').trim() === 'none';
+
+    if (isDurationDisplayNone || this.getAttribute('hide-duration') != null) {
+      this.timeDisplayEl?.removeAttribute('show-duration');
+    } else {
+      this.timeDisplayEl?.setAttribute('show-duration', '');
+    }
+  }
+
   attributeChangedCallback(attrName: string, _oldValue: string | null, newValue: string | null) {
     if (attrName === 'hide-duration') {
-      if (newValue != null) {
-        this.timeDisplayEl?.removeAttribute('show-duration');
-      } else {
-        this.timeDisplayEl?.setAttribute('show-duration', '');
-      }
+      this.#toggleDuration();
     }
     if (attrName === 'remaining') {
       if (newValue != null) {

--- a/packages/mux-player/src/media-chrome/time-display.ts
+++ b/packages/mux-player/src/media-chrome/time-display.ts
@@ -23,6 +23,7 @@ class MxpTimeDisplay extends HTMLElement {
   static styles: string = styles;
   static template: HTMLTemplateElement = template;
   timeDisplayEl: HTMLElement | null | undefined;
+  #displayInterval: any;
 
   constructor() {
     super();
@@ -61,6 +62,20 @@ class MxpTimeDisplay extends HTMLElement {
     });
 
     this.addEventListener('click', this.toggleTimeDisplay);
+
+    // Temporary fix until CSS vars are available in the time-display Media Chrome
+    // component to target each time variant: current, remaining, duration.
+    this.#displayInterval = setInterval(() => {
+      if (getComputedStyle(this).getPropertyValue('--media-duration-display').trim() === 'none') {
+        this.timeDisplayEl?.removeAttribute('show-duration');
+      } else {
+        this.timeDisplayEl?.setAttribute('show-duration', '');
+      }
+    }, 200);
+  }
+
+  disconnectedCallback() {
+    clearInterval(this.#displayInterval);
   }
 
   attributeChangedCallback(attrName: string, _oldValue: string | null, newValue: string | null) {

--- a/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
+++ b/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
@@ -22,7 +22,6 @@ type ThemeMuxTemplateProps = {
   forwardSeekOffset: string | null;
   backwardSeekOffset: string | null;
   playbackRates: string | null;
-  hideDuration: boolean;
   defaultShowRemainingTime: boolean;
 };
 
@@ -39,7 +38,6 @@ export default class MediaThemeMux extends MediaTheme {
       'forward-seek-offset',
       'backward-seek-offset',
       'playbackrates',
-      'hide-duration',
       'default-show-remaining-time',
     ];
   }
@@ -58,7 +56,6 @@ export default class MediaThemeMux extends MediaTheme {
       forwardSeekOffset: this.getAttribute('forward-seek-offset'),
       backwardSeekOffset: this.getAttribute('backward-seek-offset'),
       playbackRates: this.getAttribute('playbackrates'),
-      hideDuration: this.hasAttribute('hide-duration'),
       defaultShowRemainingTime: this.hasAttribute('default-show-remaining-time'),
     };
 
@@ -239,8 +236,8 @@ const MediaTimeRange = () => html`
   </media-time-range>`;
 
 // prettier-ignore
-const TimeDisplay = ({ hideDuration, defaultShowRemainingTime }: ComponentProps) => html`
-  <mxp-time-display hide-duration="${hideDuration}" remaining="${defaultShowRemainingTime}">
+const TimeDisplay = ({ defaultShowRemainingTime }: ComponentProps) => html`
+  <mxp-time-display remaining="${defaultShowRemainingTime}">
   </mxp-time-display>`;
 
 // prettier-ignore

--- a/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
+++ b/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
@@ -28,26 +28,6 @@ type ThemeMuxTemplateProps = {
 
 type ComponentProps = ThemeMuxTemplateProps & { part?: string };
 
-export const parts = {
-  mediaChrome: 'layer media-layer poster-layer vertical-layer centered-layer',
-  top: 'top',
-  center: 'center',
-  bottom: 'bottom',
-  play: 'play button',
-  seekBackward: 'seek-backward button',
-  seekForward: 'seek-forward button',
-  mute: 'mute button',
-  captions: 'captions button',
-  airplay: 'airplay button',
-  pip: 'pip button',
-  cast: 'cast button',
-  fullscreen: 'fullscreen button',
-  playbackRate: 'playbackrate button',
-  volumeRange: 'volume range',
-  timeRange: 'time range',
-  timeDisplay: 'time display',
-};
-
 export default class MediaThemeMux extends MediaTheme {
   static get observedAttributes() {
     return [
@@ -91,7 +71,7 @@ export default class MediaThemeMux extends MediaTheme {
           nohotkeys="${props.nohotkeys || false}"
           audio="${props.audio || false}"
           class="size-${props.playerSize}"
-          exportparts="${parts.mediaChrome.split(' ').join(', ')}"
+          exportparts="layer, media-layer, poster-layer, vertical-layer, centered-layer"
         >
           <slot name="media" slot="media"></slot>
           <media-loading-indicator slot="centered-chrome" no-auto-hide></media-loading-indicator>
@@ -101,6 +81,21 @@ export default class MediaThemeMux extends MediaTheme {
       `,
       this.shadowRoot as Node
     );
+
+    // Possibly add this functionality to the base class MediaTheme.
+    this.shadowRoot?.querySelectorAll('*').forEach((element) => {
+      if (!element.localName.includes('-')) return;
+
+      const matches = element.localName.match(/^([^-]+)-(.*)-(button|range|display)$/);
+      if (!matches) return;
+
+      const section = element.closest('[slot="top-chrome"]')
+        ? 'top'
+        : element.closest('[slot="centered-chrome"]')
+        ? 'center'
+        : 'bottom';
+      element.setAttribute('part', `${section} ${matches[2]} ${matches[3]}`);
+    });
   }
 }
 
@@ -166,27 +161,27 @@ const ChromeRenderer = (props: ThemeMuxTemplateProps) => {
 };
 
 // prettier-ignore
-const MediaPlayButton = ({ part = parts.bottom } = {}) => html`
-  <media-play-button part="${part} ${parts.play}">
+const MediaPlayButton = () => html`
+  <media-play-button>
     ${icons.Play()}
     ${icons.Pause()}
   </media-play-button>`;
 
 // prettier-ignore
-const MediaSeekBackwardButton = ({ backwardSeekOffset, part = parts.bottom }: ComponentProps) => html`
-  <media-seek-backward-button seek-offset="${backwardSeekOffset}" part="${part} ${parts.seekBackward}">
+const MediaSeekBackwardButton = ({ backwardSeekOffset }: ComponentProps) => html`
+  <media-seek-backward-button seek-offset="${backwardSeekOffset}">
     ${icons.SeekBackward({ value: backwardSeekOffset })}
   </media-seek-backward-button>`;
 
 // prettier-ignore
-const MediaSeekForwardButton = ({ forwardSeekOffset, part = parts.bottom }: ComponentProps) => html`
-  <media-seek-forward-button seek-offset="${forwardSeekOffset}" part="${part} ${parts.seekForward}">
+const MediaSeekForwardButton = ({ forwardSeekOffset }: ComponentProps) => html`
+  <media-seek-forward-button seek-offset="${forwardSeekOffset}">
     ${icons.SeekForward({ value: forwardSeekOffset })}
   </media-seek-forward-button>`;
 
 // prettier-ignore
-const MediaMuteButton = ({ part = parts.bottom } = {}) => html`
-  <media-mute-button part="${part} ${parts.mute}">
+const MediaMuteButton = () => html`
+  <media-mute-button>
     ${icons.VolumeHigh()}
     ${icons.VolumeMedium()}
     ${icons.VolumeLow()}
@@ -195,63 +190,57 @@ const MediaMuteButton = ({ part = parts.bottom } = {}) => html`
 
 type CaptionsButtonProps = { defaultHiddenCaptions: boolean; part?: string };
 // prettier-ignore
-const MediaCaptionsButton = ({
-  defaultHiddenCaptions,
-  part = parts.bottom,
-}: CaptionsButtonProps) => html`
-  <media-captions-button
-    default-showing="${!defaultHiddenCaptions}"
-    part="${part} ${parts.captions}"
-  >
+const MediaCaptionsButton = ({ defaultHiddenCaptions }: CaptionsButtonProps) => html`
+  <media-captions-button default-showing="${!defaultHiddenCaptions}">
     ${icons.CaptionsOff()}
     ${icons.CaptionsOn()}
   </media-captions-button>`;
 
 // prettier-ignore
-const MediaAirplayButton = ({ part = parts.bottom } = {}) => html`
-  <media-airplay-button part="${part} ${parts.airplay}">
+const MediaAirplayButton = () => html`
+  <media-airplay-button>
     ${icons.Airplay()}
   </media-airplay-button>`;
 
 // prettier-ignore
-const MediaPipButton = ({ part = parts.bottom } = {}) => html`
-  <media-pip-button part="${part} ${parts.pip}">
+const MediaPipButton = () => html`
+  <media-pip-button>
     ${icons.PipEnter()}
     ${icons.PipExit()}
   </media-pip-button>`;
 
 // prettier-ignore
-const MediaFullscreenButton = ({ part = parts.bottom } = {}) => html`
-  <media-fullscreen-button part="${part} ${parts.fullscreen}">
+const MediaFullscreenButton = () => html`
+  <media-fullscreen-button>
     ${icons.FullscreenEnter()}
     ${icons.FullscreenExit()}
   </media-fullscreen-button>`;
 
 // prettier-ignore
-const MediaCastButton = ({ part = parts.bottom } = {}) => html`
-  <media-cast-button part="${part} ${parts.cast}">
+const MediaCastButton = () => html`
+  <media-cast-button>
     ${icons.CastEnter()}
     ${icons.CastExit()}
   </media-cast-button>`;
 
 // prettier-ignore
-const MediaPlaybackRateButton = ({ part = parts.bottom, playbackRates }: ComponentProps) => html`
-  <media-playback-rate-button part="${part} ${parts.playbackRate}" rates="${playbackRates ?? false}" >
+const MediaPlaybackRateButton = ({ playbackRates }: ComponentProps) => html`
+  <media-playback-rate-button rates="${playbackRates ?? false}">
   </media-playback-rate-button>`;
 
 // prettier-ignore
-const MediaVolumeRange = ({ part = parts.bottom } = {}) => html`
-  <media-volume-range part="${part} ${parts.volumeRange}">
+const MediaVolumeRange = () => html`
+  <media-volume-range>
   </media-volume-range>`;
 
 // prettier-ignore
-const MediaTimeRange = ({ part = parts.bottom } = {}) => html`
-  <media-time-range part="${part} ${parts.timeRange}">
+const MediaTimeRange = () => html`
+  <media-time-range>
   </media-time-range>`;
 
 // prettier-ignore
-const TimeDisplay = ({ part = parts.bottom, hideDuration, defaultShowRemainingTime }: ComponentProps) => html`
-  <mxp-time-display part="${part} ${parts.timeDisplay}" hide-duration="${hideDuration}" remaining="${defaultShowRemainingTime}">
+const TimeDisplay = ({ hideDuration, defaultShowRemainingTime }: ComponentProps) => html`
+  <mxp-time-display hide-duration="${hideDuration}" remaining="${defaultShowRemainingTime}">
   </mxp-time-display>`;
 
 // prettier-ignore
@@ -302,18 +291,18 @@ export const AudioLiveChrome = () => html`
 // prettier-ignore
 export const VodChromeExtraSmall = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar slot="top-chrome">
-    ${MediaCaptionsButton({ ...props, part: parts.top })}
-    <div class="mxp-spacer"></div>
-    ${MediaAirplayButton({ part: parts.top })}
-    ${MediaCastButton({ part: parts.top })}
-    ${MediaPipButton({ part: parts.top })}
+    ${MediaCaptionsButton(props)}
+    <div class="spacer"></div>
+    ${MediaAirplayButton()}
+    ${MediaCastButton()}
+    ${MediaPipButton()}
   </media-control-bar>
-  <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaPlayButton({ part: parts.center })}
+  <div slot="centered-chrome" class="center-controls">
+    ${MediaPlayButton()}
   </div>
   <media-control-bar>
     ${MediaMuteButton()}
-    <div class="mxp-spacer"></div>
+    <div class="spacer"></div>
     ${MediaFullscreenButton()}
   </media-control-bar>
 `;
@@ -321,32 +310,32 @@ export const VodChromeExtraSmall = (props: ThemeMuxTemplateProps) => html`
 // prettier-ignore
 export const VodChromeSmall = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar slot="top-chrome" style="justify-content: flex-end;">
-    ${MediaCaptionsButton({ ...props, part: parts.top })}
-    ${MediaAirplayButton({ part: parts.top })}
-    ${MediaCastButton({ part: parts.top })}
-    ${MediaPipButton({ part: parts.top })}
+    ${MediaCaptionsButton(props)}
+    ${MediaAirplayButton()}
+    ${MediaCastButton()}
+    ${MediaPipButton()}
   </media-control-bar>
-  <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaSeekBackwardButton({ ...props, part: parts.center })}
-    ${MediaPlayButton({ part: parts.center })}
-    ${MediaSeekForwardButton({ ...props, part: parts.center })}
+  <div slot="centered-chrome" class="center-controls">
+    ${MediaSeekBackwardButton(props)}
+    ${MediaPlayButton()}
+    ${MediaSeekForwardButton(props)}
   </div>
   ${MediaTimeRange()}
   <media-control-bar>
     ${TimeDisplay(props)}
     ${MediaMuteButton()}
     ${MediaVolumeRange()}
-    <div class="mxp-spacer"></div>
+    <div class="spacer"></div>
     ${MediaPlaybackRateButton(props)}
     ${MediaFullscreenButton()}
-    <div class="mxp-padding-2"></div>
+    <div class="padding-2"></div>
   </media-control-bar>
 `;
 
 // prettier-ignore
 export const VodChromeLarge = (props: ThemeMuxTemplateProps) => html`
-  <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaPlayButton({ part: parts.center })}
+  <div slot="centered-chrome" class="center-controls">
+    ${MediaPlayButton()}
   </div>
   ${MediaTimeRange()}
   <media-control-bar>
@@ -356,14 +345,14 @@ export const VodChromeLarge = (props: ThemeMuxTemplateProps) => html`
     ${TimeDisplay(props)}
     ${MediaMuteButton()}
     ${MediaVolumeRange()}
-    <div class="mxp-spacer"></div>
+    <div class="spacer"></div>
     ${MediaPlaybackRateButton(props)}
     ${MediaCaptionsButton(props)}
     ${MediaAirplayButton()}
     ${MediaCastButton()}
     ${MediaPipButton()}
     ${MediaFullscreenButton()}
-    <div class="mxp-padding-2"></div>
+    <div class="padding-2"></div>
   </media-control-bar>
 `;
 
@@ -374,19 +363,19 @@ export const LiveChromeExtraSmall = VodChromeExtraSmall;
 export const LiveChromeSmall = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar slot="top-chrome">
     <slot name="seek-live"></slot>
-    <div class="mxp-spacer"></div>
-    ${MediaCaptionsButton({ ...props, part: parts.top })}
-    ${MediaAirplayButton({ part: parts.top })}
-    ${MediaCastButton({ part: parts.top })}
-    ${MediaPipButton({ part: parts.top })}
+    <div class="spacer"></div>
+    ${MediaCaptionsButton(props)}
+    ${MediaAirplayButton()}
+    ${MediaCastButton()}
+    ${MediaPipButton()}
   </media-control-bar>
-  <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaPlayButton({ part: parts.center })}
+  <div slot="centered-chrome" class="center-controls">
+    ${MediaPlayButton()}
   </div>
   <media-control-bar>
     ${MediaMuteButton()}
     ${MediaVolumeRange()}
-    <div class="mxp-spacer"></div>
+    <div class="spacer"></div>
     ${MediaFullscreenButton()}
   </media-control-bar>
 `;
@@ -396,13 +385,13 @@ export const LiveChromeLarge = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar slot="top-chrome">
     <slot name="seek-live"></slot>
   </media-control-bar>
-  <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaPlayButton({ part: parts.center })}
+  <div slot="centered-chrome" class="center-controls">
+    ${MediaPlayButton()}
   </div>
   <media-control-bar>
     ${MediaMuteButton()}
     ${MediaVolumeRange()}
-    <div class="mxp-spacer"></div>
+    <div class="spacer"></div>
     ${MediaCaptionsButton(props)}
     ${MediaAirplayButton()}
     ${MediaCastButton()}
@@ -417,31 +406,31 @@ export const DvrChromeExtraSmall = VodChromeExtraSmall;
 // prettier-ignore
 export const DvrChromeSmall = (props: ThemeMuxTemplateProps) => html`
   <media-control-bar slot="top-chrome" style="justify-content: flex-end;">
-    ${MediaCaptionsButton({ ...props, part: parts.top })}
-    ${MediaAirplayButton({ part: parts.top })}
-    ${MediaCastButton({ part: parts.top })}
-    ${MediaPipButton({ part: parts.top })}
+    ${MediaCaptionsButton(props)}
+    ${MediaAirplayButton()}
+    ${MediaCastButton()}
+    ${MediaPipButton()}
   </media-control-bar>
-  <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaSeekBackwardButton({ ...props, part: parts.center })}
-    ${MediaPlayButton({ part: parts.center })}
-    ${MediaSeekForwardButton({ ...props, part: parts.center })}
+  <div slot="centered-chrome" class="center-controls">
+    ${MediaSeekBackwardButton(props)}
+    ${MediaPlayButton()}
+    ${MediaSeekForwardButton(props)}
   </div>
   ${MediaTimeRange()}
   <media-control-bar>
     ${MediaMuteButton()}
     ${MediaVolumeRange()}
     <slot name="seek-live"></slot>
-    <div class="mxp-spacer"></div>
+    <div class="spacer"></div>
     ${MediaFullscreenButton()}
-    <div class="mxp-padding-2"></div>
+    <div class="padding-2"></div>
   </media-control-bar>
 `;
 
 // prettier-ignore
 export const DvrChromeLarge = (props: ThemeMuxTemplateProps) => html`
-  <div slot="centered-chrome" class="mxp-center-controls">
-    ${MediaPlayButton({ part: parts.center })}
+  <div slot="centered-chrome" class="center-controls">
+    ${MediaPlayButton()}
   </div>
   ${MediaTimeRange()}
   <media-control-bar>
@@ -451,12 +440,12 @@ export const DvrChromeLarge = (props: ThemeMuxTemplateProps) => html`
     ${MediaMuteButton()}
     ${MediaVolumeRange()}
     <slot name="seek-live"></slot>
-    <div class="mxp-spacer"></div>
+    <div class="spacer"></div>
     ${MediaCaptionsButton(props)}
     ${MediaAirplayButton()}
     ${MediaCastButton()}
     ${MediaPipButton()}
     ${MediaFullscreenButton()}
-    <div class="mxp-padding-2"></div>
+    <div class="padding-2"></div>
   </media-control-bar>
 `;

--- a/packages/mux-player/src/media-theme-mux/styles.css
+++ b/packages/mux-player/src/media-theme-mux/styles.css
@@ -114,7 +114,7 @@ media-control-bar :is([role='button'], [role='switch'], button) {
   padding: 4.4% 3.2%;
 }
 
-.mxp-spacer {
+.spacer {
   flex-grow: 1;
   height: 100%;
   background-color: var(--media-control-background, rgba(20, 20, 30, 0.7));
@@ -122,7 +122,7 @@ media-control-bar :is([role='button'], [role='switch'], button) {
 
 /* Add a small space on the right to have the play button and
  * fullscreen button aligned in relation to the progress bar. */
-.size-large .mxp-padding-2 {
+.size-large .padding-2 {
   width: 2px;
   height: 100%;
   background-color: var(--media-control-background, rgba(20, 20, 30, 0.7));
@@ -137,7 +137,7 @@ media-controller:is([media-paused], :not([user-inactive]))::part(vertical-layer)
   transition: background-color 0.25s;
 }
 
-.mxp-center-controls {
+.center-controls {
   --media-button-icon-width: 100%;
   --media-button-icon-height: auto;
   pointer-events: none;
@@ -148,15 +148,15 @@ media-controller:is([media-paused], :not([user-inactive]))::part(vertical-layer)
   justify-content: center;
 }
 
-.mxp-center-controls media-play-button {
+.center-controls media-play-button {
   --media-control-background: transparent;
   --media-control-hover-background: transparent;
   padding: 0;
   width: max(27px, min(9%, 90px));
 }
 
-.mxp-center-controls media-seek-backward-button,
-.mxp-center-controls media-seek-forward-button {
+.center-controls media-seek-backward-button,
+.center-controls media-seek-forward-button {
   --media-control-background: transparent;
   --media-control-hover-background: transparent;
   padding: 0;

--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -13,11 +13,6 @@ a {
   text-decoration: underline;
 }
 
-media-controller {
-  width: 100%;
-  height: 100%;
-}
-
 [part~='seek-live'] {
   height: 44px;
   background-color: var(--media-control-background, rgba(20, 20, 30, 0.7));
@@ -39,4 +34,107 @@ media-controller {
 
 [part~='seek-live'][aria-disabled]::before {
   color: #fb3c4d;
+}
+
+::part(top),
+[part~='top'] {
+  --media-controls: var(--controls, var(--top-controls));
+  --media-play-button: var(--play-button, var(--top-play-button));
+  --media-seek-live-button: var(--seek-live-button, var(--top-seek-live-button));
+  --media-seek-backward-button: var(--seek-backward-button, var(--top-seek-backward-button));
+  --media-seek-forward-button: var(--seek-forward-button, var(--top-seek-forward-button));
+  --media-mute-button: var(--mute-button, var(--top-mute-button));
+  --media-captions-button: var(--captions-button, var(--top-captions-button));
+  --media-airplay-button: var(--airplay-button, var(--top-airplay-button));
+  --media-pip-button: var(--pip-button, var(--top-pip-button));
+  --media-fullscreen-button: var(--fullscreen-button, var(--top-fullscreen-button));
+  --media-cast-button: var(--cast-button, var(--top-cast-button));
+  --media-playback-rate-button: var(--playback-rate-button, var(--top-playback-rate-button));
+  --media-volume-range: var(--volume-range, var(--top-volume-range));
+  --media-time-range: var(--time-range, var(--top-time-range));
+  --media-time-display: var(--time-display, var(--top-time-display));
+}
+
+::part(center),
+[part~='center'] {
+  --media-controls: var(--controls, var(--center-controls));
+  --media-play-button: var(--play-button, var(--center-play-button));
+  --media-seek-live-button: var(--seek-live-button, var(--center-seek-live-button));
+  --media-seek-backward-button: var(--seek-backward-button, var(--center-seek-backward-button));
+  --media-seek-forward-button: var(--seek-forward-button, var(--center-seek-forward-button));
+  --media-mute-button: var(--mute-button, var(--center-mute-button));
+  --media-captions-button: var(--captions-button, var(--center-captions-button));
+  --media-airplay-button: var(--airplay-button, var(--center-airplay-button));
+  --media-pip-button: var(--pip-button, var(--center-pip-button));
+  --media-fullscreen-button: var(--fullscreen-button, var(--center-fullscreen-button));
+  --media-cast-button: var(--cast-button, var(--center-cast-button));
+  --media-playback-rate-button: var(--playback-rate-button, var(--center-playback-rate-button));
+  --media-volume-range: var(--volume-range, var(--center-volume-range));
+  --media-time-range: var(--time-range, var(--center-time-range));
+  --media-time-display: var(--time-display, var(--center-time-display));
+}
+
+::part(bottom),
+[part~='bottom'] {
+  --media-controls: var(--controls, var(--bottom-controls));
+  --media-play-button: var(--play-button, var(--bottom-play-button));
+  --media-seek-live-button: var(--seek-live-button, var(--bottom-seek-live-button));
+  --media-seek-backward-button: var(--seek-backward-button, var(--bottom-seek-backward-button));
+  --media-seek-forward-button: var(--seek-forward-button, var(--bottom-seek-forward-button));
+  --media-mute-button: var(--mute-button, var(--bottom-mute-button));
+  --media-captions-button: var(--captions-button, var(--bottom-captions-button));
+  --media-airplay-button: var(--airplay-button, var(--bottom-airplay-button));
+  --media-pip-button: var(--pip-button, var(--bottom-pip-button));
+  --media-fullscreen-button: var(--fullscreen-button, var(--bottom-fullscreen-button));
+  --media-cast-button: var(--cast-button, var(--bottom-cast-button));
+  --media-playback-rate-button: var(--playback-rate-button, var(--bottom-playback-rate-button));
+  --media-volume-range: var(--volume-range, var(--bottom-volume-range));
+  --media-time-range: var(--time-range, var(--bottom-time-range));
+  --media-time-display: var(--time-display, var(--bottom-time-display));
+}
+
+[part*='seek-live button'] {
+  display: var(--media-controls, var(--media-seek-live-button));
+}
+
+/** Once we implement these CSS vars in Media Chrome below selectors can be deleted! */
+
+::part(play button) {
+  display: var(--media-controls, var(--media-play-button));
+}
+::part(seek-backward button) {
+  display: var(--media-controls, var(--media-seek-backward-button));
+}
+::part(seek-forward button) {
+  display: var(--media-controls, var(--media-seek-forward-button));
+}
+::part(mute button) {
+  display: var(--media-controls, var(--media-mute-button));
+}
+::part(captions button) {
+  display: var(--media-controls, var(--media-captions-button));
+}
+::part(airplay button) {
+  display: var(--media-controls, var(--media-airplay-button));
+}
+::part(pip button) {
+  display: var(--media-controls, var(--media-pip-button));
+}
+::part(fullscreen button) {
+  display: var(--media-controls, var(--media-fullscreen-button));
+}
+::part(cast button) {
+  display: var(--media-controls, var(--media-cast-button));
+}
+::part(playback-rate button) {
+  display: var(--media-controls, var(--media-playback-rate-button));
+}
+::part(volume range) {
+  display: var(--media-controls, var(--media-volume-range));
+}
+::part(time range) {
+  display: var(--media-controls, var(--media-time-range));
+}
+::part(time display) {
+  display: var(--media-controls, var(--media-time-display));
 }

--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -53,6 +53,7 @@ a {
   --media-volume-range: var(--volume-range, var(--top-volume-range));
   --media-time-range: var(--time-range, var(--top-time-range));
   --media-time-display: var(--time-display, var(--top-time-display));
+  --media-duration-display: var(--duration-display, var(--top-duration-display));
 }
 
 ::part(center),
@@ -72,6 +73,7 @@ a {
   --media-volume-range: var(--volume-range, var(--center-volume-range));
   --media-time-range: var(--time-range, var(--center-time-range));
   --media-time-display: var(--time-display, var(--center-time-display));
+  --media-duration-display: var(--duration-display, var(--center-duration-display));
 }
 
 ::part(bottom),
@@ -91,6 +93,7 @@ a {
   --media-volume-range: var(--volume-range, var(--bottom-volume-range));
   --media-time-range: var(--time-range, var(--bottom-time-range));
   --media-time-display: var(--time-display, var(--bottom-time-display));
+  --media-duration-display: var(--duration-display, var(--bottom-duration-display));
 }
 
 [part*='seek-live button'] {

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -43,9 +43,6 @@ export const content = (props: MuxTemplateProps) => html`
     forward-seek-offset="${props.forwardSeekOffset}"
     backward-seek-offset="${props.backwardSeekOffset}"
     playbackrates="${props.playbackRates ?? false}"
-    hide-duration="${[...(props?.controlsList?.values() ?? [])].some(
-      (key) => key.search(/^no(top|bottom|center)?duration/) === 0
-    )}"
     default-show-remaining-time="${props.defaultShowRemainingTime ?? false}"
     exportparts="top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display"
   >

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -1,11 +1,10 @@
-import { parts } from './media-theme-mux/media-theme-mux';
+import './media-theme-mux/media-theme-mux';
 import './dialog';
 import {
   castThemeName,
   getSrcFromPlaybackId,
   getPosterURLFromPlaybackId,
   getStoryboardURLFromPlaybackId,
-  AttributeTokenList,
 } from './helpers';
 import { html, unsafeStatic } from './html';
 // @ts-ignore
@@ -15,53 +14,12 @@ import { i18n, stylePropsToString } from './utils';
 import type { MuxTemplateProps } from './types';
 import { StreamTypes } from '@mux/playback-core';
 
-const controlsListStyles: Record<string, string> = {
-  notop: `::part(top), [part~="top"] { display: none; }`,
-  nobottom: `::part(bottom), [part~="bottom"] { display: none; }`,
-  nocenter: `::part(center), [part~="center"] { display: none; }`,
-
-  nocenterplay: `::part(center play button) { display: none; }`,
-  nocenterseekbackward: `::part(center seek-backward button) { display: none; }`,
-  nocenterseekforward: `::part(center seek-forward button) { display: none; }`,
-
-  noplay: `::part(bottom play button) { display: none; }`,
-  noseekbackward: `::part(bottom seek-backward button) { display: none; }`,
-  noseekforward: `::part(bottom seek-forward button) { display: none; }`,
-
-  nomute: `::part(mute button) { display: none; }`,
-  nocaptions: `::part(captions button) { display: none; }`,
-  noairplay: `::part(airplay button) { display: none; }`,
-  nopip: `::part(pip button) { display: none; }`,
-  nocast: `::part(cast button) { display: none; }`,
-  nofullscreen: `::part(fullscreen button) { display: none; }`,
-  noplaybackrate: `::part(playbackrate button) { display: none; }`,
-  novolumerange: `::part(volume range) { display: none; }`,
-  notimerange: `::part(time range) { display: none; }`,
-  notimedisplay: `::part(time display) { display: none; }`,
-  noremoteplayback: `::part(airplay button), ::part(cast button) { display: none; }`,
-  // The duration display isn't a "part", since it is controlled by an attribute in media-time-display
-  // Still adding here so it shows up as a valid/available controlsList value.
-  noduration: '',
-
-  // the seek live button is in the light dom below, use attribute selector.
-  noseeklive: `[part*="seek-live button"] { display: none; }`,
-};
-
-export const ControlListTokens = Object.keys(controlsListStyles);
-
 export const template = (props: MuxTemplateProps) => html`
   <style>
     ${cssStr}
-    ${[...props.controlsList]
-      .map((token) => controlsListStyles[token])
-      .filter(Boolean)
-      .join('\n')}
   </style>
   ${content(props)}
 `;
-
-const flatCSSParts = Object.values(parts).flatMap((group) => group.split(' '));
-const forwardUniqueCSSParts = [...new Set(flatCSSParts)].join(', ');
 
 const isLive = (props: MuxTemplateProps) => [StreamTypes.LIVE, StreamTypes.LL_LIVE].includes(props.streamType as any);
 
@@ -89,7 +47,7 @@ export const content = (props: MuxTemplateProps) => html`
       (key) => key.search(/^no(top|bottom|center)?duration/) === 0
     )}"
     default-show-remaining-time="${props.defaultShowRemainingTime ?? false}"
-    exportparts="seek-live, ${forwardUniqueCSSParts}"
+    exportparts="top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display"
   >
     <mux-video
       slot="media"

--- a/packages/mux-player/src/types.d.ts
+++ b/packages/mux-player/src/types.d.ts
@@ -1,5 +1,4 @@
 import type MuxVideoElement, { MediaError } from '@mux/mux-video';
-import type { AttributeTokenList } from './helpers';
 
 export type MuxPlayerProps = Partial<MuxVideoElement> & {
   nohotkeys?: boolean;
@@ -34,7 +33,6 @@ export type MuxTemplateProps = Partial<MuxPlayerProps> & {
   metadataVideoTitle: string;
   metadataViewerUserId: string;
   noHotKeys: boolean;
-  controlsList: AttributeTokenList;
 };
 
 export type DialogOptions = {

--- a/packages/mux-player/test/template.test.js
+++ b/packages/mux-player/test/template.test.js
@@ -7,7 +7,7 @@ const minify = (html) => html.trim().replace(/>\s+</g, '><');
 describe('<mux-player> template render', () => {
   const div = document.createElement('div');
 
-  const exportParts = `seek-live, layer, media-layer, poster-layer, vertical-layer, centered-layer, top, center, bottom, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, cast, fullscreen, playbackrate, volume, range, time, display`;
+  const exportParts = `top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display`;
 
   it('default template without props', function () {
     render(content({}), div);


### PR DESCRIPTION
This change adds the bulk of the refactor so the controls are toggled with CSS vars instead of the `controlsList` property.

IMO this feels a lot better as an API.

```html
<mux-player style="--center-play-button: none; --top-controls: none"></mux-player>
```

The manual adding of parts in the MediaTheme is replaced by a little script that adds parts automatically based on the tag names of the Media Chrome elements. This to prevent putting this extra work on the theme developer.

We can consider adding that to MediaTheme but I'd lean to not doing that to avoid surprises. 
CSS parts will also not be required once MediaChrome has the correct CSS vars for display.


- [x] Todo is fixing `hide-duration` now with CSS vars.
