### PR TITLE
feat: add way to set and render MC themes

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxPlayerTheme.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayerTheme.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import Head from 'next/head';
+import { useRef, useState } from "react";
+import MuxPlayer, { MuxPlayerProps } from "@mux/mux-player-react";
+import "media-chrome/dist/themes/media-theme-youtube";
+
+const INITIAL_AUTOPLAY = false;
+const INITIAL_MUTED = false;
+
+function MuxPlayerPage() {
+  const mediaElRef = useRef(null);
+  const [autoplay, setAutoplay] = useState<"muted" | boolean>(INITIAL_AUTOPLAY);
+  const [muted, setMuted] = useState(INITIAL_MUTED);
+  const [paused, setPaused] = useState<boolean | undefined>(true);
+
+  return (
+    <>
+      <Head>
+        <title>&lt;MuxPlayer/&gt; (theme) Demo</title>
+      </Head>
+
+      <MuxPlayer
+        ref={mediaElRef}
+        playbackId="23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I"
+        theme="youtube"
+        // metadata={{
+        //   video_id: "video-id-12345",
+        //   video_title: "Mad Max: Fury Road Trailer",
+        //   viewer_user_id: "user-id-6789",
+        // }}
+        // envKey="mux-data-env-key"
+        streamType="on-demand"
+        controls
+        autoPlay={autoplay}
+        muted={muted}
+        onPlay={() => {
+          setPaused(false);
+        }}
+        onPause={() => {
+          setPaused(true);
+        }}
+      />
+
+      <br/>
+      <Link href="/"><a>Browse Elements</a></Link>
+    </>
+  );
+}
+
+export default MuxPlayerPage;

