### PR TITLE
fix: adds part to mxp-dialog and exposes it

### DIFF
--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -45,7 +45,7 @@ export const content = (props: MuxTemplateProps) => html`
     hotkeys="${props.hotKeys ?? false}"
     poster="${props.poster === '' ? false : props.poster ?? false}"
     placeholder="${props.placeholder ?? false}"
-    exportparts="top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer, poster, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display"
+    exportparts="top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer, poster, seek-live, play, button, seek-backward, seek-forward, dialog, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display"
   >
     <mux-video
       slot="media"
@@ -116,6 +116,7 @@ export const content = (props: MuxTemplateProps) => html`
       open="${props.isDialogOpen ?? false}"
       onclose="${props.onCloseErrorDialog}"
       oninitfocus="${props.onInitFocusDialog}"
+      part="dialog"
     >
       ${props.dialog?.title ? html`<h3>${props.dialog.title}</h3>` : html``}
       <p>

--- a/packages/mux-player/test/template.test.js
+++ b/packages/mux-player/test/template.test.js
@@ -7,7 +7,7 @@ const minify = (html) => html.trim().replace(/>\s+</g, '><');
 describe('<mux-player> template render', () => {
   const div = document.createElement('div');
 
-  const exportParts = `top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer, poster, seek-live, play, button, seek-backward, seek-forward, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display`;
+  const exportParts = `top, center, bottom, layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer, poster, seek-live, play, button, seek-backward, seek-forward, dialog, mute, captions, airplay, pip, fullscreen, cast, playback-rate, volume, range, time, display`;
 
   it('default template without props', function () {
     render(content({}), div);


### PR DESCRIPTION
We want a way to hide the dialog box with CSS. This pull requests adds a part to <mxp-dialog> and exposes it.

Long story short, we are running into cases where the error dialog is causing more harm than good. Our case involves using mux videos as backgrounds for hero elements, so we would rather have the videos fail silently rather than having an annoying error message be displayed.