### PR TITLE
feat(mux-player-react/lazy): Adding a wrapper to avoid edge cases

### DIFF
--- a/examples/nextjs-with-typescript/styles.css
+++ b/examples/nextjs-with-typescript/styles.css
@@ -110,6 +110,9 @@ audio {
   line-height: 0;
   margin-bottom: 1rem;
 }
+[data-mux-player-react-lazy] mux-player:not([audio]) {
+  margin-bottom: 0;
+}
 
 .options {
   overflow: auto;

--- a/packages/mux-player-react/README.md
+++ b/packages/mux-player-react/README.md
@@ -57,17 +57,20 @@ import MuxPlayer from '@mux/mux-player-react/lazy';
 ```
 
 #### Styling `@mux/mux-player-react/lazy`
-Important: since `@mux/mux-player-react/lazy` adds a wrapper around mux-player to achieve its effect, if you are styling mux-player via CSS selector, use `[data-mux-player-react-lazy]` instead of `mux-player`. For example:
+
+Because `@mux/mux-player-react/lazy` adds a wrapper around mux-player to achieve its effect, use `[data-mux-player-react-lazy]` instead of `mux-player` as its CSS selector. For example:
 
 ```css
 /* This will not work */
 mux-player {
   aspect-ratio: 1;
+  max-width: 50%;
 }
 
 /* do this instead to target the mux-player-react/lazy wrapper */
 [data-mux-player-react-lazy] {
   aspect-ratio: 1;
+  max-width: 50%:
 }
 ```
 
@@ -75,7 +78,11 @@ mux-player {
 
 #### Customizing `@mux/mux-player-react/lazy`'s placeholder
 
+`@mux/mux-player-react/lazy` will display the contents of mux-player's `placeholder=` attribute as a background image.
+
 If you are generating your pages with a Node.js server (for example, [Next.js](https://nextjs.org/docs/basic-features/data-fetching/)), consider using `@mux/mux-player-react/lazy` with [`@mux/blurhash`](https://github.com/muxinc/blurhash) to generate a placeholder to display during loading.
+
+If you want to apply CSS _just_ to the placeholder, use the css selector `[data-mux-player-react-lazy-placeholder]`. 
 
 # Docs
 

--- a/packages/mux-player-react/README.md
+++ b/packages/mux-player-react/README.md
@@ -41,6 +41,8 @@ import MuxPlayer from '@mux/mux-player-react';
 
 Defer loading of Mux Player by importing from `@mux/mux-player-react/lazy`.
 
+> Note: `@mux/mux-player-react/lazy` is currently in development and may not follow the semantic versioning of mux-player or mux-player-react. Changes in behavior will be documented in the release notes; please check them when upgrading.
+
 ```jsx
 import MuxPlayer from '@mux/mux-player-react/lazy';
 

--- a/packages/mux-player-react/README.md
+++ b/packages/mux-player-react/README.md
@@ -56,6 +56,25 @@ import MuxPlayer from '@mux/mux-player-react/lazy';
 />;
 ```
 
+#### Styling `@mux/mux-player-react/lazy`
+Important: since `@mux/mux-player-react/lazy` adds a wrapper around mux-player to achieve its effect, if you are styling mux-player via CSS selector, use `[data-mux-player-react-lazy]` instead of `mux-player`. For example:
+
+```css
+/* This will not work */
+mux-player {
+  aspect-ratio: 1;
+}
+
+/* do this instead to target the mux-player-react/lazy wrapper */
+[data-mux-player-react-lazy] {
+  aspect-ratio: 1;
+}
+```
+
+> If you are styling with `className` or `style`, everything will work as expected! Nothing to change here.
+
+#### Customizing `@mux/mux-player-react/lazy`'s placeholder
+
 If you are generating your pages with a Node.js server (for example, [Next.js](https://nextjs.org/docs/basic-features/data-fetching/)), consider using `@mux/mux-player-react/lazy` with [`@mux/blurhash`](https://github.com/muxinc/blurhash) to generate a placeholder to display during loading.
 
 # Docs

--- a/packages/mux-player-react/src/lazy.tsx
+++ b/packages/mux-player-react/src/lazy.tsx
@@ -12,7 +12,7 @@ interface MuxPlayerLazyProps extends MuxPlayerProps {
   loading?: 'page' | 'viewport';
 }
 const MuxPlayer = React.forwardRef<MuxPlayerRefAttributes, MuxPlayerLazyProps>((props, ref) => {
-  const { loading = 'viewport', ...playerProps } = props;
+  const { loading = 'viewport', style, className, ...playerProps } = props;
 
   // We load mux player once two conditions are met:
   // 1. We're in a browser (react.lazy doesn't work on the server in react 17)
@@ -23,10 +23,14 @@ const MuxPlayer = React.forwardRef<MuxPlayerRefAttributes, MuxPlayerLazyProps>((
 
   return (
     <>
-      <div data-mux-player-react-lazy ref={intersectionRef}>
+      <div data-mux-player-react-lazy ref={intersectionRef} style={style} className={className || ''}>
         <ConditionalSuspense
           condition={isBrowser && (isIntersecting || loading === 'page')}
-          fallback={<div data-mux-player-react-lazy-placeholder />}
+          fallback={
+            <div data-mux-player-react-lazy-placeholder>
+              <div data-mux-player-react-lazy-placeholder-overlay />
+            </div>
+          }
         >
           <MuxPlayerIndex {...playerProps} ref={ref} />
         </ConditionalSuspense>
@@ -40,10 +44,13 @@ const MuxPlayer = React.forwardRef<MuxPlayerRefAttributes, MuxPlayerLazyProps>((
           aspect-ratio: 16/9;
           width: 100%;
         }
-        mux-player, [data-mux-player-react-lazy-placeholder] {
+        [data-mux-player-react-lazy] mux-player, [data-mux-player-react-lazy-placeholder] {
           /* its children just inherit its size */
           position: absolute;
           inset: 0;
+        }
+        [data-mux-player-react-lazy] mux-player {
+          aspect-ratio: auto;
         }
         [data-mux-player-react-lazy-placeholder] {
           background-color: var(--media-background-color, #000);
@@ -52,7 +59,7 @@ const MuxPlayer = React.forwardRef<MuxPlayerRefAttributes, MuxPlayerLazyProps>((
           background-size: var(--media-object-fit, contain);
           background-position: var(--media-object-position, 50% 50%);
         }
-        [data-mux-player-react-lazy-placeholder]:after {
+        [data-mux-player-react-lazy-placeholder-overlay] {
           /* 
             atop the placeholder is an overlay to dim the placeholder
             in the same way that the incoming controls overlay will

--- a/packages/mux-player-react/src/lazy.tsx
+++ b/packages/mux-player-react/src/lazy.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react';
-import type { DetailedHTMLProps, HTMLAttributes } from 'react';
+import React, { useRef } from 'react';
 
 import ConditionalSuspense from './ConditionalSuspense';
 import useIsBrowser from './useIsBrowser';
@@ -7,83 +6,7 @@ import useIsIntersecting from './useIsIntersecting';
 
 import type { MuxPlayerProps, MuxPlayerRefAttributes } from './index';
 
-interface MuxPlayerElement extends DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> {
-  nohotkeys?: boolean | undefined;
-}
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace JSX {
-    interface IntrinsicElements {
-      'mux-player': MuxPlayerElement;
-    }
-  }
-}
-
 const MuxPlayerIndex = React.lazy(() => import('./index'));
-
-interface FallbackProps extends MuxPlayerProps {
-  onIntersection?: () => void;
-}
-const Fallback = (props: FallbackProps) => {
-  const { style, className, onIntersection, placeholder } = props;
-
-  const intersectionRef = React.useRef<HTMLElement>(null);
-  const isIntersecting = useIsIntersecting(intersectionRef);
-
-  useEffect(() => {
-    if (isIntersecting && onIntersection) {
-      onIntersection();
-    }
-  }, [isIntersecting, onIntersection]);
-
-  return (
-    /* 
-    Why do we have a mux-player element before the mux-player bundle is even loaded?
-    Before the bundle is loaded, this mux-player element just acts like a div.
-    However, by calling this placeholder "mux-player",
-    it now gets the same CSS applied to it that the eventual "real" mux-player element will. 
-    */
-    <>
-      <mux-player
-        ref={intersectionRef}
-        data-mux-player-react-lazy-placeholder
-        placeholder={placeholder}
-        style={style}
-        className={className || ''}
-        // since there's a possibility that the bundle loads before Suspense clears this placeholder,
-        // we need to make sure that the placeholder isn't interactive and its player chrome in doesn't get rendered
-        nohotkeys
-        aria-hidden
-        tabIndex={-1}
-      >
-        <div data-mux-player-react-lazy-placeholder-overlay />
-      </mux-player>
-      <style>{
-        /* css */ `
-        mux-player[data-mux-player-react-lazy-placeholder] {
-          aspect-ratio: 16/9;
-          display: block;
-          background-color: var(--media-background-color, #000);
-          width: 100%;
-          position: relative;
-          ${placeholder ? `background-image: url(${placeholder});` : ''}
-          background-repeat: no-repeat;
-          background-size: var(--media-object-fit, contain);
-          background-position: var(--media-object-position, 50% 50%);
-          --controls: none;
-          --controls-backdrop-color: rgba(0, 0, 0, 0.6);
-        }
-        mux-player [data-mux-player-react-lazy-placeholder-overlay] {
-          position: absolute;
-          inset: 0;
-          background-color: var(--controls-backdrop-color);
-        }
-      `
-      }</style>
-    </>
-  );
-};
 
 interface MuxPlayerLazyProps extends MuxPlayerProps {
   loading?: 'page' | 'viewport';
@@ -95,22 +18,53 @@ const MuxPlayer = React.forwardRef<MuxPlayerRefAttributes, MuxPlayerLazyProps>((
   // 1. We're in a browser (react.lazy doesn't work on the server in react 17)
   const isBrowser = useIsBrowser();
   // 2. The player has entered the viewport, according to the fallback (if enabled).
-  const [isIntersecting, setIsIntersecting] = useState(() => (loading === 'viewport' ? false : true));
+  const intersectionRef = useRef<HTMLDivElement>(null);
+  const isIntersecting = useIsIntersecting(intersectionRef);
 
   return (
-    <ConditionalSuspense
-      condition={isBrowser && isIntersecting}
-      fallback={
-        <Fallback
-          style={playerProps.style}
-          className={playerProps.className}
-          placeholder={playerProps.placeholder}
-          onIntersection={() => setIsIntersecting(true)}
-        />
-      }
-    >
-      <MuxPlayerIndex {...playerProps} ref={ref} />
-    </ConditionalSuspense>
+    <>
+      <div data-mux-player-react-lazy ref={intersectionRef}>
+        <ConditionalSuspense
+          condition={isBrowser && (isIntersecting || loading === 'page')}
+          fallback={<div data-mux-player-react-lazy-placeholder />}
+        >
+          <MuxPlayerIndex {...playerProps} ref={ref} />
+        </ConditionalSuspense>
+      </div>
+      <style>{
+        /* css */ `
+        [data-mux-player-react-lazy] {
+          /* This wrapper is now in charge of sizing */
+          position: relative;
+          /* so it should have the same behavior as mux player does */
+          aspect-ratio: 16/9;
+          width: 100%;
+        }
+        mux-player, [data-mux-player-react-lazy-placeholder] {
+          /* its children just inherit its size */
+          position: absolute;
+          inset: 0;
+        }
+        [data-mux-player-react-lazy-placeholder] {
+          background-color: var(--media-background-color, #000);
+          ${playerProps.placeholder ? `background-image: url(${playerProps.placeholder});` : ''}
+          background-repeat: no-repeat;
+          background-size: var(--media-object-fit, contain);
+          background-position: var(--media-object-position, 50% 50%);
+        }
+        [data-mux-player-react-lazy-placeholder]:after {
+          /* 
+            atop the placeholder is an overlay to dim the placeholder
+            in the same way that the incoming controls overlay will
+          */
+          content: '';
+          position: absolute;
+          inset: 0;
+          background-color: var(--controls-backdrop-color, rgba(0, 0, 0, 0.6));
+        }
+      `
+      }</style>
+    </>
   );
 });
 


### PR DESCRIPTION
[Before](https://elements-demo-nextjs.vercel.app/MuxPlayerLazyBlurhash) / [After](https://elements-demo-nextjs-git-fork-decepulis-dc-lazy-wrapper-mux.vercel.app/MuxPlayerLazyBlurhash)

We've had problems with using `mux-player` as a placeholder element.
1. After the bundle has loaded and before suspense has swapped out the player, there could be weird flashes
2. css styling of controls overlay could be inconsistent if not explicitly defined
3. React 18/Next 13 does not SSR the `mux-player` element correctly. Yikes.

Risks with this approach
1. Users will have to change their css selectors from `mux-player` to `[data-mux-player-react-lazy]`. This kinda stinks

Why this is still a draft:
1. Testing
2. Expanding docs
3. Waiting for #478 