### PR TITLE
fix: also add media-object-fit/position to video

### DIFF
--- a/packages/mux-video/src/CustomVideoElement.js
+++ b/packages/mux-video/src/CustomVideoElement.js
@@ -60,6 +60,8 @@ template.innerHTML = `
     max-height: 100%;
     min-width: 100%;
     min-height: 100%;
+    object-fit: var(--media-object-fit);
+    object-position: var(--media-object-position);
   }
 </style>
 <video is="castable-video" part="video" crossorigin></video>


### PR DESCRIPTION
this adds the CSS var to the underlying video element in addition to the media poster image for easy DX.
no need to add a separate CSS part selector.

tagging this commit as a fix intentionally.