### PR TITLE
fix: don't throw an error when removing tokens or playback id

### DIFF
--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -538,7 +538,7 @@ class MuxPlayerElement extends VideoApiElement {
         break;
       }
       case MuxVideoAttributes.PLAYBACK_ID: {
-        if (newValue.includes('?token')) {
+        if (newValue?.includes('?token')) {
           logger.error(
             i18n(
               'The specificed playback ID {playbackId} contains a token which must be provided via the playback-token attribute.'

--- a/packages/mux-player/src/utils.ts
+++ b/packages/mux-player/src/utils.ts
@@ -80,7 +80,11 @@ export function toParams(obj: Record<string, any>) {
 }
 
 export function parseJwt(token: string) {
-  const base64Url = token.split('.')[1];
+  const base64Url = (token ?? '').split('.')[1];
+
+  // exit early on invalid value
+  if (!base64Url) return {};
+
   const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
   const jsonPayload = decodeURIComponent(
     atob(base64)


### PR DESCRIPTION
If you do `<mux-player>.removeAttribute('playback-id')`, it'll throw an error that you can't run `.includes` on `null`.

Additionally, removing tokens or setting tokens to a non-JWT, was throwing an error as well.

Both of these bring up potential for unexpected behavior that we should think about how we want to handle. This PR doesn't change these behaviors, it only removes the errors thrown.
- What should happen if a playback-id is removed? 
  - I'd expect the source to be removed, and no video can now be played
  - currently, you can still continue playing the video of the last playback id
- what should happen if a token is set to an invalid value?
  - I'd probably expect it to be ignored
  - currently, the invalid token is used, at least for the poster image