### PR TITLE
feat: export gesture-layer as a part

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,17 +1,14 @@
-name: Add new issues and PRs to the Project
+name: Add new issues to the Project
 
 on:
   issues:
     types:
       - opened
       - transferred
-  pull_request:
-    types:
-      - opened
 
 jobs:
   add-to-project:
-    name: Add issues and PRs to project
+    name: Add issues to project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.3.0

--- a/packages/mux-player-react/README.md
+++ b/packages/mux-player-react/README.md
@@ -189,7 +189,7 @@ Instead, some components expose **parts** that can be targeted with the [CSS par
 ```
 
 Supported **parts**:
-`seek-live`, `layer`, `media-layer`, `poster-layer`, `vertical-layer`, `centered-layer`,
+`seek-live`, `layer`, `media-layer`, `poster-layer`, `vertical-layer`, `centered-layer`, `gesture-layer`,
 `top`, `center`, `bottom`, `play`, `button`, `seek-backward`, `seek-forward`, `mute`,
 `captions`, `airplay`, `pip`, `cast`, `fullscreen`, `playbackrate`, `volume`, `range`, `time`, `display`
 

--- a/packages/mux-player/README.md
+++ b/packages/mux-player/README.md
@@ -199,7 +199,7 @@ Instead, some components expose **parts** that can be targeted with the [CSS par
 ```
 
 Supported **parts**:
-`seek-live`, `layer`, `media-layer`, `poster-layer`, `vertical-layer`, `centered-layer`,
+`seek-live`, `layer`, `media-layer`, `poster-layer`, `vertical-layer`, `centered-layer`, `gesture-layer`,
 `top`, `center`, `bottom`, `play`, `button`, `seek-backward`, `seek-forward`, `mute`,
 `captions`, `airplay`, `pip`, `cast`, `fullscreen`, `playback-rate`, `volume`, `range`, `time`, `display`
 

--- a/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
+++ b/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
@@ -86,7 +86,7 @@ export default class MediaThemeMux extends MediaTheme {
           nohotkeys="${props.nohotkeys || false}"
           audio="${props.audio || false}"
           class="size-${props.playerSize}"
-          exportparts="layer, media-layer, poster-layer, vertical-layer, centered-layer"
+          exportparts="layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer"
         >
           <slot name="media" slot="media"></slot>
           <media-poster-image slot="poster" src="${props.poster}"></media-poster-image>

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -45,7 +45,7 @@ export const content = (props: MuxTemplateProps) => html`
     playbackrates="${props.playbackRates ?? false}"
     default-show-remaining-time="${props.defaultShowRemainingTime ?? false}"
     title="${props.title ?? false}"
-    exportparts="top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display"
+    exportparts="top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display"
     hotkeys="${props.hotKeys || false}"
     poster="${
       !!props.poster

--- a/packages/mux-player/test/template.test.js
+++ b/packages/mux-player/test/template.test.js
@@ -7,7 +7,7 @@ const minify = (html) => html.trim().replace(/>\s+</g, '><');
 describe('<mux-player> template render', () => {
   const div = document.createElement('div');
 
-  const exportParts = `top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display`;
+  const exportParts = `top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display`;
 
   it('default template without props', function () {
     render(content({}), div);


### PR DESCRIPTION
This allows folks to target it via CSS to turn off gestures.

Fixes #379.