### PR TITLE
fix: subsequent preload changes

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -71,6 +71,7 @@ const DEFAULT_INITIAL_STATE: Partial<MuxPlayerProps> = Object.freeze({
   muted: undefined,
   debug: undefined,
   autoPlay: undefined,
+  preload: undefined,
   startTime: undefined,
   currentTime: undefined,
   paused: undefined,
@@ -320,6 +321,7 @@ function MuxPlayerPage({ location }: Props) {
         volume={state.volume}
         paused={state.paused}
         autoPlay={state.autoPlay}
+        preload={state.preload}
         streamType={state.streamType}
         audio={state.audio}
         primaryColor={state.primaryColor}
@@ -442,6 +444,12 @@ function MuxPlayerPage({ location }: Props) {
           name="autoPlay"
           onChange={genericOnChange}
           values={[true, false, 'any', 'muted']}
+        />
+        <EnumRenderer
+          value={state.preload}
+          name="preload"
+          onChange={genericOnChange}
+          values={['none', 'metadata', 'auto']}
         />
         <BooleanRenderer
           value={state.muted}

--- a/packages/mux-audio/package.json
+++ b/packages/mux-audio/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@mux/test-esm-exports": "0.1.0",
     "@open-wc/testing": "^3.0.3",
-    "@web/dev-server-esbuild": "^0.2.16",
+    "@web/dev-server-esbuild": "^0.3.2",
     "@web/dev-server-import-maps": "^0.0.6",
     "@web/test-runner": "^0.13.26",
     "downlevel-dts": "^0.9.0",

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -109,14 +109,16 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
   get preload() {
     const val = this.getAttribute('preload') as HTMLMediaElement['preload'];
     if (val === '') return 'auto';
-    if (val && ['none', 'metadata', 'auto'].includes(val)) return val;
+    if (['none', 'metadata', 'auto'].includes(val)) return val;
     return super.preload;
   }
 
   set preload(val) {
-    if (val === this.preload) return;
+    // don't cause an infinite loop
+    // check the attribute because an empty string maps to the `auto` prop
+    if (val == this.getAttribute('preload')) return;
 
-    if (val && ['', 'none', 'metadata', 'auto'].includes(val)) {
+    if (['', 'none', 'metadata', 'auto'].includes(val)) {
       this.setAttribute('preload', val);
     } else {
       this.removeAttribute('preload');
@@ -287,7 +289,7 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
         if (newValue === oldValue) {
           break;
         }
-        this.__core?.setPreload(this.preload);
+        this.__core?.setPreload(newValue as HTMLMediaElement['preload']);
         break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -1,7 +1,7 @@
 import { globalThis } from 'shared-polyfills';
 import {
   initialize,
-  setupAutoplay,
+  generatePlayerInitTime,
   MuxMediaProps,
   StreamTypes,
   PlaybackTypes,
@@ -9,11 +9,9 @@ import {
   toMuxVideoURL,
   teardown,
   Metadata,
-  mux,
-  generatePlayerInitTime,
   MediaError,
 } from '@mux/playback-core';
-import type { PlaybackEngine, UpdateAutoplay, ExtensionMimeTypeMap } from '@mux/playback-core';
+import type { PlaybackCore, PlaybackEngine, Autoplay, ExtensionMimeTypeMap } from '@mux/playback-core';
 import { getPlayerVersion } from './env';
 // this must be imported after playback-core for the polyfill to be included
 import CustomAudioElement, { AudioEvents } from './CustomAudioElement';
@@ -59,11 +57,9 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
     return [...AttributeNameValues, ...(CustomAudioElement.observedAttributes ?? [])];
   }
 
-  // Keeping this named "__hls" since it's exposed for unadvertised "advanced usage" via getter that assumes specifically hls.js (CJP)
-  protected __hls?: PlaybackEngine;
+  protected __core?: PlaybackCore;
   protected __playerInitTime: number;
   protected __metadata: Readonly<Metadata> = {};
-  protected __updateAutoplay?: UpdateAutoplay;
 
   constructor() {
     super();
@@ -82,8 +78,9 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
     return playerSoftwareVersion;
   }
 
+  // Keeping this named "_hls" since it's exposed for unadvertised "advanced usage" via getter that assumes specifically hls.js (CJP)
   get _hls(): PlaybackEngine | undefined {
-    return this.__hls;
+    return this.__core?.engine;
   }
 
   get mux(): Readonly<HTMLAudioElement['mux']> | undefined {
@@ -106,6 +103,23 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
       this.removeAttribute('src');
     } else {
       this.setAttribute('src', val);
+    }
+  }
+
+  get preload() {
+    const val = this.getAttribute('preload') as HTMLMediaElement['preload'];
+    if (val === '') return 'auto';
+    if (val && ['none', 'metadata', 'auto'].includes(val)) return val;
+    return super.preload;
+  }
+
+  set preload(val) {
+    if (val === this.preload) return;
+
+    if (val && ['', 'none', 'metadata', 'auto'].includes(val)) {
+      this.setAttribute('preload', val);
+    } else {
+      this.removeAttribute('preload');
     }
   }
 
@@ -236,23 +250,19 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
   }
 
   load() {
-    const nextHlsInstance = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.__hls);
-    this.__hls = nextHlsInstance;
-    const updateAutoplay = setupAutoplay(this.nativeEl, this.autoplay, nextHlsInstance);
-    this.__updateAutoplay = updateAutoplay;
+    this.__core = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.__core);
   }
 
   unload() {
-    teardown(this.nativeEl, this.__hls);
-    this.__hls = undefined;
-    this.__updateAutoplay = undefined;
+    teardown(this.nativeEl, this.__core);
+    this.__core = undefined;
   }
 
   attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string | null) {
     super.attributeChangedCallback(attrName, oldValue, newValue);
 
     switch (attrName) {
-      case 'src':
+      case 'src': {
         const hadSrc = !!oldValue;
         const hasSrc = !!newValue;
         if (!hadSrc && hasSrc) {
@@ -265,14 +275,25 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
           this.load();
         }
         break;
+      }
       case 'autoplay':
-        this.__updateAutoplay?.(newValue);
+        if (newValue === oldValue) {
+          break;
+        }
+        /** In case newValue is an empty string or null, use this.autoplay which translates to booleans (WL) */
+        this.__core?.setAutoplay(this.autoplay);
+        break;
+      case 'preload':
+        if (newValue === oldValue) {
+          break;
+        }
+        this.__core?.setPreload(this.preload);
         break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */
         this.src = toMuxVideoURL(newValue ?? undefined) as string;
         break;
-      case Attributes.DEBUG:
+      case Attributes.DEBUG: {
         const debug = this.debug;
         if (!!this.mux) {
           /** @TODO Link to docs for a more detailed discussion (CJP) */
@@ -284,6 +305,7 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
           this._hls.config.debug = debug;
         }
         break;
+      }
       case Attributes.METADATA_URL:
         if (newValue) {
           fetch(newValue)
@@ -304,7 +326,7 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
 
 type MuxAudioElementType = typeof MuxAudioElement;
 declare global {
-  var MuxAudioElement: MuxAudioElementType;
+  var MuxAudioElement: MuxAudioElementType; // eslint-disable-line
 }
 
 if (!globalThis.customElements.get('mux-audio')) {

--- a/packages/mux-audio/test/player.test.js
+++ b/packages/mux-audio/test/player.test.js
@@ -57,4 +57,38 @@ describe('<mux-audio>', () => {
       volumechange: true,
     });
   });
+
+  it('preload is forwarded to the native el', async function () {
+    const player = await fixture(`<mux-audio
+      src="https://stream.mux.com/23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I.m3u8"
+    ></mux-audio>`);
+
+    assert.equal(player.preload, 'metadata', 'browser default preload is metadata');
+
+    player.setAttribute('preload', '');
+    assert.equal(player.preload, 'auto', 'preload="" attribute maps to the auto state');
+    assert.equal(player.nativeEl.preload, 'auto', 'native preload="" attribute maps to the auto state');
+
+    player.preload = null;
+    assert.equal(player.preload, 'metadata', 'browser default preload is metadata');
+    assert.equal(player.nativeEl.preload, 'metadata', 'native browser default preload is metadata');
+
+    player.preload = 'auto';
+    assert.equal(player.getAttribute('preload'), 'auto', 'preload attr is auto');
+    assert.equal(player.nativeEl.getAttribute('preload'), 'auto', 'native preload attr is auto');
+  });
+
+  it('can use preload="none"', async function () {
+    this.timeout(10000);
+
+    const player = await fixture(`<mux-audio
+      src="https://stream.mux.com/23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I.m3u8"
+      preload="none"
+      muted
+    ></mux-audio>`);
+
+    assert.equal(player.preload, 'none', 'preload is none');
+    await aTimeout(3000);
+    assert.equal(player.buffered.length, 0, 'no buffer loaded');
+  });
 });

--- a/packages/mux-elements-codemod/package.json
+++ b/packages/mux-elements-codemod/package.json
@@ -50,8 +50,7 @@
     },
     "parser": "@typescript-eslint/parser",
     "plugins": [
-      "@typescript-eslint",
-      "@mux/i18n"
+      "@typescript-eslint"
     ],
     "extends": [
       "eslint:recommended",
@@ -67,7 +66,6 @@
     "rules": {
       "no-shadow": "error",
       "no-extra-boolean-cast": 0,
-      "@mux/i18n/no-substitutions": "error",
       "@typescript-eslint/ban-ts-comment": 0,
       "@typescript-eslint/no-explicit-any": 0
     }

--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -61,7 +61,7 @@
     "@open-wc/testing": "^3.0.3",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
-    "@web/dev-server-esbuild": "^0.2.16",
+    "@web/dev-server-esbuild": "^0.3.2",
     "@web/dev-server-import-maps": "^0.0.6",
     "@web/test-runner": "^0.13.26",
     "downlevel-dts": "^0.9.0",

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@mux/test-esm-exports": "0.1.0",
     "@open-wc/testing": "^3.0.3",
-    "@web/dev-server-esbuild": "^0.2.16",
+    "@web/dev-server-esbuild": "^0.3.2",
     "@web/dev-server-import-maps": "^0.0.6",
     "@web/test-runner": "^0.13.26",
     "downlevel-dts": "^0.9.0",

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -180,16 +180,16 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
   get preload() {
     const val = this.getAttribute('preload') as HTMLMediaElement['preload'];
     if (val === '') return 'auto';
-    if (val && ['none', 'metadata', 'auto'].includes(val)) return val;
+    if (['none', 'metadata', 'auto'].includes(val)) return val;
     return super.preload;
   }
 
   set preload(val) {
-    // dont' cause an infinite loop
+    // don't cause an infinite loop
     // check the attribute because an empty string maps to the `auto` prop
     if (val == this.getAttribute('preload')) return;
 
-    if (val != null && ['', 'none', 'metadata', 'auto'].includes(val)) {
+    if (['', 'none', 'metadata', 'auto'].includes(val)) {
       this.setAttribute('preload', val);
     } else {
       this.removeAttribute('preload');

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -185,9 +185,11 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
   }
 
   set preload(val) {
-    if (val === this.preload) return;
+    // dont' cause an infinite loop
+    // check the attribute because an empty string maps to the `auto` prop
+    if (val == this.getAttribute('preload')) return;
 
-    if (val && ['', 'none', 'metadata', 'auto'].includes(val)) {
+    if (val != null && ['', 'none', 'metadata', 'auto'].includes(val)) {
       this.setAttribute('preload', val);
     } else {
       this.removeAttribute('preload');
@@ -394,7 +396,7 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
         if (newValue === oldValue) {
           break;
         }
-        this.__core?.setPreload(this.preload);
+        this.__core?.setPreload(newValue as HTMLMediaElement['preload']);
         break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */

--- a/packages/mux-video/test/player.test.js
+++ b/packages/mux-video/test/player.test.js
@@ -120,4 +120,46 @@ describe('<mux-video>', () => {
     assert.isTrue(player.autoplay, 'can turn off autoplay');
     assert.equal(player.getAttribute('autoplay'), '', 'when prop is set to true, attribute value is an empty string');
   });
+
+  it('preload is forwarded to the native el', async function () {
+    const player = await fixture(`<mux-video
+      src="https://stream.mux.com/23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I.m3u8"
+    ></mux-video>`);
+
+    assert.equal(player.preload, 'metadata', 'browser default preload is metadata');
+
+    player.setAttribute('preload', '');
+    assert.equal(player.preload, 'auto', 'preload="" attribute maps to the auto state');
+    assert.equal(player.nativeEl.preload, 'auto', 'native preload="" attribute maps to the auto state');
+
+    player.preload = null;
+    assert.equal(player.preload, 'metadata', 'browser default preload is metadata');
+    assert.equal(player.nativeEl.preload, 'metadata', 'native browser default preload is metadata');
+
+    player.preload = 'auto';
+    assert.equal(player.getAttribute('preload'), 'auto', 'preload attr is auto');
+    assert.equal(player.nativeEl.getAttribute('preload'), 'auto', 'native preload attr is auto');
+  });
+
+  it('can use preload="none" and play', async function () {
+    this.timeout(10000);
+
+    const player = await fixture(`<mux-video
+      src="https://stream.mux.com/23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I.m3u8"
+      preload="none"
+      muted
+    ></mux-video>`);
+
+    assert.equal(player.preload, 'none', 'preload is none');
+    await aTimeout(3000);
+    assert.equal(player.buffered.length, 0, 'no buffer loaded');
+
+    try {
+      await player.play();
+    } catch (error) {
+      console.warn(error);
+    }
+
+    assert(!player.paused, 'is playing after play()');
+  });
 });

--- a/packages/playback-core/package.json
+++ b/packages/playback-core/package.json
@@ -92,6 +92,7 @@
     "rules": {
       "no-shadow": "error",
       "no-extra-boolean-cast": 0,
+      "no-empty": 0,
       "@typescript-eslint/ban-ts-comment": 0,
       "@typescript-eslint/no-explicit-any": 0
     }

--- a/packages/playback-core/package.json
+++ b/packages/playback-core/package.json
@@ -29,6 +29,8 @@
   "scripts": {
     "clean": "shx rm -rf dist/",
     "lint": "eslint src/ --ext .js,.jsx,.ts,.tsx",
+    "test": "web-test-runner **/*test.js --port 8004 --coverage --config test/web-test-runner.config.mjs --root-dir ../..",
+    "posttest": "replace 'SF:src/' 'SF:packages/playback-core/src/' coverage/lcov.info --silent",
     "dev:cjs": "yarn build:cjs --watch=forever",
     "dev:esm": "yarn build:esm --watch=forever",
     "dev:esm-module": "yarn build:esm-module --watch=forever",
@@ -51,7 +53,12 @@
     "mux-embed": "^4.7.0"
   },
   "devDependencies": {
+    "@mux/test-esm-exports": "0.1.0",
+    "@open-wc/testing": "^3.0.3",
     "@typescript-eslint/parser": "^5.38.0",
+    "@web/dev-server-esbuild": "^0.3.2",
+    "@web/dev-server-import-maps": "^0.0.6",
+    "@web/test-runner": "^0.13.26",
     "downlevel-dts": "^0.9.0",
     "esbuild": "^0.15.7",
     "eslint": "^8.23.1",
@@ -69,8 +76,7 @@
     },
     "parser": "@typescript-eslint/parser",
     "plugins": [
-      "@typescript-eslint",
-      "@mux/i18n"
+      "@typescript-eslint"
     ],
     "extends": [
       "eslint:recommended",
@@ -86,7 +92,6 @@
     "rules": {
       "no-shadow": "error",
       "no-extra-boolean-cast": 0,
-      "@mux/i18n/no-substitutions": "error",
       "@typescript-eslint/ban-ts-comment": 0,
       "@typescript-eslint/no-explicit-any": 0
     }

--- a/packages/playback-core/src/autoplay.ts
+++ b/packages/playback-core/src/autoplay.ts
@@ -1,23 +1,6 @@
 import Hls from 'hls.js';
 import { addEventListenerWithTeardown } from './util';
-
-type PlaybackEngine = Hls;
-
-// TODO add INVIEW_MUTED, INVIEW_ANY
-export type AutoplayTypes = {
-  ANY: 'any';
-  MUTED: 'muted';
-};
-
-export const AutoplayTypes: AutoplayTypes = {
-  ANY: 'any',
-  MUTED: 'muted',
-};
-
-type ValueOf<T> = T[keyof T];
-type Maybe<T> = T | null | undefined;
-export type Autoplay = boolean | ValueOf<AutoplayTypes>;
-export type UpdateAutoplay = (newAutoplay: Maybe<string | boolean>) => void;
+import { ValueOf, Autoplay, AutoplayTypes, PlaybackEngine } from './types';
 
 const AutoplayTypeValues = Object.values(AutoplayTypes);
 export const isAutoplayValue = (value: unknown): value is Autoplay => {
@@ -34,10 +17,12 @@ export const isAutoplayValue = (value: unknown): value is Autoplay => {
 // This returns a method UpdateAutoplay, that allows the user to change
 // the value of the autoplay attribute and it will react appropriately.
 export const setupAutoplay = (
-  mediaEl: HTMLMediaElement,
-  maybeAutoplay: Maybe<string | boolean>,
-  hls: PlaybackEngine | undefined
+  { autoplay: maybeAutoplay }: { autoplay?: Autoplay },
+  mediaEl?: HTMLMediaElement | null,
+  hls?: PlaybackEngine
 ) => {
+  if (!mediaEl) return () => undefined;
+
   let hasPlayed = false;
   let isLive = false;
   let autoplay: Autoplay = isAutoplayValue(maybeAutoplay) ? maybeAutoplay : !!maybeAutoplay;
@@ -130,7 +115,7 @@ export const setupAutoplay = (
 
   // this method allows us to update the value of autoplay
   // and try autoplaying appropriately.
-  const updateAutoplay: UpdateAutoplay = (newAutoplay) => {
+  const updateAutoplay = (newAutoplay?: Autoplay) => {
     if (!hasPlayed) {
       autoplay = isAutoplayValue(newAutoplay) ? newAutoplay : !!newAutoplay;
       handleAutoplay(mediaEl, autoplay);

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -5,12 +5,12 @@ import { MediaError } from './errors';
 import { setupTracks, addTextTrack, removeTextTrack } from './tracks';
 import { inSeekableRange, addEventListenerWithTeardown, toPlaybackIdParts, getType } from './util';
 import {
-  ValueOf,
   StreamTypes,
   PlaybackTypes,
   ExtensionMimeTypeMap,
-  MuxMediaProps,
-  MuxMediaPropsInternal,
+  type ValueOf,
+  type MuxMediaProps,
+  type MuxMediaPropsInternal,
 } from './types';
 
 export { mux, Hls, MediaError, setupAutoplay, addTextTrack, removeTextTrack };

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -368,9 +368,11 @@ async function handleNativeError(event: Event) {
 
   if (mediaEl.src && (code !== MediaError.MEDIA_ERR_DECODE || code !== undefined)) {
     // Attempt to get the response code from the video src url.
-    const { status } = await fetch(mediaEl.src as RequestInfo);
-    // Use the same hls.js data structure.
-    error.data = { response: { code: status } };
+    try {
+      const { status } = await fetch(mediaEl.src as RequestInfo);
+      // Use the same hls.js data structure.
+      error.data = { response: { code: status } };
+    } catch {}
   }
 
   mediaEl.dispatchEvent(

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -4,7 +4,6 @@ import { setupAutoplay } from './autoplay';
 import { MediaError } from './errors';
 import { setupTracks, addTextTrack, removeTextTrack } from './tracks';
 import { inSeekableRange, addEventListenerWithTeardown, toPlaybackIdParts, getType } from './util';
-import type { Autoplay, UpdateAutoplay } from './autoplay';
 import {
   ValueOf,
   StreamTypes,
@@ -14,7 +13,7 @@ import {
   MuxMediaPropsInternal,
 } from './types';
 
-export { mux, Hls, MediaError, Autoplay, UpdateAutoplay, setupAutoplay, addTextTrack, removeTextTrack };
+export { mux, Hls, MediaError, setupAutoplay, addTextTrack, removeTextTrack };
 export * from './types';
 
 const userAgentStr = globalThis?.navigator?.userAgent ?? '';

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -1,16 +1,22 @@
-import mux, { Options, ErrorEvent } from 'mux-embed';
-
-import Hls, { HlsConfig } from 'hls.js';
-import { AutoplayTypes, setupAutoplay } from './autoplay';
+import mux, { ErrorEvent } from 'mux-embed';
+import Hls from 'hls.js';
+import { setupAutoplay } from './autoplay';
 import { MediaError } from './errors';
 import { setupTracks, addTextTrack, removeTextTrack } from './tracks';
 import { isKeyOf, inSeekableRange, addEventListenerWithTeardown } from './util';
 import type { Autoplay, UpdateAutoplay } from './autoplay';
+import {
+  ValueOf,
+  StreamTypes,
+  PlaybackTypes,
+  ExtensionMimeTypeMap,
+  MimeTypeShorthandMap,
+  MuxMediaProps,
+  MuxMediaPropsInternal,
+} from './types';
 
-export type ValueOf<T> = T[keyof T];
-export type Metadata = Partial<Options['data']>;
-export type PlaybackEngine = Hls;
 export { mux, Hls, MediaError, Autoplay, UpdateAutoplay, setupAutoplay, addTextTrack, removeTextTrack };
+export * from './types';
 
 const userAgentStr = globalThis?.navigator?.userAgent ?? '';
 const isAndroid = userAgentStr.toLowerCase().indexOf('android') !== -1;
@@ -21,97 +27,6 @@ const DEFAULT_PREFER_MSE = isAndroid;
 
 export const generatePlayerInitTime = () => {
   return mux.utils.now();
-};
-
-export type StreamTypes = {
-  VOD: 'on-demand';
-  ON_DEMAND: 'on-demand';
-  LIVE: 'live';
-  LL_LIVE: 'll-live';
-  DVR: 'live:dvr';
-  LL_DVR: 'll-live:dvr';
-};
-
-export const StreamTypes: StreamTypes = {
-  VOD: 'on-demand',
-  ON_DEMAND: 'on-demand',
-  LIVE: 'live',
-  LL_LIVE: 'll-live',
-  DVR: 'live:dvr',
-  LL_DVR: 'll-live:dvr',
-};
-
-export type PlaybackTypes = {
-  MSE: 'mse';
-  NATIVE: 'native';
-};
-
-export const PlaybackTypes: PlaybackTypes = {
-  MSE: 'mse',
-  NATIVE: 'native',
-};
-
-export type ExtensionMimeTypeMap = {
-  M3U8: 'application/vnd.apple.mpegurl';
-  MP4: 'video/mp4';
-};
-
-export const ExtensionMimeTypeMap: ExtensionMimeTypeMap = {
-  M3U8: 'application/vnd.apple.mpegurl',
-  MP4: 'video/mp4',
-};
-
-export type MimeTypeShorthandMap = {
-  HLS: ExtensionMimeTypeMap['M3U8'];
-};
-
-export const MimeTypeShorthandMap: MimeTypeShorthandMap = {
-  HLS: ExtensionMimeTypeMap.M3U8,
-};
-
-export const shorthandKeys = Object.keys(MimeTypeShorthandMap);
-
-export type MediaTypes =
-  | ValueOf<ExtensionMimeTypeMap>
-  | keyof MimeTypeShorthandMap
-  /** @TODO Figure out a way to "downgrade" derived types below to early TS syntax (e.g. 3.4) instead of explicit versions here (CJP) */
-  | 'hls';
-// | `${Lowercase<keyof MimeTypeShorthandMap>}`
-// | `${Uppercase<keyof MimeTypeShorthandMap>}`;
-
-export const allMediaTypes = [
-  ...(Object.values(ExtensionMimeTypeMap) as ValueOf<ExtensionMimeTypeMap>[]),
-  /** @TODO Figure out a way to "downgrade" derived types below to early TS syntax (e.g. 3.4) instead of explicit versions here (CJP) */
-  'hls',
-  'HLS',
-  // ...(shorthandKeys as (keyof MimeTypeShorthandMap)[]),
-  // ...(shorthandKeys.map((k) => k.toUpperCase()) as `${Uppercase<keyof MimeTypeShorthandMap>}`[]),
-  // ...(shorthandKeys.map((k) => k.toLowerCase()) as `${Lowercase<keyof MimeTypeShorthandMap>}`[]),
-] as MediaTypes[];
-
-export type MuxMediaPropTypes = {
-  envKey: Options['data']['env_key'];
-  debug: Options['debug'] & Hls['config']['debug'];
-  metadata: Partial<Options['data']>;
-  customDomain: string;
-  beaconCollectionDomain: Options['beaconCollectionDomain'];
-  errorTranslator: Options['errorTranslator'];
-  playbackId: string;
-  playerInitTime: Options['data']['player_init_time'];
-  preferPlayback: ValueOf<PlaybackTypes> | undefined;
-  type: MediaTypes;
-  streamType: ValueOf<StreamTypes>;
-  startTime: HlsConfig['startPosition'];
-  autoPlay: boolean | ValueOf<AutoplayTypes>;
-  autoplay: boolean | ValueOf<AutoplayTypes>;
-};
-
-export type HTMLMediaElementProps = Partial<Pick<HTMLMediaElement, 'src'>>;
-
-export type MuxMediaProps = HTMLMediaElementProps & MuxMediaPropTypes;
-export type MuxMediaPropsInternal = MuxMediaProps & {
-  playerSoftwareName: Options['data']['player_software_name'];
-  playerSoftwareVersion: Options['data']['player_software_version'];
 };
 
 export const toPlaybackIdParts = (playbackIdWithOptionalParams: string): [string, string?] => {

--- a/packages/playback-core/src/preload.ts
+++ b/packages/playback-core/src/preload.ts
@@ -9,7 +9,7 @@ export const setupPreload = (
   if (!mediaEl) return () => undefined;
 
   const updatePreload = (val?: HTMLMediaElement['preload']) => {
-    if (val && ['', 'none', 'metadata', 'auto'].includes(val)) {
+    if (val != null && ['', 'none', 'metadata', 'auto'].includes(val)) {
       mediaEl.setAttribute('preload', val);
     } else {
       mediaEl.removeAttribute('preload');

--- a/packages/playback-core/src/preload.ts
+++ b/packages/playback-core/src/preload.ts
@@ -1,0 +1,70 @@
+import Hls from 'hls.js';
+import { addEventListenerWithTeardown } from './util';
+
+type PlaybackEngine = Pick<Hls, 'loadSource' | 'config'>;
+
+// the empty string is a synonym of the auto value
+export type Preload = '' | 'none' | 'metadata' | 'auto';
+export type UpdatePreload = (newPreload: Preload) => void;
+
+export const setupPreload = (
+  mediaEl: HTMLMediaElement,
+  preload: Preload,
+  src: string,
+  hls: PlaybackEngine | undefined
+) => {
+  // if we're not using hls.js (MSE) return early
+  if (!hls) return () => undefined;
+
+  let hasLoadedSource = false;
+  const originalLength = hls.config.maxBufferLength;
+  const originalSize = hls.config.maxBufferSize;
+
+  const updatePreload = (newPreload: Preload) => {
+    // update the `preload` value that is used in the `play` listener!
+    preload = newPreload;
+
+    if (preload === 'none') return;
+
+    if (preload === 'metadata') {
+      // load the least amount of data possible
+      hls.config.maxBufferLength = 1;
+      hls.config.maxBufferSize = 1;
+    } else {
+      hls.config.maxBufferLength = originalLength;
+      hls.config.maxBufferSize = originalSize;
+    }
+
+    safeLoadSource();
+  };
+
+  const safeLoadSource = () => {
+    if (!hasLoadedSource) {
+      hasLoadedSource = true;
+      hls.loadSource(src);
+    }
+  };
+
+  addEventListenerWithTeardown(
+    mediaEl,
+    'play',
+    () => {
+      switch (preload) {
+        case 'none':
+          // when preload is none, load the source on first play
+          safeLoadSource();
+          break;
+        case 'metadata':
+          // once a user has played, allow for it to load data as normal
+          hls.config.maxBufferLength = originalLength;
+          hls.config.maxBufferSize = originalSize;
+          break;
+      }
+    },
+    { once: true }
+  );
+
+  updatePreload(preload);
+
+  return updatePreload;
+};

--- a/packages/playback-core/src/types.ts
+++ b/packages/playback-core/src/types.ts
@@ -3,6 +3,7 @@ import Hls, { HlsConfig } from 'hls.js';
 import { AutoplayTypes } from './autoplay';
 
 export type { Autoplay, UpdateAutoplay } from './autoplay';
+export type { Preload, UpdatePreload } from './preload';
 
 type KeyTypes = string | number | symbol;
 

--- a/packages/playback-core/src/types.ts
+++ b/packages/playback-core/src/types.ts
@@ -1,0 +1,98 @@
+import { Options } from 'mux-embed';
+import Hls, { HlsConfig } from 'hls.js';
+import { AutoplayTypes } from './autoplay';
+
+export type ValueOf<T> = T[keyof T];
+export type Metadata = Partial<Options['data']>;
+export type PlaybackEngine = Hls;
+
+export type StreamTypes = {
+  VOD: 'on-demand';
+  ON_DEMAND: 'on-demand';
+  LIVE: 'live';
+  LL_LIVE: 'll-live';
+  DVR: 'live:dvr';
+  LL_DVR: 'll-live:dvr';
+};
+
+export const StreamTypes: StreamTypes = {
+  VOD: 'on-demand',
+  ON_DEMAND: 'on-demand',
+  LIVE: 'live',
+  LL_LIVE: 'll-live',
+  DVR: 'live:dvr',
+  LL_DVR: 'll-live:dvr',
+};
+
+export type PlaybackTypes = {
+  MSE: 'mse';
+  NATIVE: 'native';
+};
+
+export const PlaybackTypes: PlaybackTypes = {
+  MSE: 'mse',
+  NATIVE: 'native',
+};
+
+export type ExtensionMimeTypeMap = {
+  M3U8: 'application/vnd.apple.mpegurl';
+  MP4: 'video/mp4';
+};
+
+export const ExtensionMimeTypeMap: ExtensionMimeTypeMap = {
+  M3U8: 'application/vnd.apple.mpegurl',
+  MP4: 'video/mp4',
+};
+
+export type MimeTypeShorthandMap = {
+  HLS: ExtensionMimeTypeMap['M3U8'];
+};
+
+export const MimeTypeShorthandMap: MimeTypeShorthandMap = {
+  HLS: ExtensionMimeTypeMap.M3U8,
+};
+
+export const shorthandKeys = Object.keys(MimeTypeShorthandMap);
+
+export type MediaTypes =
+  | ValueOf<ExtensionMimeTypeMap>
+  | keyof MimeTypeShorthandMap
+  /** @TODO Figure out a way to "downgrade" derived types below to early TS syntax (e.g. 3.4) instead of explicit versions here (CJP) */
+  | 'hls';
+// | `${Lowercase<keyof MimeTypeShorthandMap>}`
+// | `${Uppercase<keyof MimeTypeShorthandMap>}`;
+
+export const allMediaTypes = [
+  ...(Object.values(ExtensionMimeTypeMap) as ValueOf<ExtensionMimeTypeMap>[]),
+  /** @TODO Figure out a way to "downgrade" derived types below to early TS syntax (e.g. 3.4) instead of explicit versions here (CJP) */
+  'hls',
+  'HLS',
+  // ...(shorthandKeys as (keyof MimeTypeShorthandMap)[]),
+  // ...(shorthandKeys.map((k) => k.toUpperCase()) as `${Uppercase<keyof MimeTypeShorthandMap>}`[]),
+  // ...(shorthandKeys.map((k) => k.toLowerCase()) as `${Lowercase<keyof MimeTypeShorthandMap>}`[]),
+] as MediaTypes[];
+
+export type MuxMediaPropTypes = {
+  envKey: Options['data']['env_key'];
+  debug: Options['debug'] & Hls['config']['debug'];
+  metadata: Partial<Options['data']>;
+  customDomain: string;
+  beaconCollectionDomain: Options['beaconCollectionDomain'];
+  errorTranslator: Options['errorTranslator'];
+  playbackId: string;
+  playerInitTime: Options['data']['player_init_time'];
+  preferPlayback: ValueOf<PlaybackTypes> | undefined;
+  type: MediaTypes;
+  streamType: ValueOf<StreamTypes>;
+  startTime: HlsConfig['startPosition'];
+  autoPlay: boolean | ValueOf<AutoplayTypes>;
+  autoplay: boolean | ValueOf<AutoplayTypes>;
+};
+
+export type HTMLMediaElementProps = Partial<Pick<HTMLMediaElement, 'src'>>;
+
+export type MuxMediaProps = HTMLMediaElementProps & MuxMediaPropTypes;
+export type MuxMediaPropsInternal = MuxMediaProps & {
+  playerSoftwareName: Options['data']['player_software_name'];
+  playerSoftwareVersion: Options['data']['player_software_version'];
+};

--- a/packages/playback-core/src/types.ts
+++ b/packages/playback-core/src/types.ts
@@ -1,9 +1,5 @@
 import { Options } from 'mux-embed';
 import Hls, { HlsConfig } from 'hls.js';
-import { AutoplayTypes } from './autoplay';
-
-export type { Autoplay, UpdateAutoplay } from './autoplay';
-export type { Preload, UpdatePreload } from './preload';
 
 type KeyTypes = string | number | symbol;
 
@@ -15,6 +11,25 @@ export const isKeyOf = <T = any>(k: KeyTypes, o: T): k is keyof T => {
 export type ValueOf<T> = T[keyof T];
 export type Metadata = Partial<Options['data']>;
 export type PlaybackEngine = Hls;
+
+export type PlaybackCore = {
+  engine?: PlaybackEngine;
+  setAutoplay: (autoplay?: Autoplay) => void;
+  setPreload: (preload?: HTMLMediaElement['preload']) => void;
+};
+
+// TODO add INVIEW_MUTED, INVIEW_ANY
+export type AutoplayTypes = {
+  ANY: 'any';
+  MUTED: 'muted';
+};
+
+export const AutoplayTypes: AutoplayTypes = {
+  ANY: 'any',
+  MUTED: 'muted',
+};
+
+export type Autoplay = boolean | ValueOf<AutoplayTypes>;
 
 export type StreamTypes = {
   VOD: 'on-demand';
@@ -95,11 +110,11 @@ export type MuxMediaPropTypes = {
   type: MediaTypes;
   streamType: ValueOf<StreamTypes>;
   startTime: HlsConfig['startPosition'];
-  autoPlay: boolean | ValueOf<AutoplayTypes>;
-  autoplay: boolean | ValueOf<AutoplayTypes>;
+  autoPlay?: Autoplay;
+  autoplay?: Autoplay;
 };
 
-export type HTMLMediaElementProps = Partial<Pick<HTMLMediaElement, 'src'>>;
+export type HTMLMediaElementProps = Partial<Pick<HTMLMediaElement, 'src' | 'preload'>>;
 
 export type MuxMediaProps = HTMLMediaElementProps & MuxMediaPropTypes;
 export type MuxMediaPropsInternal = MuxMediaProps & {

--- a/packages/playback-core/src/types.ts
+++ b/packages/playback-core/src/types.ts
@@ -2,6 +2,8 @@ import { Options } from 'mux-embed';
 import Hls, { HlsConfig } from 'hls.js';
 import { AutoplayTypes } from './autoplay';
 
+export type { Autoplay, UpdateAutoplay } from './autoplay';
+
 type KeyTypes = string | number | symbol;
 
 // Type Guard to determine if a given key is actually a key of some object of type T

--- a/packages/playback-core/src/types.ts
+++ b/packages/playback-core/src/types.ts
@@ -2,6 +2,13 @@ import { Options } from 'mux-embed';
 import Hls, { HlsConfig } from 'hls.js';
 import { AutoplayTypes } from './autoplay';
 
+type KeyTypes = string | number | symbol;
+
+// Type Guard to determine if a given key is actually a key of some object of type T
+export const isKeyOf = <T = any>(k: KeyTypes, o: T): k is keyof T => {
+  return k in o;
+};
+
 export type ValueOf<T> = T[keyof T];
 export type Metadata = Partial<Options['data']>;
 export type PlaybackEngine = Hls;

--- a/packages/playback-core/src/util.ts
+++ b/packages/playback-core/src/util.ts
@@ -1,4 +1,4 @@
-import { isKeyOf, ValueOf, StreamTypes, ExtensionMimeTypeMap, MimeTypeShorthandMap, MuxMediaProps } from './types';
+import { isKeyOf, ExtensionMimeTypeMap, MimeTypeShorthandMap, MuxMediaProps } from './types';
 
 type addEventListenerWithTeardown = <K extends keyof HTMLMediaElementEventMap>(
   mediaEl: HTMLMediaElement,
@@ -70,27 +70,4 @@ export const inferMimeTypeFromURL = (url: string) => {
   const upperExt = ext.toUpperCase();
 
   return isKeyOf(upperExt, ExtensionMimeTypeMap) ? ExtensionMimeTypeMap[upperExt] : '';
-};
-
-export const getStreamTypeConfig = (streamType?: ValueOf<StreamTypes>) => {
-  // for regular live videos, set backBufferLength to 8
-  if ([StreamTypes.LIVE, StreamTypes.DVR].includes(streamType as any)) {
-    const liveConfig = {
-      backBufferLength: 8,
-    };
-
-    return liveConfig;
-  }
-
-  // for LL Live videos, set backBufferLenght to 4 and maxFragLookUpTolerance to 0.001
-  if ([StreamTypes.LL_LIVE, StreamTypes.LL_DVR].includes(streamType as any)) {
-    const liveConfig = {
-      backBufferLength: 4,
-      maxFragLookUpTolerance: 0.001,
-    };
-
-    return liveConfig;
-  }
-
-  return {};
 };

--- a/packages/playback-core/src/util.ts
+++ b/packages/playback-core/src/util.ts
@@ -1,6 +1,4 @@
-import { ValueOf, StreamTypes, ExtensionMimeTypeMap, MimeTypeShorthandMap, MuxMediaProps } from './types';
-
-type KeyTypes = string | number | symbol;
+import { isKeyOf, ValueOf, StreamTypes, ExtensionMimeTypeMap, MimeTypeShorthandMap, MuxMediaProps } from './types';
 
 type addEventListenerWithTeardown = <K extends keyof HTMLMediaElementEventMap>(
   mediaEl: HTMLMediaElement,
@@ -22,11 +20,6 @@ export const addEventListenerWithTeardown: addEventListenerWithTeardown = (media
     },
     { once: true }
   );
-};
-
-// Type Guard to determine if a given key is actually a key of some object of type T
-export const isKeyOf = <T = any>(k: KeyTypes, o: T): k is keyof T => {
-  return k in o;
 };
 
 export function inSeekableRange(seekable: TimeRanges, duration: number, time: number) {

--- a/packages/playback-core/src/util.ts
+++ b/packages/playback-core/src/util.ts
@@ -1,4 +1,4 @@
-import { isKeyOf, ExtensionMimeTypeMap, MimeTypeShorthandMap, MuxMediaProps } from './types';
+import { isKeyOf, ExtensionMimeTypeMap, MimeTypeShorthandMap, type MuxMediaProps } from './types';
 
 type addEventListenerWithTeardown = <K extends keyof HTMLMediaElementEventMap>(
   mediaEl: HTMLMediaElement,

--- a/packages/playback-core/test/player.test.js
+++ b/packages/playback-core/test/player.test.js
@@ -1,0 +1,147 @@
+import { assert, aTimeout } from '@open-wc/testing';
+import { initialize, teardown } from '../src/index.ts';
+
+describe('playback core', () => {
+  it('initialize w/ default preferPlayback', async function () {
+    const video = document.createElement('video');
+    const core = initialize(
+      {
+        src: 'https://stream.mux.com/23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I.m3u8',
+      },
+      video
+    );
+    assert.equal(typeof core, 'object');
+    assert.equal(typeof core.engine, 'object');
+  });
+
+  it('teardown', async function () {
+    const video = document.createElement('video');
+    const core = initialize(
+      {
+        src: 'https://stream.mux.com/23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I.m3u8',
+      },
+      video
+    );
+    teardown(video, core);
+
+    assert(!video.hasAttribute('src'), 'src is removed on teardown');
+  });
+
+  it('setAutoplay("any")', async function () {
+    this.timeout(10000);
+
+    const video = document.createElement('video');
+    const core = initialize(
+      {
+        src: 'https://stream.mux.com/23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I.m3u8',
+        autoplay: false,
+      },
+      video
+    );
+
+    core.setAutoplay('any');
+    await new Promise((resolve) => video.addEventListener('playing', resolve));
+
+    assert(!video.paused, 'is playing after core.setAutoplay("any")');
+  });
+
+  it('setAutoplay("muted")', async function () {
+    this.timeout(10000);
+
+    const video = document.createElement('video');
+    const core = initialize(
+      {
+        src: 'https://stream.mux.com/23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I.m3u8',
+        autoplay: false,
+      },
+      video
+    );
+
+    core.setAutoplay('muted');
+    await new Promise((resolve) => video.addEventListener('playing', resolve));
+
+    assert(!video.paused, 'is playing after core.setAutoplay("muted")');
+    assert(video.muted, 'video is muted for autoplaying');
+  });
+
+  it('preload="none"', async function () {
+    this.timeout(10000);
+
+    const video = document.createElement('video');
+    initialize(
+      {
+        src: 'https://stream.mux.com/23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I.m3u8',
+        preload: 'none',
+      },
+      video
+    );
+
+    assert.equal(video.preload, 'none', 'preload is none');
+    await aTimeout(3000);
+    assert.equal(video.buffered.length, 0, 'no buffer loaded');
+
+    video.muted = true;
+    try {
+      await video.play();
+    } catch (error) {
+      console.warn(error);
+    }
+
+    assert(!video.paused, 'is playing after play()');
+  });
+
+  it('preload="auto"', async function () {
+    this.timeout(10000);
+
+    const video = document.createElement('video');
+    initialize(
+      {
+        src: 'https://stream.mux.com/23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I.m3u8',
+        preload: 'auto',
+      },
+      video
+    );
+
+    assert.equal(video.preload, 'auto', 'preload is auto');
+    await new Promise((resolve) => video.addEventListener('progress', resolve));
+    assert.equal(video.buffered.length, 1, 'some buffer loaded');
+
+    video.muted = true;
+    try {
+      await video.play();
+    } catch (error) {
+      console.warn(error);
+    }
+
+    assert(!video.paused, 'is playing after play()');
+  });
+
+  it('preload="none" to preload="metadata"', async function () {
+    this.timeout(10000);
+
+    const video = document.createElement('video');
+    const core = initialize(
+      {
+        src: 'https://stream.mux.com/23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I.m3u8',
+        preload: 'none',
+      },
+      video
+    );
+
+    assert.equal(video.preload, 'none', 'preload is none');
+
+    core.setPreload('metadata');
+    assert.equal(video.preload, 'metadata', 'preload is metadata');
+    await new Promise((resolve) => video.addEventListener('progress', resolve));
+    assert.equal(video.buffered.length, 1, 'some buffer loaded');
+
+    video.muted = true;
+    try {
+      await video.play();
+    } catch (error) {
+      console.warn(error);
+    }
+
+    assert(!video.paused, 'is playing after play()');
+  });
+});

--- a/packages/playback-core/test/web-test-runner.config.mjs
+++ b/packages/playback-core/test/web-test-runner.config.mjs
@@ -9,7 +9,7 @@ export default {
         importMap: {
           imports: {
             // see shared/test-esm-exports/README.md for more information on this configuration
-            '/test/': '/packages/mux-video/test/',
+            '/test/': '/packages/playback-core/test/',
             'hls.js': '/node_modules/@mux/test-esm-exports/dist/hls.js',
             'mux-embed': '/node_modules/@mux/test-esm-exports/dist/mux-embed.js',
           },

--- a/packages/playback-core/test/web-test-runner.config.mjs
+++ b/packages/playback-core/test/web-test-runner.config.mjs
@@ -1,0 +1,29 @@
+import { esbuildPlugin } from '@web/dev-server-esbuild';
+import { importMapsPlugin } from '@web/dev-server-import-maps';
+
+export default {
+  nodeResolve: true,
+  plugins: [
+    importMapsPlugin({
+      inject: {
+        importMap: {
+          imports: {
+            // see shared/test-esm-exports/README.md for more information on this configuration
+            '/test/': '/packages/mux-video/test/',
+            'hls.js': '/node_modules/@mux/test-esm-exports/dist/hls.js',
+            'mux-embed': '/node_modules/@mux/test-esm-exports/dist/mux-embed.js',
+          },
+        },
+      },
+    }),
+    esbuildPlugin({
+      ts: true,
+      json: true,
+      loaders: { '.css': 'text', '.svg': 'text' },
+    }),
+  ],
+  coverageConfig: {
+    report: true,
+    include: ['src/**/*'],
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1177,6 +1177,11 @@
   dependencies:
     esbuild-wasm "0.15.8"
 
+"@esbuild/linux-loong64@0.14.54":
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz#de2a4be678bd4d0d1ffbb86e6de779cde5999028"
+  integrity sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==
+
 "@esbuild/linux-loong64@0.15.7":
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.7.tgz#1ec4af4a16c554cbd402cc557ccdd874e3f7be53"
@@ -4105,14 +4110,38 @@
     picomatch "^2.2.2"
     ws "^7.4.2"
 
-"@web/dev-server-esbuild@^0.2.16":
-  version "0.2.16"
-  resolved "https://registry.yarnpkg.com/@web/dev-server-esbuild/-/dev-server-esbuild-0.2.16.tgz#fc3c429f22d89c597fa60231b6a8cacd404f9294"
-  integrity sha512-a82uKy9vQ4HvfWtjd7hJ3GtaqkL2ofxpEu3a1wIZyXB2dFWPvhRSmLNe/4IPPHe4vj6PVdRpLSFPEA3lXUW5Pw==
+"@web/dev-server-core@^0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@web/dev-server-core/-/dev-server-core-0.3.19.tgz#b61f9a0b92351371347a758b30ba19e683c72e94"
+  integrity sha512-Q/Xt4RMVebLWvALofz1C0KvP8qHbzU1EmdIA2Y1WMPJwiFJFhPxdr75p9YxK32P2t0hGs6aqqS5zE0HW9wYzYA==
+  dependencies:
+    "@types/koa" "^2.11.6"
+    "@types/ws" "^7.4.0"
+    "@web/parse5-utils" "^1.2.0"
+    chokidar "^3.4.3"
+    clone "^2.1.2"
+    es-module-lexer "^1.0.0"
+    get-stream "^6.0.0"
+    is-stream "^2.0.0"
+    isbinaryfile "^4.0.6"
+    koa "^2.13.0"
+    koa-etag "^4.0.0"
+    koa-send "^5.0.1"
+    koa-static "^5.0.0"
+    lru-cache "^6.0.0"
+    mime-types "^2.1.27"
+    parse5 "^6.0.1"
+    picomatch "^2.2.2"
+    ws "^7.4.2"
+
+"@web/dev-server-esbuild@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@web/dev-server-esbuild/-/dev-server-esbuild-0.3.2.tgz#d4f43c1677123021f6c5805beaac902318f7e083"
+  integrity sha512-Jn9b+Rs1ck4QN+ksue6qFdvUc2r/+NHpMW0R86W4Kqw5WjE7dT44pCGkKNfB8Fph4dNi0MgDaMhIkW2fcSpogA==
   dependencies:
     "@mdn/browser-compat-data" "^4.0.0"
-    "@web/dev-server-core" "^0.3.17"
-    esbuild "^0.12.21"
+    "@web/dev-server-core" "^0.3.19"
+    esbuild "^0.12 || ^0.13 || ^0.14"
     parse5 "^6.0.1"
     ua-parser-js "^1.0.2"
 
@@ -6735,6 +6764,11 @@ es-module-lexer@^0.9.0:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
   integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
 
+es-module-lexer@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.0.3.tgz#f0d8d35b36d13024110000d5e6fadc8eeaeb66b8"
+  integrity sha512-iC67eXHToclrlVhQfpRawDiF8D8sQxNxmbqw5oebegOaJkyx/w9C/k57/5e6yJR2zIByRt9OXdqX50DV2t6ZKw==
+
 es-shim-unscopables@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz#702e632193201e3edf8713635d083d378e510241"
@@ -6761,6 +6795,11 @@ esbuild-android-64@0.14.38:
   resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.38.tgz#5b94a1306df31d55055f64a62ff6b763a47b7f64"
   integrity sha512-aRFxR3scRKkbmNuGAK+Gee3+yFxkTJO/cx83Dkyzo4CnQl/2zVSurtG6+G86EQIZ+w+VYngVyK7P3HyTBKu3nw==
 
+esbuild-android-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz#505f41832884313bbaffb27704b8bcaa2d8616be"
+  integrity sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==
+
 esbuild-android-64@0.15.7:
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.7.tgz#a521604d8c4c6befc7affedc897df8ccde189bea"
@@ -6778,6 +6817,11 @@ esbuild-android-arm64@0.14.38:
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.38.tgz#78acc80773d16007de5219ccce544c036abd50b8"
   integrity sha512-L2NgQRWuHFI89IIZIlpAcINy9FvBk6xFVZ7xGdOwIm8VyhX1vNCEqUJO3DPSSy945Gzdg98cxtNt8Grv1CsyhA==
 
+esbuild-android-arm64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz#8ce69d7caba49646e009968fe5754a21a9871771"
+  integrity sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==
+
 esbuild-android-arm64@0.15.7:
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.15.7.tgz#307b81f1088bf1e81dfe5f3d1d63a2d2a2e3e68e"
@@ -6792,6 +6836,11 @@ esbuild-darwin-64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.38.tgz#e02b1291f629ebdc2aa46fabfacc9aa28ff6aa46"
   integrity sha512-5JJvgXkX87Pd1Og0u/NJuO7TSqAikAcQQ74gyJ87bqWRVeouky84ICoV4sN6VV53aTW+NE87qLdGY4QA2S7KNA==
+
+esbuild-darwin-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz#24ba67b9a8cb890a3c08d9018f887cc221cdda25"
+  integrity sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==
 
 esbuild-darwin-64@0.15.7:
   version "0.15.7"
@@ -6808,6 +6857,11 @@ esbuild-darwin-arm64@0.14.38:
   resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.38.tgz#01eb6650ec010b18c990e443a6abcca1d71290a9"
   integrity sha512-eqF+OejMI3mC5Dlo9Kdq/Ilbki9sQBw3QlHW3wjLmsLh+quNfHmGMp3Ly1eWm981iGBMdbtSS9+LRvR2T8B3eQ==
 
+esbuild-darwin-arm64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz#3f7cdb78888ee05e488d250a2bdaab1fa671bf73"
+  integrity sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==
+
 esbuild-darwin-arm64@0.15.7:
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.7.tgz#97851eacd11dacb7719713602e3319e16202fc77"
@@ -6822,6 +6876,11 @@ esbuild-freebsd-64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.38.tgz#790b8786729d4aac7be17648f9ea8e0e16475b5e"
   integrity sha512-epnPbhZUt93xV5cgeY36ZxPXDsQeO55DppzsIgWM8vgiG/Rz+qYDLmh5ts3e+Ln1wA9dQ+nZmVHw+RjaW3I5Ig==
+
+esbuild-freebsd-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz#09250f997a56ed4650f3e1979c905ffc40bbe94d"
+  integrity sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==
 
 esbuild-freebsd-64@0.15.7:
   version "0.15.7"
@@ -6838,6 +6897,11 @@ esbuild-freebsd-arm64@0.14.38:
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.38.tgz#b66340ab28c09c1098e6d9d8ff656db47d7211e6"
   integrity sha512-/9icXUYJWherhk+y5fjPI5yNUdFPtXHQlwP7/K/zg8t8lQdHVj20SqU9/udQmeUo5pDFHMYzcEFfJqgOVeKNNQ==
 
+esbuild-freebsd-arm64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz#bafb46ed04fc5f97cbdb016d86947a79579f8e48"
+  integrity sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==
+
 esbuild-freebsd-arm64@0.15.7:
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.7.tgz#0f160dbf5c9a31a1d8dd87acbbcb1a04b7031594"
@@ -6852,6 +6916,11 @@ esbuild-linux-32@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.38.tgz#7927f950986fd39f0ff319e92839455912b67f70"
   integrity sha512-QfgfeNHRFvr2XeHFzP8kOZVnal3QvST3A0cgq32ZrHjSMFTdgXhMhmWdKzRXP/PKcfv3e2OW9tT9PpcjNvaq6g==
+
+esbuild-linux-32@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz#e2a8c4a8efdc355405325033fcebeb941f781fe5"
+  integrity sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==
 
 esbuild-linux-32@0.15.7:
   version "0.15.7"
@@ -6868,6 +6937,11 @@ esbuild-linux-64@0.14.38:
   resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.38.tgz#4893d07b229d9cfe34a2b3ce586399e73c3ac519"
   integrity sha512-uuZHNmqcs+Bj1qiW9k/HZU3FtIHmYiuxZ/6Aa+/KHb/pFKr7R3aVqvxlAudYI9Fw3St0VCPfv7QBpUITSmBR1Q==
 
+esbuild-linux-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz#de5fdba1c95666cf72369f52b40b03be71226652"
+  integrity sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==
+
 esbuild-linux-64@0.15.7:
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.15.7.tgz#f89c468453bb3194b14f19dc32e0b99612e81d2b"
@@ -6882,6 +6956,11 @@ esbuild-linux-arm64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.38.tgz#8442402e37d0b8ae946ac616784d9c1a2041056a"
   integrity sha512-HlMGZTEsBrXrivr64eZ/EO0NQM8H8DuSENRok9d+Jtvq8hOLzrxfsAT9U94K3KOGk2XgCmkaI2KD8hX7F97lvA==
+
+esbuild-linux-arm64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz#dae4cd42ae9787468b6a5c158da4c84e83b0ce8b"
+  integrity sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==
 
 esbuild-linux-arm64@0.15.7:
   version "0.15.7"
@@ -6898,6 +6977,11 @@ esbuild-linux-arm@0.14.38:
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.38.tgz#d5dbf32d38b7f79be0ec6b5fb2f9251fd9066986"
   integrity sha512-FiFvQe8J3VKTDXG01JbvoVRXQ0x6UZwyrU4IaLBZeq39Bsbatd94Fuc3F1RGqPF5RbIWW7RvkVQjn79ejzysnA==
 
+esbuild-linux-arm@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz#a2c1dff6d0f21dbe8fc6998a122675533ddfcd59"
+  integrity sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==
+
 esbuild-linux-arm@0.15.7:
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.15.7.tgz#2b7c784d0b3339878013dfa82bf5eaf82c7ce7d3"
@@ -6912,6 +6996,11 @@ esbuild-linux-mips64le@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.38.tgz#95081e42f698bbe35d8ccee0e3a237594b337eb5"
   integrity sha512-qd1dLf2v7QBiI5wwfil9j0HG/5YMFBAmMVmdeokbNAMbcg49p25t6IlJFXAeLzogv1AvgaXRXvgFNhScYEUXGQ==
+
+esbuild-linux-mips64le@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz#d9918e9e4cb972f8d6dae8e8655bf9ee131eda34"
+  integrity sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==
 
 esbuild-linux-mips64le@0.15.7:
   version "0.15.7"
@@ -6928,6 +7017,11 @@ esbuild-linux-ppc64le@0.14.38:
   resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.38.tgz#dceb0a1b186f5df679618882a7990bd422089b47"
   integrity sha512-mnbEm7o69gTl60jSuK+nn+pRsRHGtDPfzhrqEUXyCl7CTOCLtWN2bhK8bgsdp6J/2NyS/wHBjs1x8aBWwP2X9Q==
 
+esbuild-linux-ppc64le@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz#3f9a0f6d41073fb1a640680845c7de52995f137e"
+  integrity sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==
+
 esbuild-linux-ppc64le@0.15.7:
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.7.tgz#52544e7fa992811eb996674090d0bc41f067a14b"
@@ -6942,6 +7036,11 @@ esbuild-linux-riscv64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.38.tgz#61fb8edb75f475f9208c4a93ab2bfab63821afd2"
   integrity sha512-+p6YKYbuV72uikChRk14FSyNJZ4WfYkffj6Af0/Tw63/6TJX6TnIKE+6D3xtEc7DeDth1fjUOEqm+ApKFXbbVQ==
+
+esbuild-linux-riscv64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz#618853c028178a61837bc799d2013d4695e451c8"
+  integrity sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==
 
 esbuild-linux-riscv64@0.15.7:
   version "0.15.7"
@@ -6958,6 +7057,11 @@ esbuild-linux-s390x@0.14.38:
   resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.38.tgz#34c7126a4937406bf6a5e69100185fd702d12fe0"
   integrity sha512-0zUsiDkGJiMHxBQ7JDU8jbaanUY975CdOW1YDrurjrM0vWHfjv9tLQsW9GSyEb/heSK1L5gaweRjzfUVBFoybQ==
 
+esbuild-linux-s390x@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz#d1885c4c5a76bbb5a0fe182e2c8c60eb9e29f2a6"
+  integrity sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==
+
 esbuild-linux-s390x@0.15.7:
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.7.tgz#8c76a125dd10a84c166294d77416caaf5e1c7b64"
@@ -6972,6 +7076,11 @@ esbuild-netbsd-64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.38.tgz#322ea9937d9e529183ee281c7996b93eb38a5d95"
   integrity sha512-cljBAApVwkpnJZfnRVThpRBGzCi+a+V9Ofb1fVkKhtrPLDYlHLrSYGtmnoTVWDQdU516qYI8+wOgcGZ4XIZh0Q==
+
+esbuild-netbsd-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz#69ae917a2ff241b7df1dbf22baf04bd330349e81"
+  integrity sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==
 
 esbuild-netbsd-64@0.15.7:
   version "0.15.7"
@@ -6988,6 +7097,11 @@ esbuild-openbsd-64@0.14.38:
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.38.tgz#1ca29bb7a2bf09592dcc26afdb45108f08a2cdbd"
   integrity sha512-CDswYr2PWPGEPpLDUO50mL3WO/07EMjnZDNKpmaxUPsrW+kVM3LoAqr/CE8UbzugpEiflYqJsGPLirThRB18IQ==
 
+esbuild-openbsd-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz#db4c8495287a350a6790de22edea247a57c5d47b"
+  integrity sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==
+
 esbuild-openbsd-64@0.15.7:
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.7.tgz#1357b2bf72fd037d9150e751420a1fe4c8618ad7"
@@ -7002,6 +7116,11 @@ esbuild-sunos-64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.38.tgz#c9446f7d8ebf45093e7bb0e7045506a88540019b"
   integrity sha512-2mfIoYW58gKcC3bck0j7lD3RZkqYA7MmujFYmSn9l6TiIcAMpuEvqksO+ntBgbLep/eyjpgdplF7b+4T9VJGOA==
+
+esbuild-sunos-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz#54287ee3da73d3844b721c21bc80c1dc7e1bf7da"
+  integrity sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==
 
 esbuild-sunos-64@0.15.7:
   version "0.15.7"
@@ -7023,6 +7142,11 @@ esbuild-windows-32@0.14.38:
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.38.tgz#f8e9b4602fd0ccbd48e5c8d117ec0ba4040f2ad1"
   integrity sha512-L2BmEeFZATAvU+FJzJiRLFUP+d9RHN+QXpgaOrs2klshoAm1AE6Us4X6fS9k33Uy5SzScn2TpcgecbqJza1Hjw==
 
+esbuild-windows-32@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz#f8aaf9a5667630b40f0fb3aa37bf01bbd340ce31"
+  integrity sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==
+
 esbuild-windows-32@0.15.7:
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.15.7.tgz#c81e688c0457665a8d463a669e5bf60870323e99"
@@ -7037,6 +7161,11 @@ esbuild-windows-64@0.14.38:
   version "0.14.38"
   resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.38.tgz#280f58e69f78535f470905ce3e43db1746518107"
   integrity sha512-Khy4wVmebnzue8aeSXLC+6clo/hRYeNIm0DyikoEqX+3w3rcvrhzpoix0S+MF9vzh6JFskkIGD7Zx47ODJNyCw==
+
+esbuild-windows-64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz#bf54b51bd3e9b0f1886ffdb224a4176031ea0af4"
+  integrity sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==
 
 esbuild-windows-64@0.15.7:
   version "0.15.7"
@@ -7053,6 +7182,11 @@ esbuild-windows-arm64@0.14.38:
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.38.tgz#d97e9ac0f95a4c236d9173fa9f86c983d6a53f54"
   integrity sha512-k3FGCNmHBkqdJXuJszdWciAH77PukEyDsdIryEHn9cKLQFxzhT39dSumeTuggaQcXY57UlmLGIkklWZo2qzHpw==
 
+esbuild-windows-arm64@0.14.54:
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz#937d15675a15e4b0e4fafdbaa3a01a776a2be982"
+  integrity sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==
+
 esbuild-windows-arm64@0.15.7:
   version "0.15.7"
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.7.tgz#7d5e9e060a7b454cb2f57f84a3f3c23c8f30b7d2"
@@ -7063,10 +7197,32 @@ esbuild-windows-arm64@0.15.8:
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.8.tgz#1d75235290bf23a111e6c0b03febd324af115cb1"
   integrity sha512-dbpAb0VyPaUs9mgw65KRfQ9rqiWCHpNzrJusoPu+LpEoswosjt/tFxN7cd2l68AT4qWdBkzAjDLRon7uqMeWcg==
 
-esbuild@^0.12.21:
-  version "0.12.29"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.29.tgz#be602db7c4dc78944a9dbde0d1ea19d36c1f882d"
-  integrity sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==
+"esbuild@^0.12 || ^0.13 || ^0.14":
+  version "0.14.54"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.54.tgz#8b44dcf2b0f1a66fc22459943dccf477535e9aa2"
+  integrity sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==
+  optionalDependencies:
+    "@esbuild/linux-loong64" "0.14.54"
+    esbuild-android-64 "0.14.54"
+    esbuild-android-arm64 "0.14.54"
+    esbuild-darwin-64 "0.14.54"
+    esbuild-darwin-arm64 "0.14.54"
+    esbuild-freebsd-64 "0.14.54"
+    esbuild-freebsd-arm64 "0.14.54"
+    esbuild-linux-32 "0.14.54"
+    esbuild-linux-64 "0.14.54"
+    esbuild-linux-arm "0.14.54"
+    esbuild-linux-arm64 "0.14.54"
+    esbuild-linux-mips64le "0.14.54"
+    esbuild-linux-ppc64le "0.14.54"
+    esbuild-linux-riscv64 "0.14.54"
+    esbuild-linux-s390x "0.14.54"
+    esbuild-netbsd-64 "0.14.54"
+    esbuild-openbsd-64 "0.14.54"
+    esbuild-sunos-64 "0.14.54"
+    esbuild-windows-32 "0.14.54"
+    esbuild-windows-64 "0.14.54"
+    esbuild-windows-arm64 "0.14.54"
 
 esbuild@^0.14.27:
   version "0.14.38"


### PR DESCRIPTION
updates the logic for preload to be updated after initial src load. e.g. from preload=none to preload=auto
this is required for starting PiP when `preload` was set to none.

I did make a change to playback-core so it returns the setAutoplay and setPreload functions in an object along with the "engine" (hls.js) because this makes it a lot easier in the React versions, don't have to mess with those hooks too much. 

in the WC versions it's also cleaner and less error prone.

less issues with importing types etc.