### PR TITLE
feat: Implement React.lazy with mux-player-react

### DIFF
--- a/packages/mux-player-react/package.json
+++ b/packages/mux-player-react/package.json
@@ -12,8 +12,7 @@
     },
     "./lazy": {
       "import": "./dist/lazy.mjs",
-      "require": "./dist/lazy.cjs.js",
-      "default": "./dist/lazy.cjs.js"
+      "default": "./dist/lazy.mjs"
     }
   },
   "types": "dist/types-ts3.4/index.d.ts",


### PR DESCRIPTION
Follow-up on: https://github.com/muxinc/elements/pull/414
This PR removes cjs references from mux-player-react/lazy
It's got a different name so that #414 makes it into the changelog.