### PR TITLE
chore: add scrollable options in nextjs/MuxPlayer

### DIFF
--- a/examples/nextjs-with-typescript/components/renderers.tsx
+++ b/examples/nextjs-with-typescript/components/renderers.tsx
@@ -6,11 +6,11 @@ export const toWordsFromCamel = (string: string) => {
   return `${first}${rest.replace(/[A-Z]/g, (match) => ` ${match}`)}`
 };
 
-export const BooleanRenderer = ({ 
-  name, 
-  value, 
-  label, 
-  onChange 
+export const BooleanRenderer = ({
+  name,
+  value,
+  label,
+  onChange
 }: { name: string, value: boolean | undefined, label?: string, onChange: (obj: any) => void }) => {
   const labelStr = label ?? toWordsFromCamel(name);
   return (
@@ -26,10 +26,10 @@ export const BooleanRenderer = ({
   );
 };
 
-export const NumberRenderer = ({ 
-  name, 
-  value, 
-  label, 
+export const NumberRenderer = ({
+  name,
+  value,
+  label,
   onChange,
   min,
   max,
@@ -52,10 +52,10 @@ export const NumberRenderer = ({
   );
 };
 
-export const TextRenderer = ({ 
-  name, 
-  value, 
-  label, 
+export const TextRenderer = ({
+  name,
+  value,
+  label,
   onChange,
   placeholder,
 }: { name: string; value: string | undefined; label?: string; onChange: (obj: any) => void; placeholder?: string }) => {
@@ -74,10 +74,10 @@ export const TextRenderer = ({
   );
 };
 
-export const URLRenderer = ({ 
-  name, 
-  value, 
-  label, 
+export const URLRenderer = ({
+  name,
+  value,
+  label,
   onChange,
   placeholder,
 }: { name: string; value: string | undefined; label?: string; onChange: (obj: any) => void; placeholder?: string }) => {
@@ -96,10 +96,10 @@ export const URLRenderer = ({
   );
 };
 
-export const ColorRenderer = ({ 
-  name, 
-  value, 
-  label, 
+export const ColorRenderer = ({
+  name,
+  value,
+  label,
   onChange,
 }: { name: string; value: string | undefined; label?: string; onChange: (obj: any) => void; }) => {
   const labelStr = label ?? toWordsFromCamel(name);
@@ -116,10 +116,10 @@ export const ColorRenderer = ({
   );
 };
 
-export const EnumRenderer = ({ 
-  name, 
-  value, 
-  label, 
+export const EnumRenderer = ({
+  name,
+  value,
+  label,
   onChange,
   values,
 }: { name: string; value: any | undefined; label?: string; onChange: (obj: any) => void; values: any[] }) => {
@@ -154,10 +154,10 @@ export const EnumRenderer = ({
   );
 };
 
-export const EnumMultiSelectRenderer = ({ 
-  name, 
-  value, 
-  label, 
+export const EnumMultiSelectRenderer = ({
+  name,
+  value,
+  label,
   onChange,
   values,
 }: { name: string; value: any[] | undefined; label?: string; onChange: (obj: any) => void; values: any[] }) => {
@@ -169,8 +169,9 @@ export const EnumMultiSelectRenderer = ({
             id={`${name}-control`}
             multiple
             size={values.length}
+            defaultValue={value ?? []}
             onChange={({ target: { selectedOptions } }) => {
-              const currentValues = selectedOptions?.length 
+              const currentValues = selectedOptions?.length
                 ? Array.from(selectedOptions, ({ value }) => values.find(enumValue => enumValue.toString() === value))
                 : undefined;
               onChange({ [name]: currentValues });
@@ -178,10 +179,9 @@ export const EnumMultiSelectRenderer = ({
           >
             {values.map((enumValue) => {
               return (
-                <option 
-                  key={`${name}-${enumValue}-option`} 
+                <option
+                  key={`${name}-${enumValue}-option`}
                   value={enumValue}
-                  selected={value?.includes(enumValue)}
                 >
                   {`${enumValue}`}
                 </option>

--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -206,6 +206,11 @@ const PlayerSizeWidths = {
   [MediaChromeSizes.SM]: 600,
   [MediaChromeSizes.XS]: 250,
 };
+const PlayerSizeHeights = {
+  [MediaChromeSizes.LG]: 450,
+  [MediaChromeSizes.SM]: 338,
+  [MediaChromeSizes.XS]: 141,
+};
 
 function getPlayerSize(width) {
   if (width == undefined) return undefined;
@@ -288,6 +293,15 @@ function MuxPlayerPage({ location }: Props) {
   const genericOnChange = (obj) => dispatch(updateProps<MuxPlayerProps>(obj));
   const genericOnStyleChange = (obj) => dispatchStyles(updateProps(obj));
 
+  const [optionStyles, optionsDispatchStyles] = useReducer(reducer, {
+    '--player-height': '450px'
+  });
+  const optionsGenericOnStyleChange = (obj) => optionsDispatchStyles(updateProps(obj));
+  useEffect(() => {
+    const height = mediaElRef.current.offsetHeight;
+    optionsGenericOnStyleChange({'--player-height': height + 'px'});
+  }, [mediaElRef]);
+
   return (
     <>
       <Head>
@@ -347,7 +361,7 @@ function MuxPlayerPage({ location }: Props) {
         onSeeked={onSeeked}
       />
 
-      <div className="options">
+      <div className="options" style={optionStyles}>
         <MuxPlayerCodeRenderer state={state}/>
         <UrlPathRenderer
           state={state}
@@ -395,7 +409,13 @@ function MuxPlayerPage({ location }: Props) {
           label="Width Cutoffs for Responsive Player Chrome/UI"
           onChange={({ width: playerSize }) => {
             const width = PlayerSizeWidths[playerSize?.split(' ')[0]];
+            const height = PlayerSizeHeights[playerSize?.split(' ')[0]];
             dispatchStyles(updateProps({ width }));
+            if (height) {
+              optionsGenericOnStyleChange({'--player-height': height + 'px'});
+            } else {
+              optionsGenericOnStyleChange({'--player-height': ''});
+            }
           }}
           values={['extra-small', 'small', 'large']}
         />

--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -179,20 +179,6 @@ const UrlPathRenderer = ({
   );
 };
 
-type Props = { location?: Pick<Location, 'origin' | 'pathname'> };
-
-const getUrl = ({ req, resolvedUrl }) => {
-  const { headers } = req;
-  const refererUrl = headers.referer && new URL(headers.referer);
-  const baseUrlHost = headers.host.toLowerCase();
-  const refererHost = refererUrl?.host?.toLowerCase();
-
-  if (refererHost === baseUrlHost && headers["sec-fetch-site"] === "same-origin") return new URL(refererUrl?.origin ?? './');
-  const startsLocal = baseUrlHost.startsWith('localhost') || baseUrlHost.startsWith('127.') || baseUrlHost.startsWith('192.');
-  const protocol = startsLocal ? 'http:' : 'https:';
-  return new URL(`${protocol}//${baseUrlHost}${resolvedUrl}`);
-};
-
 const SMALL_BREAKPOINT = 700;
 const XSMALL_BREAKPOINT = 300;
 const MediaChromeSizes = {
@@ -271,6 +257,24 @@ const getControlCustomizationCSSVars = (state) => {
   return Object.entries(state)
     .filter(([k, v]) => ControlCustomizationCSSVars.includes(k) && !!v)
     .map(([k]) => k);
+};
+
+type Props = { location?: Pick<Location, 'origin' | 'pathname'> };
+
+const getUrl = ({ req, resolvedUrl }) => {
+  const { headers } = req;
+  const refererUrl = headers.referer && new URL(headers.referer);
+  const baseUrlHost = headers.host.toLowerCase();
+  const refererHost = refererUrl?.host?.toLowerCase();
+
+
+  if (refererHost === baseUrlHost && headers["sec-fetch-site"] === "same-origin") {
+    return new URL(refererUrl?.origin ? refererUrl.origin + resolvedUrl : './');
+  }
+
+  const startsLocal = baseUrlHost.startsWith('localhost') || baseUrlHost.startsWith('127.') || baseUrlHost.startsWith('192.');
+  const protocol = startsLocal ? 'http:' : 'https:';
+  return new URL(`${protocol}//${baseUrlHost}${resolvedUrl}`);
 };
 
 export const getServerSideProps: GetServerSideProps<Props> = async context => {

--- a/examples/nextjs-with-typescript/styles.css
+++ b/examples/nextjs-with-typescript/styles.css
@@ -105,6 +105,11 @@ audio {
   margin-bottom: 1rem;
 }
 
+.options {
+  overflow: scroll;
+  max-height: calc(100vh - calc(var(--player-height, 450px) + 201px));
+}
+
 .options > div {
   padding: 5px 10px;
   min-height: 25px;

--- a/examples/nextjs-with-typescript/styles.css
+++ b/examples/nextjs-with-typescript/styles.css
@@ -108,6 +108,7 @@ audio {
 .options {
   overflow: auto;
   max-height: calc(100vh - calc(var(--player-height, 450px) + 201px));
+  min-height: 400px;
 }
 
 .options > div {

--- a/examples/nextjs-with-typescript/styles.css
+++ b/examples/nextjs-with-typescript/styles.css
@@ -106,7 +106,7 @@ audio {
 }
 
 .options {
-  overflow: scroll;
+  overflow: auto;
   max-height: calc(100vh - calc(var(--player-height, 450px) + 201px));
 }
 


### PR DESCRIPTION
Sets the height of the options section to be 100vh minus the player height and everything else.

Player height defaults to 450 and will grab the first height that's set when loaded. Will update this if the player size is changed via the "width cutoffs for reponsinve player chrome/ui" option.