### PR TITLE
Don't fail on relative paths

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -171,7 +171,10 @@ export const isMuxVideoSrc = ({
   if (!!playbackId) return true;
   // having no playback id and no src string should never actually happen, but could
   if (typeof src !== 'string') return false;
-  const hostname = new URL(src).hostname.toLocaleLowerCase();
+  // Include base for relative paths
+  const base = window?.location.href;
+  const hostname = new URL(src, base).hostname.toLocaleLowerCase();
+
   return hostname.includes(MUX_VIDEO_DOMAIN) || (!!customDomain && hostname.includes(customDomain.toLocaleLowerCase()));
 };
 


### PR DESCRIPTION
## The problem
When using `mux-video` and include a relative path (e.g. by using a custom domain), it will not resolve. This is because `URL()` API only accepts absolute paths and will therefor return an error causing it to fail.

## The solution
You can use a base, which it uses to resolve when it's relative: https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#parameters

For example `new URL("https://mux.com", "https://mave.io")` will return `https://mux.com` but `new URL("/video.m3u8", "https://mave.io")` will resolve to `https://mave.io/video.m3u8`. And  `new URL("https://mux.com", null)` will fallback to `https://mux.com`.

Another approach would be to use the `custom-domain` attribute as base, but this wouldn't work in the case when you try to proxy videos through your own server.

--- 

There is currently no issue for this, if you'd like I can add one if needed (as per [contributing.md](https://github.com/muxinc/elements/blob/main/CONTRIBUTING.md)). But it would feel redundant with this PR.