### PR TITLE
fix: Add exportparts to mux-player so we can style nested video

### DIFF
--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -45,7 +45,6 @@ export const content = (props: MuxTemplateProps) => html`
     playbackrates="${props.playbackRates ?? false}"
     default-show-remaining-time="${props.defaultShowRemainingTime ?? false}"
     title="${props.title ?? false}"
-    exportparts="top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display"
     hotkeys="${props.hotKeys || false}"
     poster="${
       !!props.poster
@@ -58,6 +57,7 @@ export const content = (props: MuxTemplateProps) => html`
           })
         : false
     }"
+    exportparts="top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display"
   >
     <mux-video
       slot="media"
@@ -79,7 +79,6 @@ export const content = (props: MuxTemplateProps) => html`
       env-key="${props.envKey ?? false}"
       stream-type="${props.streamType ?? false}"
       custom-domain="${props.customDomain ?? false}"
-      exportparts="video: video"
       src="${
         !!props.src
           ? props.src
@@ -106,6 +105,7 @@ export const content = (props: MuxTemplateProps) => html`
           : false
       }"
       cast-stream-type="${isLive(props) ? 'live' : false}"
+      exportparts="video"
     >
       ${
         props.playbackId && !props.audio && !isLiveOrDVR(props)

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -79,6 +79,7 @@ export const content = (props: MuxTemplateProps) => html`
       env-key="${props.envKey ?? false}"
       stream-type="${props.streamType ?? false}"
       custom-domain="${props.customDomain ?? false}"
+      exportparts="video: video"
       src="${
         !!props.src
           ? props.src

--- a/packages/mux-player/test/template.test.js
+++ b/packages/mux-player/test/template.test.js
@@ -12,8 +12,10 @@ describe('<mux-player> template render', () => {
   it('default template without props', function () {
     render(content({}), div);
     assert.equal(
-      minify(div.innerHTML),
-      `<media-theme-mux class="size-" stream-type="" player-size="" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version=""></mux-video><mxp-dialog no-auto-hide="" open=""><p></p></mxp-dialog></media-theme-mux>`
+      normalizeAttributes(minify(div.innerHTML)),
+      normalizeAttributes(
+        `<media-theme-mux class="size-" stream-type="" player-size="" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" exportparts="video"></mux-video><mxp-dialog no-auto-hide="" open=""><p></p></mxp-dialog></media-theme-mux>`
+      )
     );
   });
 
@@ -30,8 +32,10 @@ describe('<mux-player> template render', () => {
     );
     div.querySelectorAll('svg').forEach((svg) => svg.remove());
     assert.equal(
-      minify(div.innerHTML),
-      `<media-theme-mux class="size-extra-small" stream-type="live" player-size="extra-small" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="live" cast-stream-type="live"></mux-video><button slot="seek-live" part="top seek-live button" aria-disabled="">\n            Live\n          </button><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme-mux>`
+      normalizeAttributes(minify(div.innerHTML)),
+      normalizeAttributes(
+        `<media-theme-mux class="size-extra-small" stream-type="live" player-size="extra-small" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="live" cast-stream-type="live" exportparts="video"></mux-video><button slot="seek-live" part="top seek-live button" aria-disabled="">\n            Live\n          </button><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme-mux>`
+      )
     );
   });
 
@@ -46,8 +50,10 @@ describe('<mux-player> template render', () => {
     );
     div.querySelectorAll('svg').forEach((svg) => svg.remove());
     assert.equal(
-      minify(div.innerHTML),
-      `<media-theme-mux class="size-large" stream-type="on-demand" player-size="large" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><mxp-dialog no-auto-hide="" open=""><p></p></mxp-dialog></media-theme-mux>`
+      normalizeAttributes(minify(div.innerHTML)),
+      normalizeAttributes(
+        `<media-theme-mux class="size-large" stream-type="on-demand" player-size="large" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand" exportparts="video"></mux-video><mxp-dialog no-auto-hide="" open=""><p></p></mxp-dialog></media-theme-mux>`
+      )
     );
   });
 
@@ -65,8 +71,18 @@ describe('<mux-player> template render', () => {
     );
     div.querySelectorAll('svg').forEach((svg) => svg.remove());
     assert.equal(
-      minify(div.innerHTML),
-      `<media-theme-mux class="size-large" stream-type="on-demand" player-size="large" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand"></mux-video><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme-mux>`
+      normalizeAttributes(minify(div.innerHTML)),
+      normalizeAttributes(
+        `<media-theme-mux class="size-large" stream-type="on-demand" player-size="large" default-hidden-captions="" forward-seek-offset="" backward-seek-offset="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" player-software-name="" player-software-version="" stream-type="on-demand" exportparts="video"></mux-video><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme-mux>`
+      )
     );
   });
 });
+
+function normalizeAttributes(htmlStr) {
+  return htmlStr.replace(/<([a-z0-9-]+)((?:\s[a-z0-9:_.-]+=".*?")+)((?:\s*\/)?>)/gi, (s, pre, attrs, after) => {
+    let list = attrs.match(/\s[a-z0-9:_.-]+=".*?"/gi).sort((a, b) => (a > b ? 1 : -1));
+    if (~after.indexOf('/')) after = '></' + pre + '>';
+    return '<' + pre + list.join('') + after;
+  });
+}


### PR DESCRIPTION
Original at https://github.com/muxinc/elements/pull/384 by @mikker

> This is needed to allow adding CSS to a nested web component via the `part()` syntax.
> 
> See [developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/exportparts](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/exportparts)
> 
> Tested and it works.
> 
> ```
> exportparts="video: video"
> ```
> 
> ```css
> mux-player::part(video) {
>   border: 3px solid red;
> }
> ```