### PR TITLE
improv: default width: 100% in shadowDOM

### DIFF
--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -1,5 +1,6 @@
 :host {
   display: inline-block;
+  width: 100%;
 }
 
 /* Hide custom elements that are not defined yet */


### PR DESCRIPTION
 lets see if this has any bad side effects

The main motivation for this is that we put a lot of work into making sure that `<mux-player>` behaves *exactly* like the `<video>` element with regards to sizing. 

The `<video>` element by default (& `<mux-player>`, before this change) will change dimensions based on the underlying resolution. Not great for adaptive bitrate streaming.

Several folks reported this as a "bug" that the player was jumping sizes. Personally, in nearly every implementation I have done, I typically apply something like: `width: 100%; max-width: 500px;`.

I think having `<mux-player>` default to `width: 100%` is the right decision because:

- It is sort of "responsive" by default (on mobile it stretches the full viewport), on larger viewports it will be contained by whatever parent bounding element is there
- It prevents the element from jumping around as ABR is happening, which has been perceived as a bug
- It seems to match how developers expect it to work

We definitely expect users to apply their own styles, including a value for `width` to the `<mux-player>` element, and if they already have (they should be), then this change will have no effect. This is purely for the default experience.
