### PR TITLE
fix(mux-player-react): explicitly add className to typescript types f…

### DIFF
--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -49,6 +49,7 @@ type MuxMediaPropTypes = {
 };
 
 export type MuxPlayerProps = {
+  className?: string;
   hotkeys?: string;
   nohotkeys?: boolean;
   defaultHiddenCaptions?: boolean;


### PR DESCRIPTION
…or mux-player-react (different impl from MuxVideo and MuxAudio).