### PR TITLE
feat: remove deprecated .hls and .video props

### DIFF
--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -82,14 +82,6 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
     return playerSoftwareVersion;
   }
 
-  /**
-   * @deprecated please use ._hls instead
-   */
-  get hls(): PlaybackEngine | undefined {
-    console.warn('<mux-audio>.hls is deprecated, please use ._hls instead');
-    return this._hls;
-  }
-
   get _hls(): PlaybackEngine | undefined {
     return this.__hls;
   }

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -582,14 +582,6 @@ class MuxPlayerElement extends VideoApiElement {
     return this.#state.inLiveWindow;
   }
 
-  /**
-   * @deprecated please use ._hls instead
-   */
-  get hls(): PlaybackEngine | undefined {
-    logger.warn('<mux-player>.hls is deprecated, please use ._hls instead');
-    return this._hls;
-  }
-
   get _hls(): PlaybackEngine | undefined {
     return this.media?._hls;
   }

--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -163,14 +163,6 @@ class VideoApiElement extends globalThis.HTMLElement implements VideoApiElement 
     return this.shadowRoot?.querySelector('mux-video');
   }
 
-  /**
-   * @deprecated please use .media instead
-   */
-  get video(): MuxVideoElementExt | null | undefined {
-    logger.warn('<mux-player>.video is deprecated, please use .media instead');
-    return this.media;
-  }
-
   get paused() {
     return this.media?.paused ?? true;
   }

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -100,14 +100,6 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
     this.__playerSoftwareVersion = value;
   }
 
-  /**
-   * @deprecated please use ._hls instead
-   */
-  get hls(): PlaybackEngine | undefined {
-    console.warn('<mux-video>.hls is deprecated, please use ._hls instead');
-    return this._hls;
-  }
-
   get _hls(): PlaybackEngine | undefined {
     return this.__hls;
   }


### PR DESCRIPTION
Please use ._hls for hls.js access if you must and use .media instead of .video for consistency.

BREAKING CHANGE: remove deprecated .hls and .video props.