### PR TITLE
fix: lazy placeholder properly scoped styles

### DIFF
--- a/packages/mux-player-react/src/lazy.tsx
+++ b/packages/mux-player-react/src/lazy.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import type * as CSS from 'csstype';
 import type { DetailedHTMLProps, HTMLAttributes } from 'react';
 
 import ConditionalSuspense from './ConditionalSuspense';
@@ -6,6 +7,13 @@ import useIsBrowser from './useIsBrowser';
 import useIsIntersecting from './useIsIntersecting';
 
 import type { MuxPlayerProps, MuxPlayerRefAttributes } from './index';
+
+declare module 'csstype' {
+  interface Properties {
+    // Add a CSS Custom Property
+    '--mux-player-react-lazy-placeholder'?: CSS.Properties['display'];
+  }
+}
 
 interface MuxPlayerElement extends DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> {
   nohotkeys?: boolean | undefined;
@@ -49,7 +57,10 @@ const Fallback = (props: FallbackProps) => {
         ref={intersectionRef}
         data-mux-player-react-lazy-placeholder
         placeholder={placeholder}
-        style={style}
+        style={{
+          '--mux-player-react-lazy-placeholder': placeholder ? `url(${placeholder});` : '',
+          ...style,
+        }}
         className={className || ''}
         // since there's a possibility that the bundle loads before Suspense clears this placeholder,
         // we need to make sure that the placeholder isn't interactive and its player chrome in doesn't get rendered
@@ -67,7 +78,7 @@ const Fallback = (props: FallbackProps) => {
           background-color: var(--media-background-color, #000);
           width: 100%;
           position: relative;
-          ${placeholder ? `background-image: url(${placeholder});` : ''}
+          background-image: var(--mux-player-react-lazy-placeholder);
           background-repeat: no-repeat;
           background-size: var(--media-object-fit, contain);
           background-position: var(--media-object-position, 50% 50%);

--- a/packages/mux-player-react/src/lazy.tsx
+++ b/packages/mux-player-react/src/lazy.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import type * as CSS from 'csstype';
 import type { DetailedHTMLProps, HTMLAttributes } from 'react';
 
 import ConditionalSuspense from './ConditionalSuspense';

--- a/packages/mux-player-react/src/lazy.tsx
+++ b/packages/mux-player-react/src/lazy.tsx
@@ -8,13 +8,6 @@ import useIsIntersecting from './useIsIntersecting';
 
 import type { MuxPlayerProps, MuxPlayerRefAttributes } from './index';
 
-declare module 'csstype' {
-  interface Properties {
-    // Add a CSS Custom Property
-    '--mux-player-react-lazy-placeholder'?: CSS.Properties['display'];
-  }
-}
-
 interface MuxPlayerElement extends DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> {
   nohotkeys?: boolean | undefined;
 }
@@ -57,10 +50,12 @@ const Fallback = (props: FallbackProps) => {
         ref={intersectionRef}
         data-mux-player-react-lazy-placeholder
         placeholder={placeholder}
-        style={{
-          '--mux-player-react-lazy-placeholder': placeholder ? `url(${placeholder});` : '',
-          ...style,
-        }}
+        style={
+          {
+            '--mux-player-react-lazy-placeholder': placeholder ? `url(${placeholder});` : '',
+            ...style,
+          } as React.CSSProperties
+        }
         className={className || ''}
         // since there's a possibility that the bundle loads before Suspense clears this placeholder,
         // we need to make sure that the placeholder isn't interactive and its player chrome in doesn't get rendered


### PR DESCRIPTION
In https://github.com/muxinc/elements/pull/465, we moved from inline styles to a style tag to reduce our styles' specificity. 
Which... um... style tags are globally scoped. So all instances of mux-player-react/lazy would receive the same background-image as the final player declared in the dom.
Oops.
<img width="400" alt="Screen Shot 2022-10-24 at 11 19 44 AM" src="https://user-images.githubusercontent.com/8933386/197576144-fccf9b7f-c44d-4947-b612-962b20fa03bc.png">


This PR still uses global style tags, though it scopes background images correctly by using an inline `--mux-player-react-lazy-placeholder` css custom property.
<img width="400" alt="Screen Shot 2022-10-24 at 11 17 51 AM" src="https://user-images.githubusercontent.com/8933386/197576300-d13d18e8-6f3f-41bb-a336-62029a661efa.png">
