### PR TITLE
fix: export media loading indicator

### DIFF
--- a/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
+++ b/packages/mux-player/src/media-theme-mux/media-theme-mux.ts
@@ -135,7 +135,11 @@ export default class MediaThemeMux extends MediaTheme {
             src="${props.poster ?? false}"
             placeholder-src="${props.placeholder ?? false}"
           ></media-poster-image>
-          <media-loading-indicator slot="centered-chrome" no-auto-hide></media-loading-indicator>
+          <media-loading-indicator
+            slot="centered-chrome"
+            no-auto-hide
+            part="media-loading-indicator"
+          ></media-loading-indicator>
           ${ChromeRenderer(props)}
           <slot></slot>
         </media-controller>

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -45,7 +45,7 @@ export const content = (props: MuxTemplateProps) => html`
     hotkeys="${props.hotKeys ?? false}"
     poster="${props.poster === '' ? false : props.poster ?? false}"
     placeholder="${props.placeholder ?? false}"
-    exportparts="top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer, poster, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display"
+    exportparts="top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer, media-loading-indicator, poster, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display"
   >
     <mux-video
       slot="media"

--- a/packages/mux-player/test/template.test.js
+++ b/packages/mux-player/test/template.test.js
@@ -7,7 +7,7 @@ const minify = (html) => html.trim().replace(/>\s+</g, '><');
 describe('<mux-player> template render', () => {
   const div = document.createElement('div');
 
-  const exportParts = `top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer, poster, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display`;
+  const exportParts = `top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer, media-loading-indicator, poster, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display`;
 
   it('default template without props', function () {
     render(content({}), div);


### PR DESCRIPTION
We want the ability to hide the media loading indicator using CSS. This pull request adds a part to the media loading indicator and exports said part so that it is available from outside of the shadow tree.