### PR TITLE
fix: should have focus outline on dialog's close button

### DIFF
--- a/packages/mux-player/src/media-chrome/dialog.ts
+++ b/packages/mux-player/src/media-chrome/dialog.ts
@@ -43,7 +43,6 @@ const styles = `
     box-shadow: 0 0 0 2px rgba(27, 127, 204, 0.9);
   }
 
-
   .dialog {
     position: relative;
     box-sizing: border-box;

--- a/packages/mux-player/src/media-chrome/dialog.ts
+++ b/packages/mux-player/src/media-chrome/dialog.ts
@@ -39,15 +39,10 @@ const styles = `
     pointer-events: none !important;
   }
 
-  /*
-    Only show outline when keyboard focusing.
-    https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo
-    :host-context support is bad https://caniuse.com/mdn-css_selectors_host-context
-  */
-  :host-context([media-keyboard-control]) ::slotted(:focus),
-  :host-context([media-keyboard-control]) :focus {
+  :focus-visible {
     box-shadow: 0 0 0 2px rgba(27, 127, 204, 0.9);
   }
+
 
   .dialog {
     position: relative;


### PR DESCRIPTION
Firefox doesn't show a focus outline on the dialog due to no `:host-context` support. However, it doesn't seem to be necessary. Seems `:focus-visible` is working well enough.
As far as I can tell, this is the only focus outline issue that we currently have in the player, currently.