### PR TITLE
fix: turbo build clean bug

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,8 +21,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install
         run: yarn install --frozen-lockfile
+      - name: Clean
+        run: yarn clean
       - name: Test
         run: yarn test
+      - name: Clean
+        run: yarn clean
       - name: Build
         run: yarn build:packages
       - name: Publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
       - run: yarn install --frozen-lockfile
+      - run: yarn clean
       - run: yarn build:packages
       - run: npm run publish-release -- canary
         if: ${{ github.ref == 'refs/heads/main' }}
@@ -50,6 +51,7 @@ jobs:
           cache: yarn
       # esbuild requires --ignore-scripts to NOT be added here.
       - run: yarn install --frozen-lockfile
+      - run: yarn clean
       - run: yarn test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2.1.0

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,7 @@
     },
     "dev": {
       "cache": false,
-      "dependsOn": ["clean", "build:types", "^build"]
+      "dependsOn": ["build:types", "^build"]
     },
     "build:types": {
       "outputs": ["dist/types/**/*", "dist/types-ts3.4/**/*"],
@@ -23,11 +23,11 @@
     },
     "build:packages": {
       "outputs": ["dist/**/*"],
-      "dependsOn": ["clean", "build:types", "^build"]
+      "dependsOn": ["^build"]
     },
     "build": {
       "outputs": ["dist/**/*", "build/**/*", ".next/**/*", ".svelte-kit/**/*"],
-      "dependsOn": ["clean", "build:types", "^build"]
+      "dependsOn": ["build:types", "^build"]
     }
   }
 }


### PR DESCRIPTION
there was a bug in building where the "build" task was dependent on "clean" and "build:types" and "dev" was dependent on the "clean" task and the "^build" task. it comes down to some `dist` folders were being cleaned while another script was trying to `build` or `build:types` to the same folder.

I believe we can finally get rid of the auto clean because the build is now done in order from "dependency" to "dependents".

