### PR TITLE
tools: fix uploader types

### DIFF
--- a/packages/mux-uploader/package.json
+++ b/packages/mux-uploader/package.json
@@ -39,7 +39,7 @@
     "build:cjs": "esbuild src/index.ts --target=es2019 --external:@mux/upchunk --bundle --sourcemap --metafile=./dist/cjs.json --format=cjs --outdir=dist --out-extension:.js=.cjs",
     "build:iife": "esbuild src/index.ts --target=es2019 --bundle  --sourcemap --metafile=./dist/iife.json --format=iife --outfile=./dist/mux-uploader.js",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
-    "postbuild:types": "copyfiles -u 1 \"src/**/*.d.ts\" dist/types && downlevel-dts ./dist/types ./dist/types-ts3.4",
+    "postbuild:types": "downlevel-dts ./dist/types ./dist/types-ts3.4",
     "build": "npm-run-all --parallel 'build:esm --minify' 'build:iife --minify' 'build:cjs --minify' 'build:esm-module --minify'",
     "create-release-notes": "create-release-notes ./CHANGELOG.md",
     "publish-release": "../../scripts/publish.sh"


### PR DESCRIPTION
was seeing this in `yarn dev`. there are no `.d.ts` files in src so maybe that was the issue

> @mux/mux-uploader-react:dev: src/index.tsx(5,37): error TS2307: Cannot find module '@mux/mux-uploader' or its corresponding type declarations.
@mux/mux-uploader-react:dev: src/index.tsx(6,49): error TS2307: Cannot find module '@mux/mux-uploader' or its corresponding type declarations.
@mux/mux-uploader-react:dev: src/mux-uploader-drop.tsx(4,41): error TS2307: Cannot find module '@mux/mux-uploader' or its corresponding type declarations.