### PR TITLE
fix: use new MC template syntax

### DIFF
--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@mux/mux-video": "0.12.1",
     "@mux/playback-core": "0.15.1",
-    "media-chrome": "0.18.0"
+    "media-chrome": "0.18.1"
   },
   "devDependencies": {
     "@mux/esbuilder": "0.1.0",

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -38,23 +38,6 @@ export type Tokens = {
 
 const streamTypeValues = Object.values(StreamTypes);
 
-const SMALL_BREAKPOINT = 700;
-const XSMALL_BREAKPOINT = 300;
-const MediaChromeSizes = {
-  LG: 'large',
-  SM: 'small',
-  XS: 'extra-small',
-};
-
-function getPlayerSize(el: Element) {
-  const muxPlayerRect = el.getBoundingClientRect();
-  return muxPlayerRect.width < XSMALL_BREAKPOINT
-    ? MediaChromeSizes.XS
-    : muxPlayerRect.width < SMALL_BREAKPOINT
-    ? MediaChromeSizes.SM
-    : MediaChromeSizes.LG;
-}
-
 const VideoAttributes = {
   SRC: 'src',
   POSTER: 'poster',
@@ -126,7 +109,6 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
     defaultShowRemainingTime: el.defaultShowRemainingTime,
     playbackRates: el.getAttribute(PlayerAttributes.PLAYBACK_RATES),
     customDomain: el.getAttribute(MuxVideoAttributes.CUSTOM_DOMAIN) ?? undefined,
-    playerSize: getPlayerSize(el.mediaController ?? el),
     title: el.getAttribute(PlayerAttributes.TITLE),
     ...state,
   };
@@ -150,7 +132,6 @@ class MuxPlayerElement extends VideoApiElement {
   #tokens = {};
   #userInactive = true;
   #hotkeys = new AttributeTokenList(this, 'hotkeys');
-  #resizeObserver?: ResizeObserver;
   #state: Partial<MuxTemplateProps> = {
     ...initialState,
     onCloseErrorDialog: () => this.#setState({ dialog: undefined, isDialogOpen: false }),
@@ -189,7 +170,7 @@ class MuxPlayerElement extends VideoApiElement {
     this.#isInit = true;
 
     // The next line triggers the first render of the template.
-    this.#setState({ playerSize: getPlayerSize(this) });
+    this.#setState();
 
     // Fixes a bug in React where mux-player's CE children were not upgraded yet.
     // These lines ensure the rendered mux-video and media-controller are upgraded,
@@ -265,16 +246,10 @@ class MuxPlayerElement extends VideoApiElement {
   }
 
   connectedCallback() {
-    this.#renderChrome();
     const muxVideo = this.shadowRoot?.querySelector('mux-video') as MuxVideoElement;
     if (muxVideo) {
       muxVideo.metadata = this.metadataFromAttrs;
     }
-    this.#initResizing();
-  }
-
-  disconnectedCallback() {
-    this.#deinitResizing();
   }
 
   #setState(newState: Record<string, any>) {
@@ -284,21 +259,6 @@ class MuxPlayerElement extends VideoApiElement {
 
   #render(props: Record<string, any> = {}) {
     render(template(getProps(this, { ...this.#state, ...props })), this.shadowRoot as Node);
-  }
-
-  #renderChrome() {
-    if (this.#state.playerSize != getPlayerSize(this.mediaController ?? this)) {
-      this.#setState({ playerSize: getPlayerSize(this.mediaController ?? this) });
-    }
-  }
-
-  #initResizing() {
-    this.#resizeObserver = new ResizeObserver(() => this.#renderChrome());
-    this.#resizeObserver.observe(this.mediaController ?? this);
-  }
-
-  #deinitResizing() {
-    this.#resizeObserver?.disconnect();
   }
 
   #setUpErrors() {

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -170,7 +170,7 @@ class MuxPlayerElement extends VideoApiElement {
     this.#isInit = true;
 
     // The next line triggers the first render of the template.
-    this.#setState();
+    this.#render();
 
     // Fixes a bug in React where mux-player's CE children were not upgraded yet.
     // These lines ensure the rendered mux-video and media-controller are upgraded,

--- a/packages/mux-player/src/media-theme-mux.html
+++ b/packages/mux-player/src/media-theme-mux.html
@@ -305,7 +305,9 @@
 
     <template partial="TitleDisplay">
       <template if="title">
-        <media-text-display part="top title display" class="title-display"> {{title}} </media-text-display>
+        <media-text-display part="top title display" class="title-display">
+          {{title}}
+        </media-text-display>
       </template>
     </template>
 
@@ -550,7 +552,7 @@
           </media-control-bar>
         </template>
 
-        <template if="targetLiveWindow == 0">
+        <template if="targetLiveWindow == null">
           <template if="title">
             <media-control-bar>{{>TitleDisplay}}</media-control-bar>
           </template>
@@ -639,7 +641,7 @@
 
       <template if="streamType == 'live'">
 
-        <template if="targetLiveWindow == 0">
+        <template if="targetLiveWindow == null">
 
           <template if="breakpointSm == null">
             <media-control-bar slot="top-chrome">

--- a/packages/mux-player/src/media-theme-mux.html
+++ b/packages/mux-player/src/media-theme-mux.html
@@ -580,7 +580,7 @@
             {{>PlayButton}}
             {{>MuteButton}}
             <div class="spacer"></div>
-            {{>CaptionsButton}}
+            {{>CaptionsMenuButton}}
             {{>FullscreenButton}}
           </media-control-bar>
         </template>
@@ -603,7 +603,7 @@
               {{>VolumeRange}}
               <div class="spacer"></div>
               {{>PlaybackRateButton}}
-              {{>CaptionsButton}}
+              {{>CaptionsMenuButton}}
               {{>AirplayButton}}
               {{>CastButton}}
               {{>PipButton}}
@@ -629,7 +629,7 @@
             {{>VolumeRange}}
             <div class="spacer"></div>
             {{>PlaybackRateButton}}
-            {{>CaptionsButton}}
+            {{>CaptionsMenuButton}}
             {{>AirplayButton}}
             {{>CastButton}}
             {{>PipButton}}
@@ -645,13 +645,13 @@
 
           <template if="breakpointSm == null">
             <media-control-bar slot="top-chrome">
-              {{>LiveButton section="top"}}
+              {{>LiveButton}}
             </media-control-bar>
             <media-control-bar>
               {{>PlayButton}}
               {{>MuteButton}}
               <div class="spacer"></div>
-              {{>CaptionsButton}}
+              {{>CaptionsMenuButton}}
               {{>FullscreenButton}}
             </media-control-bar>
           </template>
@@ -659,7 +659,7 @@
           <template if="breakpointSm">
             <template if="breakpointMd == null">
               <media-control-bar slot="top-chrome">
-                {{>LiveButton section="top"}}
+                {{>LiveButton}}
                 {{>TitleDisplay}}
               </media-control-bar>
               <div slot="centered-chrome" class="center-controls">
@@ -670,7 +670,7 @@
                 {{>MuteButton}}
                 {{>VolumeRange}}
                 <div class="spacer"></div>
-                {{>CaptionsButton}}
+                {{>CaptionsMenuButton}}
                 {{>AirplayButton}}
                 {{>CastButton}}
                 {{>PipButton}}
@@ -681,7 +681,7 @@
 
           <template if="breakpointMd">
             <media-control-bar slot="top-chrome">
-              {{>LiveButton section="top"}}
+              {{>LiveButton}}
               {{>TitleDisplay}}
             </media-control-bar>
             <div slot="centered-chrome" class="center-controls">
@@ -692,7 +692,7 @@
               {{>MuteButton}}
               {{>VolumeRange}}
               <div class="spacer"></div>
-              {{>CaptionsButton}}
+              {{>CaptionsMenuButton}}
               {{>AirplayButton}}
               {{>CastButton}}
               {{>PipButton}}
@@ -705,14 +705,14 @@
 
           <template if="breakpointSm == null">
             <media-control-bar slot="top-chrome">
-              {{>LiveButton section="top"}}
+              {{>LiveButton}}
             </media-control-bar>
             {{>TimeRange}}
             <media-control-bar>
               {{>PlayButton}}
               {{>MuteButton}}
               <div class="spacer"></div>
-              {{>CaptionsButton}}
+              {{>CaptionsMenuButton}}
               {{>FullscreenButton}}
             </media-control-bar>
           </template>
@@ -720,7 +720,7 @@
           <template if="breakpointSm">
             <template if="breakpointMd == null">
               <media-control-bar slot="top-chrome">
-                {{>LiveButton section="top"}}
+                {{>LiveButton}}
                 {{>TitleDisplay}}
               </media-control-bar>
               <div slot="centered-chrome" class="center-controls">
@@ -734,7 +734,7 @@
                 {{>MuteButton}}
                 {{>VolumeRange}}
                 <div class="spacer"></div>
-                {{>CaptionsButton}}
+                {{>CaptionsMenuButton}}
                 {{>AirplayButton}}
                 {{>CastButton}}
                 {{>PipButton}}
@@ -745,7 +745,7 @@
 
           <template if="breakpointMd">
             <media-control-bar slot="top-chrome">
-              {{>LiveButton section="top"}}
+              {{>LiveButton}}
               {{>TitleDisplay}}
             </media-control-bar>
             <div slot="centered-chrome" class="center-controls">
@@ -759,7 +759,7 @@
               {{>MuteButton}}
               {{>VolumeRange}}
               <div class="spacer"></div>
-              {{>CaptionsButton}}
+              {{>CaptionsMenuButton}}
               {{>AirplayButton}}
               {{>CastButton}}
               {{>PipButton}}

--- a/packages/mux-player/src/media-theme-mux.html
+++ b/packages/mux-player/src/media-theme-mux.html
@@ -1,3 +1,4 @@
+<!-- prettier-ignore -->
 <template id="media-theme-mux">
   <style>
     :host(:not([audio])) {
@@ -136,15 +137,15 @@
     }
 
     media-control-bar {
-      --media-control-padding: 9px 7px;
+      --media-control-padding: 4px 3px;
     }
 
-    .size-small media-control-bar {
+    [breakpoint-sm] media-control-bar {
       --media-control-padding: 9px 5px;
     }
 
-    .size-extra-small media-control-bar {
-      --media-control-padding: 4px 3px;
+    [breakpoint-md] media-control-bar {
+      --media-control-padding: 9px 7px;
     }
 
     media-control-bar :is([role='button'], [role='switch'], button) {
@@ -286,11 +287,11 @@
     }
   </style>
   <media-controller
+    breakpoints="sm:300 md:700"
     gestures-disabled="{{disabled}}"
     hotkeys="{{hotkeys}}"
     nohotkeys="{{nohotkeys}}"
     audio="{{audio}}"
-    class="size-{{playerSize}}"
     exportparts="layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer"
   >
     <slot name="media" slot="media"></slot>
@@ -508,138 +509,269 @@
       ></media-time-range>
     </template>
 
-    <template if="layout == 'audio on-demand'">
-      <template if="title">
-        <media-control-bar>{{>TitleDisplay}}</media-control-bar>
+    <template if="audio">
+
+      <template if="streamType == 'on-demand'">
+        <template if="title">
+          <media-control-bar>{{>TitleDisplay}}</media-control-bar>
+        </template>
+        <media-control-bar>
+          {{>PlayButton}}
+          {{>SeekBackwardButton}}
+          {{>SeekForwardButton}}
+          {{>TimeDisplay}}
+          {{>TimeRange}}
+          {{>MuteButton}}
+          {{>VolumeRange}}
+          {{>PlaybackRateButton}}
+          {{>AirplayButton}}
+          {{>CastButton}}
+        </media-control-bar>
       </template>
-      <media-control-bar>
-        {{>PlayButton}} {{>SeekBackwardButton}} {{>SeekForwardButton}} {{>TimeDisplay}} {{>TimeRange}} {{>MuteButton}}
-        {{>VolumeRange}} {{>PlaybackRateButton}} {{>AirplayButton}} {{>CastButton}}
-      </media-control-bar>
-    </template>
 
-    <template if="layout == 'audio dvr'">
-      <template if="title">
-        <media-control-bar>{{>TitleDisplay}}</media-control-bar>
+      <template if="streamType == 'live'">
+
+        <template if="targetLiveWindow > 0">
+          <template if="title">
+            <media-control-bar>{{>TitleDisplay}}</media-control-bar>
+          </template>
+          <media-control-bar>
+            {{>PlayButton}}
+            {{>LiveButton section="bottom"}}
+            {{>SeekBackwardButton}}
+            {{>SeekForwardButton}}
+            {{>TimeDisplay}}
+            {{>TimeRange}}
+            {{>MuteButton}}
+            {{>VolumeRange}}
+            {{>PlaybackRateButton}}
+            {{>AirplayButton}}
+            {{>CastButton}}
+          </media-control-bar>
+        </template>
+
+        <template if="targetLiveWindow == 0">
+          <template if="title">
+            <media-control-bar>{{>TitleDisplay}}</media-control-bar>
+          </template>
+          <media-control-bar>
+            {{>PlayButton}}
+            {{>LiveButton section="bottom"}}
+            {{>MuteButton}}
+            {{>VolumeRange}}
+            <div class="spacer"></div>
+            {{>AirplayButton}}
+            {{>CastButton}}
+          </media-control-bar>
+        </template>
+
       </template>
-      <media-control-bar>
-        {{>PlayButton}} {{> LiveButton section="bottom"}} {{>SeekBackwardButton}} {{>SeekForwardButton}}
-        {{>TimeDisplay}} {{>TimeRange}} {{>MuteButton}} {{>VolumeRange}} {{>PlaybackRateButton}} {{>AirplayButton}}
-        {{>CastButton}}
-      </media-control-bar>
     </template>
 
-    <template if="layout == 'audio live'">
-      <template if="title">
-        <media-control-bar>{{>TitleDisplay}}</media-control-bar>
+    <template if="audio == null">
+
+      <template if="streamType == 'on-demand'">
+
+        <template if="breakpointSm == null">
+          {{>TimeRange}}
+          <media-control-bar>
+            {{>PlayButton}}
+            {{>MuteButton}}
+            <div class="spacer"></div>
+            {{>CaptionsButton}}
+            {{>FullscreenButton}}
+          </media-control-bar>
+        </template>
+
+        <template if="breakpointSm">
+          <template if="breakpointMd == null">
+            <media-control-bar slot="top-chrome">
+              {{>TitleDisplay}}
+            </media-control-bar>
+            <div slot="centered-chrome" class="center-controls">
+              {{>SeekBackwardButton section="center"}}
+              {{>PlayButton section="center"}}
+              {{>SeekForwardButton section="center"}}
+            </div>
+            {{>TimeRange}}
+            <media-control-bar>
+              {{>PlayButton}}
+              {{>TimeDisplay}}
+              {{>MuteButton}}
+              {{>VolumeRange}}
+              <div class="spacer"></div>
+              {{>PlaybackRateButton}}
+              {{>CaptionsButton}}
+              {{>AirplayButton}}
+              {{>CastButton}}
+              {{>PipButton}}
+              {{>FullscreenButton}}
+            </media-control-bar>
+          </template>
+        </template>
+
+        <template if="breakpointMd">
+          <media-control-bar slot="top-chrome">
+            {{>TitleDisplay}}
+          </media-control-bar>
+          <div slot="centered-chrome" class="center-controls">
+            {{>PlayButton section="center"}}
+          </div>
+          {{>TimeRange}}
+          <media-control-bar>
+            {{>PlayButton}}
+            {{>SeekBackwardButton}}
+            {{>SeekForwardButton}}
+            {{>TimeDisplay}}
+            {{>MuteButton}}
+            {{>VolumeRange}}
+            <div class="spacer"></div>
+            {{>PlaybackRateButton}}
+            {{>CaptionsButton}}
+            {{>AirplayButton}}
+            {{>CastButton}}
+            {{>PipButton}}
+            {{>FullscreenButton}}
+          </media-control-bar>
+        </template>
+
       </template>
-      <media-control-bar>
-        {{>PlayButton}} {{> LiveButton section="bottom"}} {{>MuteButton}} {{>VolumeRange}}
-        <div class="spacer"></div>
-        {{>AirplayButton}} {{>CastButton}}
-      </media-control-bar>
-    </template>
 
-    <template if="layout == 'on-demand extra-small'">
-      {{>TimeRange}}
-      <media-control-bar>
-        {{>PlayButton}} {{>MuteButton}}
-        <div class="spacer"></div>
-        {{>CaptionsMenuButton}} {{>FullscreenButton}}
-      </media-control-bar>
-    </template>
+      <template if="streamType == 'live'">
 
-    <template if="layout == 'on-demand small'">
-      <media-control-bar slot="top-chrome"> {{>TitleDisplay}} </media-control-bar>
-      <div slot="centered-chrome" class="center-controls">
-        {{>SeekBackwardButton section="center"}} {{>PlayButton section="center"}} {{>SeekForwardButton
-        section="center"}}
-      </div>
-      {{>TimeRange}}
-      <media-control-bar>
-        {{>PlayButton}} {{>TimeDisplay}} {{>MuteButton}} {{>VolumeRange}}
-        <div class="spacer"></div>
-        {{>PlaybackRateButton}} {{>CaptionsMenuButton}} {{>AirplayButton}} {{>CastButton}} {{>PipButton}}
-        {{>FullscreenButton}}
-      </media-control-bar>
-    </template>
+        <template if="targetLiveWindow == 0">
 
-    <template if="layout == 'on-demand large'">
-      <media-control-bar slot="top-chrome"> {{>TitleDisplay}} </media-control-bar>
-      <div slot="centered-chrome" class="center-controls">{{>PlayButton section="center"}}</div>
-      {{>TimeRange}}
-      <media-control-bar>
-        {{>PlayButton}} {{>SeekBackwardButton}} {{>SeekForwardButton}} {{>TimeDisplay}} {{>MuteButton}} {{>VolumeRange}}
-        <div class="spacer"></div>
-        {{>PlaybackRateButton}} {{>CaptionsMenuButton}} {{>AirplayButton}} {{>CastButton}} {{>PipButton}}
-        {{>FullscreenButton}}
-      </media-control-bar>
-    </template>
+          <template if="breakpointSm == null">
+            <media-control-bar slot="top-chrome">
+              {{>LiveButton section="top"}}
+            </media-control-bar>
+            <media-control-bar>
+              {{>PlayButton}}
+              {{>MuteButton}}
+              <div class="spacer"></div>
+              {{>CaptionsButton}}
+              {{>FullscreenButton}}
+            </media-control-bar>
+          </template>
 
-    <template if="layout == 'live extra-small'">
-      <media-control-bar slot="top-chrome"> {{> LiveButton}} </media-control-bar>
-      <media-control-bar>
-        {{>PlayButton}} {{>MuteButton}}
-        <div class="spacer"></div>
-        {{>CaptionsMenuButton}} {{>FullscreenButton}}
-      </media-control-bar>
-    </template>
+          <template if="breakpointSm">
+            <template if="breakpointMd == null">
+              <media-control-bar slot="top-chrome">
+                {{>LiveButton section="top"}}
+                {{>TitleDisplay}}
+              </media-control-bar>
+              <div slot="centered-chrome" class="center-controls">
+                {{>PlayButton section="center"}}
+              </div>
+              <media-control-bar>
+                {{>PlayButton}}
+                {{>MuteButton}}
+                {{>VolumeRange}}
+                <div class="spacer"></div>
+                {{>CaptionsButton}}
+                {{>AirplayButton}}
+                {{>CastButton}}
+                {{>PipButton}}
+                {{>FullscreenButton}}
+              </media-control-bar>
+            </template>
+          </template>
 
-    <template if="layout == 'live small'">
-      <media-control-bar slot="top-chrome"> {{> LiveButton}} {{>TitleDisplay}} </media-control-bar>
-      <div slot="centered-chrome" class="center-controls">{{>PlayButton section="center"}}</div>
-      <media-control-bar>
-        {{>PlayButton}} {{>MuteButton}} {{>VolumeRange}}
-        <div class="spacer"></div>
-        {{>CaptionsMenuButton}} {{>AirplayButton}} {{>CastButton}} {{>PipButton}} {{>FullscreenButton}}
-      </media-control-bar>
-    </template>
+          <template if="breakpointMd">
+            <media-control-bar slot="top-chrome">
+              {{>LiveButton section="top"}}
+              {{>TitleDisplay}}
+            </media-control-bar>
+            <div slot="centered-chrome" class="center-controls">
+              {{>PlayButton section="center"}}
+            </div>
+            <media-control-bar>
+              {{>PlayButton}}
+              {{>MuteButton}}
+              {{>VolumeRange}}
+              <div class="spacer"></div>
+              {{>CaptionsButton}}
+              {{>AirplayButton}}
+              {{>CastButton}}
+              {{>PipButton}}
+              {{>FullscreenButton}}
+            </media-control-bar>
+          </template>
+        </template>
 
-    <template if="layout == 'live large'">
-      <media-control-bar slot="top-chrome"> {{> LiveButton}} {{>TitleDisplay}} </media-control-bar>
-      <div slot="centered-chrome" class="center-controls">{{>PlayButton section="center"}}</div>
-      <media-control-bar>
-        {{>PlayButton}} {{>MuteButton}} {{>VolumeRange}}
-        <div class="spacer"></div>
-        {{>CaptionsMenuButton}} {{>AirplayButton}} {{>CastButton}} {{>PipButton}} {{>FullscreenButton}}
-      </media-control-bar>
-    </template>
+        <template if="targetLiveWindow > 0">
 
-    <template if="layout == 'dvr extra-small'">
-      <media-control-bar slot="top-chrome"> {{> LiveButton}} </media-control-bar>
-      {{>TimeRange}}
-      <media-control-bar>
-        {{>PlayButton}} {{>MuteButton}}
-        <div class="spacer"></div>
-        {{>CaptionsMenuButton}} {{>FullscreenButton}}
-      </media-control-bar>
-    </template>
+          <template if="breakpointSm == null">
+            <media-control-bar slot="top-chrome">
+              {{>LiveButton section="top"}}
+            </media-control-bar>
+            {{>TimeRange}}
+            <media-control-bar>
+              {{>PlayButton}}
+              {{>MuteButton}}
+              <div class="spacer"></div>
+              {{>CaptionsButton}}
+              {{>FullscreenButton}}
+            </media-control-bar>
+          </template>
 
-    <template if="layout == 'dvr small'">
-      <media-control-bar slot="top-chrome"> {{> LiveButton}} {{>TitleDisplay}} </media-control-bar>
-      <div slot="centered-chrome" class="center-controls">
-        {{>SeekBackwardButton section="center"}} {{>PlayButton section="center"}} {{>SeekForwardButton
-        section="center"}}
-      </div>
-      {{>TimeRange}}
-      <media-control-bar>
-        {{>PlayButton}} {{>MuteButton}} {{>VolumeRange}}
-        <div class="spacer"></div>
-        {{>CaptionsMenuButton}} {{>AirplayButton}} {{>CastButton}} {{>PipButton}} {{>FullscreenButton}}
-      </media-control-bar>
-    </template>
+          <template if="breakpointSm">
+            <template if="breakpointMd == null">
+              <media-control-bar slot="top-chrome">
+                {{>LiveButton section="top"}}
+                {{>TitleDisplay}}
+              </media-control-bar>
+              <div slot="centered-chrome" class="center-controls">
+                {{>SeekBackwardButton section="center"}}
+                {{>PlayButton section="center"}}
+                {{>SeekForwardButton section="center"}}
+              </div>
+              {{>TimeRange}}
+              <media-control-bar>
+                {{>PlayButton}}
+                {{>MuteButton}}
+                {{>VolumeRange}}
+                <div class="spacer"></div>
+                {{>CaptionsButton}}
+                {{>AirplayButton}}
+                {{>CastButton}}
+                {{>PipButton}}
+                {{>FullscreenButton}}
+              </media-control-bar>
+            </template>
+          </template>
 
-    <template if="layout == 'dvr large'">
-      <media-control-bar slot="top-chrome"> {{> LiveButton}} {{>TitleDisplay}} </media-control-bar>
-      <div slot="centered-chrome" class="center-controls">{{>PlayButton section="center"}}</div>
-      {{>TimeRange}}
-      <media-control-bar>
-        {{>PlayButton}} {{>SeekBackwardButton}} {{>SeekForwardButton}} {{>MuteButton}} {{>VolumeRange}}
-        <div class="spacer"></div>
-        {{>CaptionsMenuButton}} {{>AirplayButton}} {{>CastButton}} {{>PipButton}} {{>FullscreenButton}}
-      </media-control-bar>
+          <template if="breakpointMd">
+            <media-control-bar slot="top-chrome">
+              {{>LiveButton section="top"}}
+              {{>TitleDisplay}}
+            </media-control-bar>
+            <div slot="centered-chrome" class="center-controls">
+              {{>PlayButton section="center"}}
+            </div>
+            {{>TimeRange}}
+            <media-control-bar>
+              {{>PlayButton}}
+              {{>SeekBackwardButton}}
+              {{>SeekForwardButton}}
+              {{>MuteButton}}
+              {{>VolumeRange}}
+              <div class="spacer"></div>
+              {{>CaptionsButton}}
+              {{>AirplayButton}}
+              {{>CastButton}}
+              {{>PipButton}}
+              {{>FullscreenButton}}
+            </media-control-bar>
+          </template>
+
+        </template>
+
+      </template>
+
     </template>
 
     <slot></slot>
+
   </media-controller>
 </template>

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -41,9 +41,9 @@ const getHotKeys = (props: MuxTemplateProps) => {
 export const content = (props: MuxTemplateProps) => html`
   <media-theme
     template="${props.theme ?? muxTemplate.content.children[0]}"
-    class="${props.secondaryColor ? ' two-tone' : ''}"
+    class="${props.secondaryColor ? 'two-tone' : false}"
     stream-type="${isLiveOrDVR(props) ? 'live' : 'on-demand'}"
-    target-live-window="${isDVR(props) ? 1 : 0}"
+    target-live-window="${isDVR(props) ? 1 : false}"
     hotkeys="${getHotKeys(props) || false}"
     nohotkeys="${props.noHotKeys || !props.hasSrc || props.isDialogOpen || false}"
     disabled="${!props.hasSrc || props.isDialogOpen}"

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -26,18 +26,9 @@ export const template = (props: MuxTemplateProps) => html`
 
 const isLive = (props: MuxTemplateProps) => [StreamTypes.LIVE, StreamTypes.LL_LIVE].includes(props.streamType as any);
 
-const isLiveOrDVR = (props: MuxTemplateProps) =>
-  [StreamTypes.LIVE, StreamTypes.LL_LIVE, StreamTypes.DVR, StreamTypes.LL_DVR].includes(props.streamType as any);
+const isDVR = (props: MuxTemplateProps) => [StreamTypes.DVR, StreamTypes.LL_DVR].includes(props.streamType as any);
 
-const getLayout = (props: MuxTemplateProps) => {
-  let layout = '';
-  if (props.audio) layout += 'audio ';
-  if (isLive(props)) layout += 'live';
-  else if (isLiveOrDVR(props)) layout += 'dvr';
-  else layout += props.streamType || 'on-demand';
-  if (!props.audio && props.playerSize) layout += ` ${props.playerSize}`;
-  return layout;
-};
+const isLiveOrDVR = (props: MuxTemplateProps) => isLive(props) || isDVR(props);
 
 const getHotKeys = (props: MuxTemplateProps) => {
   let hotKeys = props.hotKeys ? `${props.hotKeys}` : '';
@@ -50,9 +41,9 @@ const getHotKeys = (props: MuxTemplateProps) => {
 export const content = (props: MuxTemplateProps) => html`
   <media-theme
     template="${props.theme ?? muxTemplate.content.children[0]}"
-    class="size-${props.playerSize}${props.secondaryColor ? ' two-tone' : ''}"
-    player-size="${props.playerSize ?? false}"
-    layout="${getLayout(props)}"
+    class="${props.secondaryColor ? ' two-tone' : ''}"
+    stream-type="${isLiveOrDVR(props) ? 'live' : 'on-demand'}"
+    target-live-window="${isDVR(props) ? 1 : 0}"
     hotkeys="${getHotKeys(props) || false}"
     nohotkeys="${props.noHotKeys || !props.hasSrc || props.isDialogOpen || false}"
     disabled="${!props.hasSrc || props.isDialogOpen}"

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -793,7 +793,6 @@ describe('<mux-player> seek to live behaviors', function () {
       preload="auto"
     ></mux-player>`);
 
-    const seekToLiveEl = playerEl.theme.shadowRoot.querySelector('media-live-button');
     // NOTE: Need try catch due to bug in play+autoplay behavior (CJP)
     try {
       await playerEl.play();
@@ -802,6 +801,7 @@ describe('<mux-player> seek to live behaviors', function () {
     await waitUntil(() => playerEl.inLiveWindow, 'playback did not start inLiveWindow');
     playerEl.pause();
     await waitUntil(() => !playerEl.inLiveWindow, 'still inLiveWindow after long pause', { timeout: 11000 });
+    const seekToLiveEl = playerEl.theme.shadowRoot.querySelector('media-live-button');
     seekToLiveEl.click();
     await waitUntil(() => playerEl.inLiveWindow, 'clicking seek to live did not seek to live window');
   });

--- a/packages/mux-player/test/template.test.js
+++ b/packages/mux-player/test/template.test.js
@@ -14,7 +14,7 @@ describe('<mux-player> template render', () => {
     assert.equal(
       normalizeAttributes(minify(div.innerHTML)),
       normalizeAttributes(
-        `<media-theme class="size-" default-showing-captions="" disabled="" nohotkeys="" layout="on-demand" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" exportparts="video"></mux-video><mxp-dialog no-auto-hide=""><p></p></mxp-dialog></media-theme>`
+        `<media-theme default-showing-captions="" disabled="" nohotkeys="" stream-type="on-demand" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" exportparts="video"></mux-video><mxp-dialog no-auto-hide=""><p></p></mxp-dialog></media-theme>`
       )
     );
   });
@@ -23,7 +23,6 @@ describe('<mux-player> template render', () => {
     render(
       content({
         inLiveWindow: false,
-        playerSize: 'extra-small',
         streamType: 'live',
         isDialogOpen: true,
         dialog: {
@@ -36,7 +35,7 @@ describe('<mux-player> template render', () => {
     assert.equal(
       normalizeAttributes(minify(div.innerHTML)),
       normalizeAttributes(
-        `<media-theme hotkeys=" noarrowleft noarrowright" class="size-extra-small" layout="live extra-small" player-size="extra-small" default-showing-captions="" disabled="" nohotkeys="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" stream-type="live" cast-stream-type="live" exportparts="video"></mux-video><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme>`
+        `<media-theme hotkeys=" noarrowleft noarrowright" stream-type="live" default-showing-captions="" disabled="" nohotkeys="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" stream-type="live" cast-stream-type="live" exportparts="video"></mux-video><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme>`
       )
     );
   });
@@ -44,7 +43,6 @@ describe('<mux-player> template render', () => {
   it('template VodChromeLarge with captions', function () {
     render(
       content({
-        playerSize: 'large',
         streamType: 'on-demand',
         hasCaptions: true,
       }),
@@ -54,7 +52,7 @@ describe('<mux-player> template render', () => {
     assert.equal(
       normalizeAttributes(minify(div.innerHTML)),
       normalizeAttributes(
-        `<media-theme class="size-large" default-showing-captions="" disabled="" nohotkeys="" layout="on-demand large" player-size="large" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" stream-type="on-demand" exportparts="video"></mux-video><mxp-dialog no-auto-hide=""><p></p></mxp-dialog></media-theme>`
+        `<media-theme default-showing-captions="" disabled="" nohotkeys="" stream-type="on-demand" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" stream-type="on-demand" exportparts="video"></mux-video><mxp-dialog no-auto-hide=""><p></p></mxp-dialog></media-theme>`
       )
     );
   });
@@ -62,7 +60,6 @@ describe('<mux-player> template render', () => {
   it('template VodChromeLarge without captions', function () {
     render(
       content({
-        playerSize: 'large',
         streamType: 'on-demand',
         hasCaptions: false,
         isDialogOpen: true,
@@ -76,7 +73,7 @@ describe('<mux-player> template render', () => {
     assert.equal(
       normalizeAttributes(minify(div.innerHTML)),
       normalizeAttributes(
-        `<media-theme class="size-large" layout="on-demand large" player-size="large" default-showing-captions="" disabled="" nohotkeys="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" stream-type="on-demand" exportparts="video"></mux-video><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme>`
+        `<media-theme stream-type="on-demand" default-showing-captions="" disabled="" nohotkeys="" exportparts="${exportParts}"><mux-video slot="media" crossorigin="" playsinline="" stream-type="on-demand" exportparts="video"></mux-video><mxp-dialog no-auto-hide="" open=""><h3>Errr</h3><p></p></mxp-dialog></media-theme>`
       )
     );
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10576,10 +10576,10 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-media-chrome@0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-0.18.0.tgz#7824fbeb3694a683beac6e9e448bfcb07df4df74"
-  integrity sha512-lru0kFpSKe7F7Ow7XptejIS6Fmc9WJnHZRckrVKNHzf2MoCVMZiFt4UCn3zEmC3IxLJNeOAavSqYpwqbdaenGA==
+media-chrome@0.18.1:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-0.18.1.tgz#ae50c924e08176450d867eb97c4de499312bab57"
+  integrity sha512-lnElqsujJzeDCt/YkhQyVaeAO4xIHB6bhTPClALRkaei+1qt3tbIQeVDZ/cCw8TjNs9b44JpFtJsZq91/TEDhA==
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
requires https://github.com/muxinc/media-chrome/pull/448

requires a Media Chrome upgrade that makes the theme attributes (if there are any) overwrite the ones supplied by the media controller.

`stream-type` is an example of this, we still want to be able to override this and also set it before it is computed in Media Chrome.

`audio` will have to be removed as a supplied param by media-controller because we set this ourselves, that was my bad.
https://github.com/muxinc/media-chrome/blob/main/src/js/media-theme-element.js#L12

