### PR TITLE
feat: add --controls-backdrop-color CSS var to allow changing the backdrop color

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -79,7 +79,7 @@ function MuxPlayerPage() {
           ref={mediaElRef}
           style={{
             ...selectedCssVars,
-            '--controls-backdrop-color': controlsBackdropColor
+            ...(controlsBackdropColor && {'--controls-backdrop-color': controlsBackdropColor} as typeof selectedCssVars)
             }}
           envKey={envKey || undefined}
           metadata={toMetadataFromMediaAsset(selectedAsset, mediaAssets)}

--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -7,6 +7,7 @@ import mediaAssetsJSON from "@mux/assets/media-assets.json";
 
 const INITIAL_PRIMARY_COLOR = undefined;
 const INITIAL_SECONDARY_COLOR = undefined;
+const INITIAL_CONTROLS_BACKDROP_COLOR = undefined;
 const INITIAL_START_TIME = undefined;
 const INITIAL_THUMBNAIL_TIME = undefined;
 const INITIAL_DEBUG = false;
@@ -64,6 +65,7 @@ function MuxPlayerPage() {
   const [autoplay, setAutoplay] = useState<"muted" | boolean>(INITIAL_AUTOPLAY);
   const [primaryColor, setPrimaryColor] = useState<string|undefined>(INITIAL_PRIMARY_COLOR);
   const [secondaryColor, setSecondaryColor] = useState<string|undefined>(INITIAL_SECONDARY_COLOR);
+  const [controlsBackdropColor, setControlsBackdropColor] = useState<string|undefined>(INITIAL_CONTROLS_BACKDROP_COLOR);
   const [selectedCssVars, setSelectedCssVars] = useState(INITIAL_SELECTED_CSS_VARS);
   const [hotkeys, setHotkeys] = useState(INITIAL_HOTKEYS);
   const [title, setTitle] = useState(INITIAL_TITLE);
@@ -75,7 +77,10 @@ function MuxPlayerPage() {
         <Script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1" />
         <MuxPlayer
           ref={mediaElRef}
-          style={selectedCssVars}
+          style={{
+            ...selectedCssVars,
+            '--controls-backdrop-color': controlsBackdropColor
+            }}
           envKey={envKey || undefined}
           metadata={toMetadataFromMediaAsset(selectedAsset, mediaAssets)}
           title={title}
@@ -275,6 +280,15 @@ function MuxPlayerPage() {
             <option value="--top-seek-live-button">--top-seek-live-button</option>
             <option value="--bottom-seek-live-button">--bottom-seek-live-button</option>
           </select>
+        </div>
+        <div>
+          <label htmlFor="controls-backdrop-color">Controls Backdrop Color</label>
+          <input
+            id="controls-backdrop-color"
+            type="color"
+            onChange={(event) => setControlsBackdropColor(event.target.value)}
+            value={controlsBackdropColor}
+          />
         </div>
         <div>
           <label htmlFor="hotkeys-control">hotkeys </label>

--- a/packages/mux-player/README.md
+++ b/packages/mux-player/README.md
@@ -198,6 +198,18 @@ Instead, some components expose **parts** that can be targeted with the [CSS par
 <mux-player playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"></mux-player>
 ```
 
+### Controls Backdrop Color
+
+We expose a CSS variable to set the controls backdrop color.
+
+```css
+mux-player {
+  --controls-backdrop-color: rgb(0 0 0 / 0%);
+}
+```
+
+Turning this off completely as implications on the accessibility of the controls as they may not meet [the contrast ratio requirements for WCAG 2.1](https://www.w3.org/TR/WCAG/#contrast-minimum) without it.
+
 Supported **parts**:
 `seek-live`, `layer`, `media-layer`, `poster-layer`, `vertical-layer`, `centered-layer`, `gesture-layer`,
 `top`, `center`, `bottom`, `play`, `button`, `seek-backward`, `seek-forward`, `mute`,

--- a/packages/mux-player/README.md
+++ b/packages/mux-player/README.md
@@ -208,7 +208,7 @@ mux-player {
 }
 ```
 
-Turning this off completely as implications on the accessibility of the controls as they may not meet [the contrast ratio requirements for WCAG 2.1](https://www.w3.org/TR/WCAG/#contrast-minimum) without it.
+Turning this off completely has implications on the accessibility of the controls as they may not meet [the contrast ratio requirements for WCAG 2.1](https://www.w3.org/TR/WCAG/#contrast-minimum) without it.
 
 Supported **parts**:
 `seek-live`, `layer`, `media-layer`, `poster-layer`, `vertical-layer`, `centered-layer`, `gesture-layer`,

--- a/packages/mux-player/src/media-theme-mux/styles.css
+++ b/packages/mux-player/src/media-theme-mux/styles.css
@@ -137,7 +137,7 @@ media-controller::part(vertical-layer) {
 }
 
 media-controller:is([media-paused], :not([user-inactive]))::part(vertical-layer) {
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: var(--controls-backdrop-color, rgba(0, 0, 0, 0.6));
   transition: background-color 0.25s;
 }
 


### PR DESCRIPTION
~"controls shade color" is sort of a placeholder to kick off a discussion for a better name.~

You can try it out on the MuxPlayer nextjs test page.