### PR TITLE
chore: add workflow to auto-add issues to project

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,20 @@
+name: Add new issues and PRs to the Project
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issues and PRs to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/muxinc/projects/8/views/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
This PR adds a GitHub Action that adds new issues and PRs to the project using the https://github.com/actions/add-to-project action.

Unfortunately, this requires a Personal Access Token with repo and project access. I've added one to this repo, which will expire in 30 days, but we should consider how we want that generated longer term and as we roll this action out to other repos.