### PR TITLE
fix: add async effect for loading media

### DIFF
--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -58,7 +58,9 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
       playerSoftwareVersion,
       autoplay: autoPlay,
     };
-    playbackCoreRef.current = initialize(propsWithState, mediaElRef.current, playbackCoreRef.current);
+    if (mediaElRef.current) {
+      playbackCoreRef.current = initialize(propsWithState, mediaElRef.current, playbackCoreRef.current);
+    }
   }, [src]);
 
   useEffect(() => {

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -1,6 +1,7 @@
 import { globalThis } from 'shared-polyfills';
 import {
   initialize,
+  teardown,
   generatePlayerInitTime,
   MuxMediaProps,
   StreamTypes,
@@ -58,7 +59,6 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
     return [...AttributeNameValues, ...(CustomAudioElement.observedAttributes ?? [])];
   }
 
-  autoload = false;
   #core?: PlaybackCore;
   #loadRequested?: Promise<void> | null;
   #playerInitTime: number;
@@ -269,19 +269,15 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
   }
 
   async load() {
-    // Reset Hls.js and Mux data synchronously so all needed props are updated but
-    // wait 1 tick w/ loading the source to prevent multiple requests and cancels.
-    this.#core = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
-
     if (this.#loadRequested || !this.src) return;
     await (this.#loadRequested = Promise.resolve());
     this.#loadRequested = null;
 
-    this.#core.loadMedia();
+    this.#core = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
   }
 
   unload() {
-    this.#core?.teardown();
+    teardown(this.nativeEl, this.#core);
     this.#core = undefined;
   }
 
@@ -289,13 +285,6 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
     super.attributeChangedCallback(attrName, oldValue, newValue);
 
     switch (attrName) {
-      case Attributes.ENV_KEY:
-      case Attributes.STREAM_TYPE:
-      case Attributes.DEBUG:
-      case Attributes.BEACON_COLLECTION_DOMAIN:
-      case Attributes.DISABLE_COOKIES:
-        this.load();
-        break;
       case 'src': {
         const hadSrc = !!oldValue;
         const hasSrc = !!newValue;
@@ -327,6 +316,19 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */
         this.src = toMuxVideoURL(newValue ?? undefined) as string;
         break;
+      case Attributes.DEBUG: {
+        const debug = this.debug;
+        if (!!this.mux) {
+          /** @TODO Link to docs for a more detailed discussion (CJP) */
+          console.info(
+            'Cannot toggle debug mode of mux data after initialization. Make sure you set all metadata to override before setting the src.'
+          );
+        }
+        if (!!this._hls) {
+          this._hls.config.debug = debug;
+        }
+        break;
+      }
       case Attributes.METADATA_URL:
         if (newValue) {
           fetch(newValue)

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -297,9 +297,15 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
         this.load();
         break;
       case 'src': {
-        if (!newValue) {
+        const hadSrc = !!oldValue;
+        const hasSrc = !!newValue;
+        if (!hadSrc && hasSrc) {
+          this.load();
+        } else if (hadSrc && !hasSrc) {
           this.unload();
-        } else {
+          /** @TODO Test this thoroughly (async?) and confirm unload() necessary (CJP) */
+        } else if (hadSrc && hasSrc) {
+          this.unload();
           this.load();
         }
         break;

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -7,7 +7,6 @@ import {
   PlaybackTypes,
   ValueOf,
   toMuxVideoURL,
-  teardown,
   Metadata,
   MediaError,
 } from '@mux/playback-core';
@@ -59,7 +58,9 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
     return [...AttributeNameValues, ...(CustomAudioElement.observedAttributes ?? [])];
   }
 
+  autoload = false;
   #core?: PlaybackCore;
+  #loadRequested?: Promise<void> | null;
   #playerInitTime: number;
   #metadata: Readonly<Metadata> = {};
 
@@ -267,12 +268,20 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
     }
   }
 
-  load() {
+  async load() {
+    // Reset Hls.js and Mux data synchronously so all needed props are updated but
+    // wait 1 tick w/ loading the source to prevent multiple requests and cancels.
     this.#core = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
+
+    if (this.#loadRequested || !this.src) return;
+    await (this.#loadRequested = Promise.resolve());
+    this.#loadRequested = null;
+
+    this.#core.loadMedia();
   }
 
   unload() {
-    teardown(this.nativeEl, this.#core);
+    this.#core?.teardown();
     this.#core = undefined;
   }
 
@@ -280,16 +289,17 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
     super.attributeChangedCallback(attrName, oldValue, newValue);
 
     switch (attrName) {
+      case Attributes.ENV_KEY:
+      case Attributes.STREAM_TYPE:
+      case Attributes.DEBUG:
+      case Attributes.BEACON_COLLECTION_DOMAIN:
+      case Attributes.DISABLE_COOKIES:
+        this.load();
+        break;
       case 'src': {
-        const hadSrc = !!oldValue;
-        const hasSrc = !!newValue;
-        if (!hadSrc && hasSrc) {
-          this.load();
-        } else if (hadSrc && !hasSrc) {
+        if (!newValue) {
           this.unload();
-          /** @TODO Test this thoroughly (async?) and confirm unload() necessary (CJP) */
-        } else if (hadSrc && hasSrc) {
-          this.unload();
+        } else {
           this.load();
         }
         break;
@@ -311,19 +321,6 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */
         this.src = toMuxVideoURL(newValue ?? undefined) as string;
         break;
-      case Attributes.DEBUG: {
-        const debug = this.debug;
-        if (!!this.mux) {
-          /** @TODO Link to docs for a more detailed discussion (CJP) */
-          console.info(
-            'Cannot toggle debug mode of mux data after initialization. Make sure you set all metadata to override before setting the src.'
-          );
-        }
-        if (!!this._hls) {
-          this._hls.config.debug = debug;
-        }
-        break;
-      }
       case Attributes.METADATA_URL:
         if (newValue) {
           fetch(newValue)

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -59,17 +59,17 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
     return [...AttributeNameValues, ...(CustomAudioElement.observedAttributes ?? [])];
   }
 
-  protected __core?: PlaybackCore;
-  protected __playerInitTime: number;
-  protected __metadata: Readonly<Metadata> = {};
+  #core?: PlaybackCore;
+  #playerInitTime: number;
+  #metadata: Readonly<Metadata> = {};
 
   constructor() {
     super();
-    this.__playerInitTime = generatePlayerInitTime();
+    this.#playerInitTime = generatePlayerInitTime();
   }
 
   get playerInitTime() {
-    return this.__playerInitTime;
+    return this.#playerInitTime;
   }
 
   get playerSoftwareName() {
@@ -82,7 +82,7 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
 
   // Keeping this named "_hls" since it's exposed for unadvertised "advanced usage" via getter that assumes specifically hls.js (CJP)
   get _hls(): PlaybackEngine | undefined {
-    return this.__core?.engine;
+    return this.#core?.engine;
   }
 
   get mux(): Readonly<HTMLAudioElement['mux']> | undefined {
@@ -253,27 +253,27 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
   }
 
   get metadata() {
-    return this.__metadata;
+    return this.#metadata;
   }
 
   set metadata(val: Readonly<Metadata> | undefined) {
-    this.__metadata = val ?? {};
+    this.#metadata = val ?? {};
     if (!!this.mux) {
       /** @TODO Link to docs for a more detailed discussion (CJP) */
       console.info(
         'Some metadata values may not be overridable at this time. Make sure you set all metadata to override before setting the src.'
       );
-      this.mux.emit('hb', this.__metadata);
+      this.mux.emit('hb', this.#metadata);
     }
   }
 
   load() {
-    this.__core = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.__core);
+    this.#core = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
   }
 
   unload() {
-    teardown(this.nativeEl, this.__core);
-    this.__core = undefined;
+    teardown(this.nativeEl, this.#core);
+    this.#core = undefined;
   }
 
   attributeChangedCallback(attrName: string, oldValue: string | null, newValue: string | null) {
@@ -299,13 +299,13 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
           break;
         }
         /** In case newValue is an empty string or null, use this.autoplay which translates to booleans (WL) */
-        this.__core?.setAutoplay(this.autoplay);
+        this.#core?.setAutoplay(this.autoplay);
         break;
       case 'preload':
         if (newValue === oldValue) {
           break;
         }
-        this.__core?.setPreload(newValue as HTMLMediaElement['preload']);
+        this.#core?.setPreload(newValue as HTMLMediaElement['preload']);
         break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -268,11 +268,14 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
     }
   }
 
-  async load() {
-    if (this.#loadRequested || !this.src) return;
+  async #requestLoad() {
+    if (this.#loadRequested) return;
     await (this.#loadRequested = Promise.resolve());
     this.#loadRequested = null;
+    this.load();
+  }
 
+  load() {
     this.#core = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
   }
 
@@ -289,13 +292,13 @@ class MuxAudioElement extends CustomAudioElement<HTMLAudioElement> implements Pa
         const hadSrc = !!oldValue;
         const hasSrc = !!newValue;
         if (!hadSrc && hasSrc) {
-          this.load();
+          this.#requestLoad();
         } else if (hadSrc && !hasSrc) {
           this.unload();
           /** @TODO Test this thoroughly (async?) and confirm unload() necessary (CJP) */
         } else if (hadSrc && hasSrc) {
           this.unload();
-          this.load();
+          this.#requestLoad();
         }
         break;
       }

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -58,7 +58,9 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
       playerSoftwareVersion,
       autoplay: autoPlay,
     };
-    playbackCoreRef.current = initialize(propsWithState, mediaElRef.current, playbackCoreRef.current);
+    if (mediaElRef.current) {
+      playbackCoreRef.current = initialize(propsWithState, mediaElRef.current, playbackCoreRef.current);
+    }
   }, [src]);
 
   useEffect(() => {

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -392,11 +392,14 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
     }
   }
 
-  async load() {
-    if (this.#loadRequested || !this.src) return;
+  async #requestLoad() {
+    if (this.#loadRequested) return;
     await (this.#loadRequested = Promise.resolve());
     this.#loadRequested = null;
+    this.load();
+  }
 
+  load() {
     this.#core = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
   }
 
@@ -430,13 +433,13 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
         const hadSrc = !!oldValue;
         const hasSrc = !!newValue;
         if (!hadSrc && hasSrc) {
-          this.load();
+          this.#requestLoad();
         } else if (hadSrc && !hasSrc) {
           this.unload();
           /** @TODO Test this thoroughly (async?) and confirm unload() necessary (CJP) */
         } else if (hadSrc && hasSrc) {
           this.unload();
-          this.load();
+          this.#requestLoad();
         }
         break;
       }

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -445,9 +445,15 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
         this.load();
         break;
       case 'src': {
-        if (!newValue) {
+        const hadSrc = !!oldValue;
+        const hasSrc = !!newValue;
+        if (!hadSrc && hasSrc) {
+          this.load();
+        } else if (hadSrc && !hasSrc) {
           this.unload();
-        } else {
+          /** @TODO Test this thoroughly (async?) and confirm unload() necessary (CJP) */
+        } else if (hadSrc && hasSrc) {
+          this.unload();
           this.load();
         }
         break;

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -72,16 +72,16 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
     return [...AttributeNameValues, ...(CustomVideoElement.observedAttributes ?? [])];
   }
 
-  protected __core?: PlaybackCore;
-  protected __playerInitTime: number;
-  protected __metadata: Readonly<Metadata> = {};
-  protected __playerSoftwareVersion?: string;
-  protected __playerSoftwareName?: string;
-  protected __errorTranslator?: (errorEvent: any) => any;
+  #core?: PlaybackCore;
+  #playerInitTime: number;
+  #metadata: Readonly<Metadata> = {};
+  #playerSoftwareVersion?: string;
+  #playerSoftwareName?: string;
+  #errorTranslator?: (errorEvent: any) => any;
 
   constructor() {
     super();
-    this.__playerInitTime = generatePlayerInitTime();
+    this.#playerInitTime = generatePlayerInitTime();
   }
 
   get experimentalCmcd() {
@@ -113,28 +113,28 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
   }
 
   get playerInitTime() {
-    return this.__playerInitTime;
+    return this.#playerInitTime;
   }
 
   get playerSoftwareName() {
-    return this.__playerSoftwareName ?? playerSoftwareName;
+    return this.#playerSoftwareName ?? playerSoftwareName;
   }
 
   set playerSoftwareName(value: string | undefined) {
-    this.__playerSoftwareName = value;
+    this.#playerSoftwareName = value;
   }
 
   get playerSoftwareVersion() {
-    return this.__playerSoftwareVersion ?? playerSoftwareVersion;
+    return this.#playerSoftwareVersion ?? playerSoftwareVersion;
   }
 
   set playerSoftwareVersion(value: string | undefined) {
-    this.__playerSoftwareVersion = value;
+    this.#playerSoftwareVersion = value;
   }
 
   // Keeping this named "_hls" since it's exposed for unadvertised "advanced usage" via getter that assumes specifically hls.js (CJP)
   get _hls(): PlaybackEngine | undefined {
-    return this.__core?.engine;
+    return this.#core?.engine;
   }
 
   get mux(): Readonly<HTMLVideoElement['mux']> | undefined {
@@ -147,11 +147,11 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
   }
 
   get errorTranslator(): ((errorEvent: any) => any) | undefined {
-    return this.__errorTranslator;
+    return this.#errorTranslator;
   }
 
   set errorTranslator(value: ((errorEvent: any) => any) | undefined) {
-    this.__errorTranslator = value;
+    this.#errorTranslator = value;
   }
 
   get src() {
@@ -377,7 +377,7 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
     const video_title = this.getAttribute(Attributes.METADATA_VIDEO_TITLE);
     const viewer_user_id = this.getAttribute(Attributes.METADATA_VIEWER_USER_ID);
     return {
-      ...this.__metadata,
+      ...this.#metadata,
       ...(video_id != null ? { video_id } : {}),
       ...(video_title != null ? { video_title } : {}),
       ...(viewer_user_id != null ? { viewer_user_id } : {}),
@@ -385,19 +385,19 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
   }
 
   set metadata(val: Readonly<Metadata> | undefined) {
-    this.__metadata = val ?? {};
+    this.#metadata = val ?? {};
     if (!!this.mux) {
-      this.mux.emit('hb', this.__metadata);
+      this.mux.emit('hb', this.#metadata);
     }
   }
 
   load() {
-    this.__core = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.__core);
+    this.#core = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
   }
 
   unload() {
-    teardown(this.nativeEl, this.__core);
-    this.__core = undefined;
+    teardown(this.nativeEl, this.#core);
+    this.#core = undefined;
   }
 
   // NOTE: This was carried over from hls-video-element. Is it needed for an edge case?
@@ -440,13 +440,13 @@ class MuxVideoElement extends CustomVideoElement<HTMLVideoElement> implements Pa
           break;
         }
         /** In case newValue is an empty string or null, use this.autoplay which translates to booleans (WL) */
-        this.__core?.setAutoplay(this.autoplay);
+        this.#core?.setAutoplay(this.autoplay);
         break;
       case 'preload':
         if (newValue === oldValue) {
           break;
         }
-        this.__core?.setPreload(newValue as HTMLMediaElement['preload']);
+        this.#core?.setPreload(newValue as HTMLMediaElement['preload']);
         break;
       case Attributes.PLAYBACK_ID:
         /** @TODO Improv+Discuss - how should playback-id update wrt src attr changes (and vice versa) (CJP) */

--- a/packages/playback-core/src/autoplay.ts
+++ b/packages/playback-core/src/autoplay.ts
@@ -18,11 +18,9 @@ export const isAutoplayValue = (value: unknown): value is Autoplay => {
 // the value of the autoplay attribute and it will react appropriately.
 export const setupAutoplay = (
   { autoplay: maybeAutoplay }: { autoplay?: Autoplay },
-  mediaEl?: HTMLMediaElement | null,
+  mediaEl: HTMLMediaElement,
   hls?: PlaybackEngine
 ) => {
-  if (!mediaEl) return () => undefined;
-
   let hasPlayed = false;
   let isLive = false;
   let autoplay: Autoplay = isAutoplayValue(maybeAutoplay) ? maybeAutoplay : !!maybeAutoplay;

--- a/packages/playback-core/src/preload.ts
+++ b/packages/playback-core/src/preload.ts
@@ -2,7 +2,7 @@ import { addEventListenerWithTeardown } from './util';
 import { PlaybackEngine } from './types';
 
 export const setupPreload = (
-  { preload, src }: Partial<HTMLMediaElement>,
+  { src }: Partial<HTMLMediaElement>,
   mediaEl?: HTMLMediaElement | null,
   hls?: PlaybackEngine
 ) => {
@@ -18,7 +18,6 @@ export const setupPreload = (
 
   // handle native without hls.js (MSE)
   if (!hls) {
-    updatePreload(preload);
     return updatePreload;
   }
 
@@ -69,8 +68,6 @@ export const setupPreload = (
     },
     { once: true }
   );
-
-  updateHlsPreload(preload);
 
   return updateHlsPreload;
 };

--- a/packages/playback-core/src/preload.ts
+++ b/packages/playback-core/src/preload.ts
@@ -2,12 +2,10 @@ import { addEventListenerWithTeardown } from './util';
 import { PlaybackEngine } from './types';
 
 export const setupPreload = (
-  { src }: Partial<HTMLMediaElement>,
-  mediaEl?: HTMLMediaElement | null,
+  { preload, src }: Partial<HTMLMediaElement>,
+  mediaEl: HTMLMediaElement,
   hls?: PlaybackEngine
 ) => {
-  if (!mediaEl) return () => undefined;
-
   const updatePreload = (val?: HTMLMediaElement['preload']) => {
     if (val != null && ['', 'none', 'metadata', 'auto'].includes(val)) {
       mediaEl.setAttribute('preload', val);
@@ -18,6 +16,7 @@ export const setupPreload = (
 
   // handle native without hls.js (MSE)
   if (!hls) {
+    updatePreload(preload);
     return updatePreload;
   }
 
@@ -68,6 +67,8 @@ export const setupPreload = (
     },
     { once: true }
   );
+
+  updateHlsPreload(preload);
 
   return updateHlsPreload;
 };

--- a/packages/playback-core/src/types.ts
+++ b/packages/playback-core/src/types.ts
@@ -12,6 +12,12 @@ export type ValueOf<T> = T[keyof T];
 export type Metadata = Partial<Options['data']>;
 export type PlaybackEngine = Hls;
 
+export type PlaybackCore = {
+  engine?: PlaybackEngine;
+  setAutoplay: (autoplay?: Autoplay) => void;
+  setPreload: (preload?: HTMLMediaElement['preload']) => void;
+};
+
 // TODO add INVIEW_MUTED, INVIEW_ANY
 export type AutoplayTypes = {
   ANY: 'any';
@@ -127,7 +133,6 @@ export type HTMLMediaElementProps = Partial<Pick<HTMLMediaElement, 'src' | 'prel
 
 export type MuxMediaProps = HTMLMediaElementProps & MuxMediaPropTypes;
 export type MuxMediaPropsInternal = MuxMediaProps & {
-  autoload: boolean;
   playerSoftwareName: Options['data']['player_software_name'];
   playerSoftwareVersion: Options['data']['player_software_version'];
 };

--- a/packages/playback-core/src/types.ts
+++ b/packages/playback-core/src/types.ts
@@ -12,12 +12,6 @@ export type ValueOf<T> = T[keyof T];
 export type Metadata = Partial<Options['data']>;
 export type PlaybackEngine = Hls;
 
-export type PlaybackCore = {
-  engine?: PlaybackEngine;
-  setAutoplay: (autoplay?: Autoplay) => void;
-  setPreload: (preload?: HTMLMediaElement['preload']) => void;
-};
-
 // TODO add INVIEW_MUTED, INVIEW_ANY
 export type AutoplayTypes = {
   ANY: 'any';
@@ -133,6 +127,7 @@ export type HTMLMediaElementProps = Partial<Pick<HTMLMediaElement, 'src' | 'prel
 
 export type MuxMediaProps = HTMLMediaElementProps & MuxMediaPropTypes;
 export type MuxMediaPropsInternal = MuxMediaProps & {
+  autoload: boolean;
   playerSoftwareName: Options['data']['player_software_name'];
   playerSoftwareVersion: Options['data']['player_software_version'];
 };


### PR DESCRIPTION
- this adds an async effect for init playback core and loading the media for the mux-video and mux-audio custom elements.
- made the `mediaEl` required in playback-core making some code and types easier.