### PR TITLE
docs(mux-player): Document media-object-size and media-object-position css variables

### DIFF
--- a/packages/mux-player/REFERENCE.md
+++ b/packages/mux-player/REFERENCE.md
@@ -195,8 +195,15 @@ Other CSS variables:
 
 ```
 mux-player {
-  /* the controls backdrop color */
+  /* The controls backdrop color */
   --controls-backdrop-color: rgb(0 0 0 / 0%);
+
+  /*
+   * Controls how the media is sized and positioned inside of the <video> element
+   * Supports everything the standard CSS properties support
+   */
+  --media-object-size: cover;
+  --media-object-position: center;
 }
 ```
 


### PR DESCRIPTION
Mux Player supports `--media-object-size` and `--media-object-position` css variables but doesn't have them documented. This just adds them to the `REFERENCE.md` file.

See: #455 for the original feature PR.