### PR TITLE
fix: audio and nohotkeys props not being removed when set to false

### DIFF
--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -619,6 +619,7 @@ class MuxPlayerElement extends VideoApiElement {
   set audio(val: boolean) {
     if (!val) {
       this.removeAttribute(PlayerAttributes.AUDIO);
+      return;
     }
     this.setAttribute(PlayerAttributes.AUDIO, '');
   }
@@ -634,6 +635,7 @@ class MuxPlayerElement extends VideoApiElement {
   set nohotkeys(val: boolean) {
     if (!val) {
       this.removeAttribute(PlayerAttributes.NOHOTKEYS);
+      return;
     }
     this.setAttribute(PlayerAttributes.NOHOTKEYS, '');
   }


### PR DESCRIPTION
The properties were being removed, but then the functions weren't being exited early, so, they would get re-added.