### PR TITLE
fix: preload property in mux-player

### DIFF
--- a/examples/nextjs-with-typescript/pages/mux-video.tsx
+++ b/examples/nextjs-with-typescript/pages/mux-video.tsx
@@ -28,7 +28,6 @@ function MuxVideoWCPage() {
       <mux-video
         // style={{ aspectRatio: "16 / 9" }}
         playback-id={playbackId}
-        start-time="4.6"
         // onPlayerReady={() => console.log("ready!")}
         {...debugObj}
         {...mutedObj}

--- a/examples/nextjs-with-typescript/styles.css
+++ b/examples/nextjs-with-typescript/styles.css
@@ -87,6 +87,7 @@ li a.uploader {
 mux-player:not([audio]),
 mux-video:not([audio]),
 video {
+  width: 100%;
   display: block;
   line-height: 0;
   margin-bottom: 1rem;

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -202,15 +202,6 @@ class MuxPlayerElement extends VideoApiElement {
 
     initVideoApi(this);
 
-    /**
-     * @todo determine sensible defaults for preloading buffer
-     * @see https://github.com/muxinc/elements/issues/51
-     */
-    // if (this.media?._hls) {
-    //   // Temporarily here to load less segments on page load, remove later!!!!
-    //   this.media._hls.config.maxMaxBufferLength = 2;
-    // }
-
     this.#setUpErrors();
     this.#setUpCaptionsButton();
     this.#monitorLiveWindow();

--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -379,14 +379,15 @@ class VideoApiElement extends globalThis.HTMLElement implements VideoApiElement 
   }
 
   get preload() {
-    return (getVideoAttribute(this, AllowedVideoAttributes.PRELOAD) ?? '') as HTMLVideoElement['preload'];
+    // The browser has a default preload that is only available via the native `media.preload`.
+    return (this.media ? this.media.preload : this.getAttribute('preload')) as HTMLVideoElement['preload'];
   }
 
   set preload(val) {
-    if (val) {
+    // An empty string is a valid value and is an alias for the `auto` value.
+    if (['', 'none', 'metadata', 'auto'].includes(val)) {
       this.setAttribute(AllowedVideoAttributes.PRELOAD, val);
     } else {
-      // Remove boolean attribute if false, 0, '', null, undefined.
       this.removeAttribute(AllowedVideoAttributes.PRELOAD);
     }
   }

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -201,9 +201,10 @@ describe('<mux-player>', () => {
     const player = await fixture(`<mux-player
     ></mux-player>`);
     const muxVideo = player.media;
+    const defaultPreload = document.createElement('video').preload;
 
-    assert.equal(player.preload, 'metadata', "Chrome's player default preload is metadata");
-    assert.equal(muxVideo.preload, 'metadata', "Chrome's muxVideo default preload is metadata");
+    assert.equal(player.preload, defaultPreload, `player default preload is ${defaultPreload}`);
+    assert.equal(muxVideo.preload, defaultPreload, `muxVideo default preload is ${defaultPreload}`);
 
     player.setAttribute('preload', '');
     assert.equal(player.preload, 'auto', 'player preload="" maps to auto');
@@ -211,8 +212,8 @@ describe('<mux-player>', () => {
 
     player.preload = null;
     assert(!muxVideo.hasAttribute('preload'), `has preload attr removed`);
-    assert.equal(player.preload, 'metadata', "Chrome's player default preload is metadata");
-    assert.equal(muxVideo.preload, 'metadata', "Chrome's muxVideo default preload is metadata");
+    assert.equal(player.preload, defaultPreload, `player default preload is ${defaultPreload}`);
+    assert.equal(muxVideo.preload, defaultPreload, `muxVideo default preload is ${defaultPreload}`);
   });
 
   it('poster is forwarded to the media element', async function () {

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -197,6 +197,24 @@ describe('<mux-player>', () => {
     assert.equal(muxVideo.preload, 'auto', `has preload enabled`);
   });
 
+  it('preload behaves like expected', async function () {
+    const player = await fixture(`<mux-player
+    ></mux-player>`);
+    const muxVideo = player.media;
+
+    assert.equal(player.preload, 'metadata', "Chrome's player default preload is metadata");
+    assert.equal(muxVideo.preload, 'metadata', "Chrome's muxVideo default preload is metadata");
+
+    player.setAttribute('preload', '');
+    assert.equal(player.preload, 'auto', 'player preload="" maps to auto');
+    assert.equal(muxVideo.preload, 'auto', 'muxVideo preload="" maps to auto');
+
+    player.preload = null;
+    assert(!muxVideo.hasAttribute('preload'), `has preload attr removed`);
+    assert.equal(player.preload, 'metadata', "Chrome's player default preload is metadata");
+    assert.equal(muxVideo.preload, 'metadata', "Chrome's muxVideo default preload is metadata");
+  });
+
   it('poster is forwarded to the media element', async function () {
     const player = await fixture(`<mux-player
       poster="https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=0"


### PR DESCRIPTION
fixes an issue in mux-player where `.preload` was an empty string as default which maps to the `auto` value.