--- a/examples/nextjs-with-typescript/pages/MuxPlayerTheme.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayerTheme.tsx
@@ -30,7 +30,6 @@ function MuxPlayerPage() {
         // }}
         // envKey="mux-data-env-key"
         streamType="on-demand"
-        controls
         autoPlay={autoplay}
         muted={muted}
         onPlay={() => {

--- a/examples/nextjs-with-typescript/pages/index.tsx
+++ b/examples/nextjs-with-typescript/pages/index.tsx
@@ -7,6 +7,7 @@ function HomePage() {
         <li><Link href="/MuxVideo"><a className="video">&lt;MuxVideo&gt;</a></Link></li>
         <li><Link href="/MuxAudio"><a className="audio">&lt;MuxAudio&gt;</a></Link></li>
         <li><Link href="/MuxPlayer"><a className="player">&lt;MuxPlayer&gt;</a></Link></li>
+        <li><Link href="/MuxPlayerTheme"><a className="player">&lt;MuxPlayer&gt;<br/>(theme)</a></Link></li>
         <li><Link href="/MuxPlayerLazy"><a className="player">&lt;MuxPlayer&gt;<br/>(lazy)</a></Link></li>
         <li><Link href="/MuxPlayerDynamic"><a className="player">&lt;MuxPlayer&gt;<br/>(Next.js dynamic)</a></Link></li>
         <li><Link href="/MuxPlayerLazyDynamic"><a className="player">&lt;MuxPlayer&gt;<br/>(lazy + dynamic)</a></Link></li>

--- a/examples/vanilla-ts-esm/public/index.html
+++ b/examples/vanilla-ts-esm/public/index.html
@@ -27,6 +27,7 @@
         <li><a href="./mux-player.html" class="player">&lt;mux-player&gt;</a></li>
         <li><a href="./mux-player-audio.html" class="player">&lt;mux-player audio&gt;</a></li>
         <li><a href="./mux-player-cuepoints.html" class="player">&lt;mux-player&gt; (cuePoints)</a></li>
+        <li><a href="./mux-player-theme.html" class="player">&lt;mux-player&gt; (theme)</a></li>
         <li><a href="./mux-uploader-simple.html" class="uploader">&lt;mux-uploader&gt;</a></li>
         <li><a href="./mux-uploader-full.html" class="uploader">&lt;mux-uploader&gt; (full-page)</a></li>
       </ul>

--- a/examples/vanilla-ts-esm/public/mux-player-theme.html
+++ b/examples/vanilla-ts-esm/public/mux-player-theme.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <title>&lt;mux-player&gt; example</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+    <link rel="stylesheet" href="./styles.css">
+    <script
+      defer
+      src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
+    ></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome@0.18.1/dist/themes/media-theme-youtube.js"></script>
+    <script type="module" src="./dist/mux-player.js"></script>
+    <style>
+      mux-player {
+        display: block;
+        width: 100%;
+        margin: 1rem 0 2rem;
+        background-color: #000;
+        line-height: 0;
+      }
+
+      mux-player:not([audio]) {
+        aspect-ratio: 16 / 9;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="left-header">
+        <a class="mux-logo" href="https://www.mux.com/player" target="_blank">
+          <img width="81" height="26" src="./images/mux-logo@2x.webp" alt="Mux logo" decoding="async">
+        </a>
+        <h1><a href="/">Elements</a></h1>
+      </div>
+      <div class="right-header">
+        <a class="github-logo" href="https://github.com/muxinc/elements" target="_blank">
+          <img width="32" height="32" src="./images/github-logo.svg" alt="Github logo">
+        </a>
+      </div>
+    </header>
+
+    <mux-player
+      theme="youtube"
+      stream-type="on-demand"
+      playback-id="VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA"
+      start-time="1"
+    ></mux-player>
+
+    <a href="../">Browse Elements</a>
+  </body>
+</html>

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -77,6 +77,7 @@ export type MuxPlayerProps = {
   thumbnailTime?: number;
   title?: string;
   tokens?: Tokens;
+  theme?: string;
   onAbort?: GenericEventListener<MuxPlayerElementEventMap['abort']>;
   onCanPlay?: GenericEventListener<MuxPlayerElementEventMap['canplay']>;
   onCanPlayThrough?: GenericEventListener<MuxPlayerElementEventMap['canplaythrough']>;

--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@mux/mux-video": "0.14.0",
     "@mux/playback-core": "0.17.0",
-    "media-chrome": "0.18.2"
+    "media-chrome": "0.18.4"
   },
   "devDependencies": {
     "@mux/esbuilder": "0.1.0",

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -122,7 +122,7 @@ function getThemeTemplate(el: MuxPlayerElement) {
   let themeName = el.getAttribute('theme');
   if (themeName) {
     // @ts-ignore
-    const templateElement = el.getRootNode()?.getElementById(themeName);
+    const templateElement = el.getRootNode()?.getElementById?.(themeName);
     if (templateElement) return templateElement;
 
     if (!themeName.startsWith('media-theme-')) {

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -224,21 +224,20 @@ class MuxPlayerElement extends VideoApiElement {
 
   #setupCSSProperties() {
     // registerProperty will throw if the prop has already been registered
-    // and there's currently no way to check ahead of time
+    // and there's currently no way to check ahead of time.
+    // initialValue's are defined in the theme
     try {
       // @ts-ignore
       window?.CSS?.registerProperty({
         name: '--primary-color',
         syntax: '<color>',
         inherits: true,
-        initialValue: 'white',
       });
       // @ts-ignore
       window?.CSS?.registerProperty({
         name: '--secondary-color',
         syntax: '<color>',
         inherits: true,
-        initialValue: 'transparent',
       });
     } catch (e) {}
   }
@@ -809,13 +808,14 @@ class MuxPlayerElement extends VideoApiElement {
    * Get the primary color used by the player.
    */
   get primaryColor() {
-    const color = this.getAttribute(PlayerAttributes.PRIMARY_COLOR);
-    if (color) return color;
+    let color = this.getAttribute(PlayerAttributes.PRIMARY_COLOR);
+    if (color != null) return color;
 
     // Fallback to computed style if no attribute is set, causes layout.
     // https://gist.github.com/paulirish/5d52fb081b3570c81e3a
     if (this.mediaTheme) {
-      return globalThis.getComputedStyle(this.mediaTheme).getPropertyValue('--primary-color');
+      color = globalThis.getComputedStyle(this.mediaTheme)?.getPropertyValue('--_primary-color')?.trim();
+      if (color) return color;
     }
   }
 
@@ -830,13 +830,14 @@ class MuxPlayerElement extends VideoApiElement {
    * Get the secondary color used by the player.
    */
   get secondaryColor() {
-    const color = this.getAttribute(PlayerAttributes.SECONDARY_COLOR);
-    if (color) return color;
+    let color = this.getAttribute(PlayerAttributes.SECONDARY_COLOR);
+    if (color != null) return color;
 
     // Fallback to computed style if no attribute is set, causes layout.
     // https://gist.github.com/paulirish/5d52fb081b3570c81e3a
     if (this.mediaTheme) {
-      return globalThis.getComputedStyle(this.mediaTheme).getPropertyValue('--secondary-color');
+      color = globalThis.getComputedStyle(this.mediaTheme)?.getPropertyValue('--_secondary-color')?.trim();
+      if (color) return color;
     }
   }
 

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -119,11 +119,15 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
 }
 
 function getThemeTemplate(el: MuxPlayerElement) {
-  const themeName = el.getAttribute('theme');
+  let themeName = el.getAttribute('theme');
   if (themeName) {
     // @ts-ignore
     const templateElement = el.getRootNode()?.getElementById(themeName);
     if (templateElement) return templateElement;
+
+    if (!themeName.startsWith('media-theme-')) {
+      themeName = `media-theme-${themeName}`;
+    }
 
     const ThemeElement = globalThis.customElements.get(themeName) as MediaThemeElement | undefined;
     if (ThemeElement?.template) return ThemeElement.template;

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -2,6 +2,7 @@ import { globalThis, document } from 'shared-polyfills';
 // @ts-ignore
 import { MediaController } from 'media-chrome';
 import 'media-chrome/dist/experimental/media-captions-menu-button.js';
+import { MediaThemeElement } from 'media-chrome/dist/media-theme-element.js';
 import MuxVideoElement, { MediaError, Attributes as MuxVideoAttributes } from '@mux/mux-video';
 import {
   ValueOf,
@@ -74,7 +75,7 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
     storyboard: el.storyboard,
     storyboardSrc: el.getAttribute(PlayerAttributes.STORYBOARD_SRC),
     placeholder: el.getAttribute('placeholder'),
-    theme: el.getAttribute('theme'),
+    themeTemplate: getThemeTemplate(el),
     thumbnailTime: !el.tokens.thumbnail && el.thumbnailTime,
     autoplay: el.autoplay,
     crossOrigin: el.crossOrigin,
@@ -115,6 +116,18 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
   };
 
   return props;
+}
+
+function getThemeTemplate(el: MuxPlayerElement) {
+  const themeName = el.getAttribute('theme');
+  if (themeName) {
+    // @ts-ignore
+    const templateElement = el.getRootNode()?.getElementById(themeName);
+    if (templateElement) return templateElement;
+
+    const ThemeElement = globalThis.customElements.get(themeName) as MediaThemeElement | undefined;
+    if (ThemeElement?.template) return ThemeElement.template;
+  }
 }
 
 const MuxVideoAttributeNames = Object.values(MuxVideoAttributes);

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -194,8 +194,8 @@ class MuxPlayerElement extends VideoApiElement {
     // These lines ensure the rendered mux-video and media-controller are upgraded,
     // even before they are connected to the main document.
     try {
-      customElements.upgrade(this.theme as Node);
-      if (!(this.theme instanceof globalThis.HTMLElement)) throw '';
+      customElements.upgrade(this.mediaTheme as Node);
+      if (!(this.mediaTheme instanceof globalThis.HTMLElement)) throw '';
     } catch (error) {
       logger.error(`<media-theme> failed to upgrade!`);
     }
@@ -243,12 +243,12 @@ class MuxPlayerElement extends VideoApiElement {
     } catch (e) {}
   }
 
-  get theme(): Element | null | undefined {
+  get mediaTheme(): Element | null | undefined {
     return this.shadowRoot?.querySelector('media-theme');
   }
 
   get mediaController(): MediaController | null | undefined {
-    return this.theme?.shadowRoot?.querySelector('media-controller');
+    return this.mediaTheme?.shadowRoot?.querySelector('media-controller');
   }
 
   get metadataFromAttrs() {

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -809,7 +809,14 @@ class MuxPlayerElement extends VideoApiElement {
    * Get the primary color used by the player.
    */
   get primaryColor() {
-    return this.getAttribute(PlayerAttributes.PRIMARY_COLOR) ?? undefined;
+    const color = this.getAttribute(PlayerAttributes.PRIMARY_COLOR);
+    if (color) return color;
+
+    // Fallback to computed style if no attribute is set, causes layout.
+    // https://gist.github.com/paulirish/5d52fb081b3570c81e3a
+    if (this.mediaTheme) {
+      return globalThis.getComputedStyle(this.mediaTheme).getPropertyValue('--primary-color');
+    }
   }
 
   /**
@@ -823,7 +830,14 @@ class MuxPlayerElement extends VideoApiElement {
    * Get the secondary color used by the player.
    */
   get secondaryColor() {
-    return this.getAttribute(PlayerAttributes.SECONDARY_COLOR) ?? 'rgb(0 0 0 / .75)';
+    const color = this.getAttribute(PlayerAttributes.SECONDARY_COLOR);
+    if (color) return color;
+
+    // Fallback to computed style if no attribute is set, causes layout.
+    // https://gist.github.com/paulirish/5d52fb081b3570c81e3a
+    if (this.mediaTheme) {
+      return globalThis.getComputedStyle(this.mediaTheme).getPropertyValue('--secondary-color');
+    }
   }
 
   /**

--- a/packages/mux-player/src/media-theme-mux.html
+++ b/packages/mux-player/src/media-theme-mux.html
@@ -2,7 +2,7 @@
 <template id="media-theme-mux">
   <style>
     :host {
-      --_primary-color: var(--primary-color, #fff);
+      --_primary-color: var(--primary-color, white);
       --_secondary-color: var(--secondary-color, rgb(0 0 0 / .75));
 
       --media-icon-color: var(--_primary-color);
@@ -11,38 +11,25 @@
       --media-control-background: var(--_secondary-color);
       --media-control-hover-background: var(--_secondary-color);
       --media-time-buffered-color: rgba(255, 255, 255, 0.4);
-      --media-range-track-background: rgba(255, 255, 255, 0.5);
-      --media-range-track-border-radius: 3px;
-      --media-preview-thumbnail-border: 1px solid #fff;
-      --media-preview-thumbnail-border-radius: 2px;
-      --media-preview-time-margin: 5px 0 2px;
+      --media-range-track-background:
+        linear-gradient(rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.5)),
+        linear-gradient(rgba(20, 20, 30, 0.7), rgba(20, 20, 30, 0.7));
+      --media-preview-thumbnail-border: 0;
+      --media-preview-thumbnail-border-radius: 2px 2px 0 0;
+      --media-preview-time-border-radius: 0 0 2px 2px;
+      --media-preview-time-margin: 0 0 8px;
+      --media-preview-time-text-shadow: none;
+
       color: var(--_primary-color);
       display: inline-block;
       width: 100%;
       height: 100%;
     }
 
-    :host(:not([audio])) {
-      --secondary-color: transparent;
-    }
-
-    :host(.two-tone:not([audio])) {
-      --mux-time-range-padding: 0px; /* px is needed in calc() */
-      --media-preview-thumbnail-border: 0;
-      --media-preview-thumbnail-border-radius: 2px 2px 0 0;
-      --media-preview-time-border-radius: 0 0 2px 2px;
-      --media-preview-time-margin: 0 0 8px;
-      --media-preview-time-text-shadow: none;
-    }
-
     :host([audio]) {
       --media-preview-time-border-radius: 3px;
       --media-preview-time-margin: 0 0 5px;
       --media-preview-time-text-shadow: none;
-    }
-
-    :host(.two-tone:not([audio])) media-time-range {
-      --media-range-track-border-radius: 0;
     }
 
     :host([audio]) ::slotted([slot='media']) {
@@ -119,21 +106,11 @@
     }
 
     :host(:not([audio])) media-time-range {
-      --media-range-padding-left: var(--mux-time-range-padding, 10px);
-      --media-range-padding-right: var(--mux-time-range-padding, 10px);
       --media-range-padding: 0;
+      background: transparent;
       z-index: 10;
       height: 10px;
       bottom: -3px;
-      background: linear-gradient(
-        180deg,
-        transparent,
-        transparent 3px,
-        var(--media-control-background, rgba(20, 20, 30, 0.7)) 3px,
-        var(--media-control-background, rgba(20, 20, 30, 0.7)) 7px,
-        transparent 7px,
-        transparent
-      );
       width: 100%;
     }
 

--- a/packages/mux-player/src/media-theme-mux.html
+++ b/packages/mux-player/src/media-theme-mux.html
@@ -1,18 +1,15 @@
 <!-- prettier-ignore -->
 <template id="media-theme-mux">
   <style>
-    :host(:not([audio])) {
-      --secondary-color: transparent;
-    }
-
     :host {
       --_primary-color: var(--primary-color, #fff);
+      --_secondary-color: var(--secondary-color, rgb(0 0 0 / .75));
 
       --media-icon-color: var(--_primary-color);
       --media-range-thumb-background: var(--_primary-color);
       --media-range-bar-color: var(--_primary-color);
-      --media-control-background: var(--secondary-color);
-      --media-control-hover-background: var(--secondary-color);
+      --media-control-background: var(--_secondary-color);
+      --media-control-hover-background: var(--_secondary-color);
       --media-time-buffered-color: rgba(255, 255, 255, 0.4);
       --media-range-track-background: rgba(255, 255, 255, 0.5);
       --media-range-track-border-radius: 3px;
@@ -23,6 +20,10 @@
       display: inline-block;
       width: 100%;
       height: 100%;
+    }
+
+    :host(:not([audio])) {
+      --secondary-color: transparent;
     }
 
     :host(.two-tone:not([audio])) {
@@ -80,7 +81,7 @@
     }
 
     media-captions-menu-button {
-      --media-listbox-background: var(--secondary-color);
+      --media-listbox-background: var(--_secondary-color);
       --media-listbox-selected-background: rgba(255, 255, 255, 0.28);
       --media-listbox-hover-background: none;
       --media-listbox-hover-outline: white solid 1px;

--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -14,6 +14,11 @@ a {
   text-decoration: underline;
 }
 
+media-theme {
+  width: 100%;
+  height: 100%;
+}
+
 ::part(top),
 [part~='top'] {
   --media-controls: var(--controls, var(--top-controls));

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -41,7 +41,6 @@ const getHotKeys = (props: MuxTemplateProps) => {
 export const content = (props: MuxTemplateProps) => html`
   <media-theme
     template="${props.themeTemplate ?? muxTemplate.content.children[0]}"
-    class="${props.secondaryColor ? 'two-tone' : false}"
     stream-type="${isLiveOrDVR(props) ? 'live' : 'on-demand'}"
     target-live-window="${isDVR(props) ? 1 : false}"
     hotkeys="${getHotKeys(props) || false}"

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -40,7 +40,7 @@ const getHotKeys = (props: MuxTemplateProps) => {
 
 export const content = (props: MuxTemplateProps) => html`
   <media-theme
-    template="${props.theme ?? muxTemplate.content.children[0]}"
+    template="${props.themeTemplate ?? muxTemplate.content.children[0]}"
     class="${props.secondaryColor ? 'two-tone' : false}"
     stream-type="${isLiveOrDVR(props) ? 'live' : 'on-demand'}"
     target-live-window="${isDVR(props) ? 1 : false}"

--- a/packages/mux-player/src/types.d.ts
+++ b/packages/mux-player/src/types.d.ts
@@ -11,7 +11,7 @@ export type MuxPlayerProps = Partial<MuxVideoElement> & {
 export type MuxTemplateProps = Partial<MuxPlayerProps> & {
   hasSrc: boolean;
   audio: boolean;
-  theme?: string;
+  themeTemplate?: string | HTMLTemplateElement;
   playerSize: string;
   showLoading: boolean;
   thumbnailTime: number;

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -192,7 +192,7 @@ describe('<mux-player>', () => {
     const player = await fixture(`<mux-player
       poster="https://image.mux.com/xLGf7y8cRquv7QXoDB02zEe6centwKfVmUOiPSY02JhCE/thumbnail.jpg?time=0"
     ></mux-player>`);
-    const mediaPosterImage = player.theme.shadowRoot.querySelector('media-poster-image');
+    const mediaPosterImage = player.mediaTheme.shadowRoot.querySelector('media-poster-image');
 
     assert.equal(
       player.poster,
@@ -227,7 +227,7 @@ describe('<mux-player>', () => {
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
       stream-type="on-demand"
     ></mux-player>`);
-    const mediaPosterImage = player.theme.shadowRoot.querySelector('media-poster-image');
+    const mediaPosterImage = player.mediaTheme.shadowRoot.querySelector('media-poster-image');
 
     assert.equal(
       player.poster,
@@ -424,7 +424,7 @@ describe('<mux-player>', () => {
     ></mux-player>`);
 
     const muxVideo = player.media;
-    const mediaPosterImage = player.theme.shadowRoot.querySelector('media-poster-image');
+    const mediaPosterImage = player.mediaTheme.shadowRoot.querySelector('media-poster-image');
     const storyboardTrack = muxVideo.shadowRoot.querySelector("track[label='thumbnails']");
 
     assert.equal(
@@ -774,7 +774,7 @@ describe('<mux-player> seek to live behaviors', function () {
     ></mux-player>`);
 
     const mediaControllerEl = playerEl.mediaController;
-    const seekToLiveEl = playerEl.theme.shadowRoot.querySelector('media-live-button');
+    const seekToLiveEl = playerEl.mediaTheme.shadowRoot.querySelector('media-live-button');
     assert.exists(mediaControllerEl);
     assert.notExists(seekToLiveEl);
   });
@@ -787,7 +787,7 @@ describe('<mux-player> seek to live behaviors', function () {
     ></mux-player>`);
 
     const mediaControllerEl = playerEl.mediaController;
-    const seekToLiveEl = playerEl.theme.shadowRoot.querySelector('media-live-button');
+    const seekToLiveEl = playerEl.mediaTheme.shadowRoot.querySelector('media-live-button');
     assert.exists(mediaControllerEl);
     assert.exists(seekToLiveEl);
   });
@@ -800,7 +800,7 @@ describe('<mux-player> seek to live behaviors', function () {
     ></mux-player>`);
 
     const mediaControllerEl = playerEl.mediaController;
-    const seekToLiveEl = playerEl.theme.shadowRoot.querySelector('media-live-button');
+    const seekToLiveEl = playerEl.mediaTheme.shadowRoot.querySelector('media-live-button');
     assert.exists(mediaControllerEl);
     assert.exists(seekToLiveEl);
   });
@@ -822,7 +822,7 @@ describe('<mux-player> seek to live behaviors', function () {
     await waitUntil(() => playerEl.inLiveWindow, 'playback did not start inLiveWindow');
     playerEl.pause();
     await waitUntil(() => !playerEl.inLiveWindow, 'still inLiveWindow after long pause', { timeout: 11000 });
-    const seekToLiveEl = playerEl.theme.shadowRoot.querySelector('media-live-button');
+    const seekToLiveEl = playerEl.mediaTheme.shadowRoot.querySelector('media-live-button');
     seekToLiveEl.click();
     await waitUntil(() => playerEl.inLiveWindow, 'clicking seek to live did not seek to live window');
   });
@@ -843,7 +843,7 @@ describe('<mux-player> seek to live behaviors', function () {
     playerEl.pause();
     await waitUntil(() => !playerEl.inLiveWindow, 'still inLiveWindow after long pause', { timeout: 11000 });
 
-    const mcPlayEl = playerEl.theme.shadowRoot.querySelector('media-play-button');
+    const mcPlayEl = playerEl.mediaTheme.shadowRoot.querySelector('media-play-button');
     mcPlayEl.click();
     await waitUntil(() => playerEl.inLiveWindow, 'clicking play did not seek to live window');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10576,10 +10576,10 @@ mdn-data@2.0.4:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
 
-media-chrome@0.18.2:
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-0.18.2.tgz#884d165cc6be50bbc2268f1a87ea2f83cf4e60da"
-  integrity sha512-RWSUQTDNQBQ1r5U3Gl8+TwIJuZGdeVLVy4csnfuPaoMeQVxfCcmzIcCoyf/71JGjE58hW1L8ocDfJZgB9d7VbQ==
+media-chrome@0.18.4:
+  version "0.18.4"
+  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-0.18.4.tgz#50438f0635d9027a5d23c69e8baf75358b22dfcd"
+  integrity sha512-ftG68jxSUraibyjOhyNEueEW94jVA87wJRYPylS8b/k6/nm07yURRPmk0O321NaI+eQ6i15wpA8UFgKSoBOqnQ==
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
currently packaging of MC themes is done by wrapping them in a web component see
https://github.com/muxinc/media-chrome/blob/main/src/js/themes/media-theme-youtube.js

this change adds some logic that checks (when the `theme` attribute is set) if the `media-theme-x` is defined as a custom element and uses its template for theming.

test url: https://elements-demo-nextjs-git-fork-luwes-mc-theme3-mux.vercel.app/MuxPlayerTheme