### PR TITLE
fix: startTime on iOS when preload=auto

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -92,6 +92,7 @@
     <mux-player
       stream-type="on-demand"
       playback-id="026vljfeZ99KwUPRbl5YHVdCTSrBsPfxjkyM3PSlfWGw"
+      start-time="10"
     ></mux-player>
 
     <div class="buttons">

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -349,7 +349,7 @@ export const loadMedia = (
       if (props.startTime) {
         (muxMediaState.get(mediaEl) ?? {}).startTime = props.startTime;
         // seekable is set to the range of the entire video once durationchange fires
-        mediaEl.addEventListener('durationchange', seekInSeekableRange);
+        mediaEl.addEventListener('durationchange', seekInSeekableRange, { once: true });
       }
     } else {
       mediaEl.removeAttribute('src');
@@ -437,8 +437,6 @@ export const loadMedia = (
 
 function seekInSeekableRange(event: Event) {
   const mediaEl = event.target as HTMLMediaElement;
-  mediaEl.removeEventListener('durationchange', seekInSeekableRange);
-
   const startTime = muxMediaState.get(mediaEl)?.startTime;
   if (!startTime) return;
 

--- a/packages/playback-core/src/util.ts
+++ b/packages/playback-core/src/util.ts
@@ -4,3 +4,15 @@ type KeyTypes = string | number | symbol;
 export const isKeyOf = <T = any>(k: KeyTypes, o: T): k is keyof T => {
   return k in o;
 };
+
+export function inSeekableRange(seekable: TimeRanges, duration: number, time: number) {
+  if (duration && time > duration) {
+    time = duration;
+  }
+  for (let i = 0; i < seekable.length ?? 0; i++) {
+    if (seekable.start(i) <= time && seekable.end(i) >= time) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Fixes the issue where startTime was not being set on iOS when `preload=auto`, the default in some cases.

After setting currentTime 2 issues happened:
- setting currentTime did not actually work, when hitting play it would start at 0s
- the `seeking` event was fired but not the `seeked` event and subsequently no `timeupdate` events were fired causing the time range and time display to show wrong info