### PR TITLE
feat(mux-uploader): Upgrade upchunk to take advantage of readable str…

### DIFF
--- a/packages/mux-uploader/package.json
+++ b/packages/mux-uploader/package.json
@@ -46,7 +46,7 @@
     "publish-release": "../../scripts/publish.sh"
   },
   "dependencies": {
-    "@mux/upchunk": "^2.6.0"
+    "@mux/upchunk": "^3.0.0"
   },
   "devDependencies": {
     "@mux/test-esm-exports": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2283,10 +2283,10 @@
     blurhash "^1.1.5"
     sharp "^0.30.7"
 
-"@mux/upchunk@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@mux/upchunk/-/upchunk-2.6.0.tgz#076b1186c3b859e44a3293514b28d8ef8162ee21"
-  integrity sha512-r7nMbgsjjVudjzhRwV8pfhamMrKyBvEXERSj3Fngy9EPwukXK6e1A5wMeFCvsL7mBGGLYQp9HmSDkhoiyq8phw==
+"@mux/upchunk@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@mux/upchunk/-/upchunk-3.0.0.tgz#657d88241e24776b9b9c53365ded3b70cf60c4c8"
+  integrity sha512-Aan5CzCcQSjVBOa2KxyMZiQVvh+D6vfnfcM4JXayQCTQ1bipK8jukmuXwC/ipd8IzBVAVyaLmXMuDX4LAk5mXA==
   dependencies:
     event-target-shim "^6.0.2"
     xhr "^2.6.0"


### PR DESCRIPTION
…eams.

To test:
* From terminal, run:
```sh
curl https://api.mux.com/video/v1/uploads \
  -X POST \
  -H "Content-Type: application/json" \
  -u MUX_TOKEN_ID:MUX_TOKEN_SECRET \
  -d '{ "new_asset_settings": { "playback_policy": ["public"] }, "cors_origin": "*" }'
```
(Replace `MUX_TOKEN_ID` & `MUX_TOKEN_SECRET` with a token id + token secret from your account)

* Grab the URL from the response JSON.
* Use URL in one of our demo app pages for `MuxUploader` or `mux-uploader` (e.g.) (https://elements-demo-nextjs-git-fork-cjpillsbury-feat-mux-u-e3d6bc-mux.vercel.app/MuxUploader)
