### PR TITLE
Add exportparts to mux-player so we can style nested video

### DIFF
--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -79,6 +79,7 @@ export const content = (props: MuxTemplateProps) => html`
       env-key="${props.envKey ?? false}"
       stream-type="${props.streamType ?? false}"
       custom-domain="${props.customDomain ?? false}"
+      exportparts="video: video"
       src="${
         !!props.src
           ? props.src


### PR DESCRIPTION
This is needed to allow adding CSS to a nested web component via the `part()` syntax.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/exportparts

Tested and it works.

```html
exportparts="video: video"
```

```css
mux-player::part(video) {
  border: 3px solid red;
}
```