### PR TITLE
fix: smoother transition between placeholder and player in mux-player-react/lazy

### DIFF
--- a/packages/mux-player-react/src/lazy.tsx
+++ b/packages/mux-player-react/src/lazy.tsx
@@ -79,6 +79,11 @@ const Fallback = (props: FallbackProps) => {
           --controls: none;
           --controls-backdrop-color: rgba(0, 0, 0, 0.6);
         }
+        mux-player[data-mux-player-react-lazy-placeholder]::part(poster),
+        mux-player[data-mux-player-react-lazy-placeholder]::part(vertical-layer) {
+          opacity: 1;
+          transition: none;
+        }
         mux-player [data-mux-player-react-lazy-placeholder-overlay] {
           position: absolute;
           inset: 0;


### PR DESCRIPTION

https://user-images.githubusercontent.com/8933386/197632287-8dd50288-9b25-4ec7-affb-6e6c0cd72446.mov

Mux player has a fade-in effect that causes flashing during mux-player-react/lazy's loading. 

This doesn't fix it yet, but I think I'm onto something.