### PR TITLE
chore: graduate mux-player and mux-player-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "build": "turbo run build",
     "i18n": "turbo run i18n",
     "prepare": "husky install",
-    "deploy": "lerna publish from-package --no-private --no-verify-access --conventional-commits --conventional-prerelease=@mux/mux-player,@mux/mux-player-react",
+    "deploy": "lerna publish from-package --no-private --no-verify-access --conventional-commits",
     "deploy:canary": "lerna run deploy:canary --npm-client=npm --scope @mux/*",
-    "version:update": "lerna version --exact --no-private --conventional-commits --conventional-prerelease=@mux/mux-player,@mux/mux-player-react",
+    "version:update": "lerna version --exact --no-private --conventional-commits --conventional-graduate=@mux/mux-player,@mux/mux-player-react",
     "create-release-notes": "lerna run create-release-notes --scope @mux/*",
     "publish-release": "lerna run publish-release --scope @mux/* --"
   },


### PR DESCRIPTION
To release mux-player and mux-player-react as no longer beta, we need to graduate them as per https://github.com/lerna/lerna/blob/main/commands/version/README.md#--conventional-graduate.

Since we run things in CI, we'll need a follow-up PR to remove this flag afterwards.