### PR TITLE
feat: Livestream status element

### DIFF
--- a/examples/vanilla-ts-esm/package.json
+++ b/examples/vanilla-ts-esm/package.json
@@ -22,6 +22,7 @@
     "@mux/mux-audio": ">=0.3.0",
     "@mux/mux-player": ">=1.0.0-beta.0",
     "@mux/mux-uploader": ">=1.0.0-beta.0",
-    "@mux/mux-video": ">=0.3.0"
+    "@mux/mux-video": ">=0.3.0",
+    "@mux/mux-livestream-status": ">=0.1.0-alpha.0"
   }
 }

--- a/examples/vanilla-ts-esm/public/index.html
+++ b/examples/vanilla-ts-esm/public/index.html
@@ -29,6 +29,7 @@
         <li><a href="./mux-player-cuepoints.html" class="player">&lt;mux-player&gt; (cuePoints)</a></li>
         <li><a href="./mux-uploader-simple.html" class="uploader">&lt;mux-uploader&gt;</a></li>
         <li><a href="./mux-uploader-full.html" class="uploader">&lt;mux-uploader&gt; (full-page)</a></li>
+        <li><a href="./mux-livestream-status.html" class="video">&lt;mux-livestream-status&gt;</a></li>
       </ul>
     </nav>
   </body>

--- a/examples/vanilla-ts-esm/public/mux-livestream-status.html
+++ b/examples/vanilla-ts-esm/public/mux-livestream-status.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <title>&lt;mux-livestream-status&gt; example</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+    <link rel="stylesheet" href="./styles.css">
+    <script type="module" src="./dist/mux-livestream-status.js"></script>
+	<style>
+		.custom-style {
+			display: inline-block;
+			width: 30px;
+			height: 30px;
+			overflow: hidden;
+			border-radius: 50%;
+			font-size: 0;
+			box-shadow: 0 0 10px #a3cc80;
+		}
+
+		.custom-style[status=active] {
+			background: #82f479;
+		}
+	</style>
+  </head>
+  <body>
+    <header>
+      <div class="left-header">
+        <a class="mux-logo" href="https://www.mux.com/player" target="_blank">
+          <img width="81" height="26" src="./images/mux-logo@2x.webp" alt="Mux logo" decoding="async">
+        </a>
+        <h1><a href="/">Elements</a></h1>
+      </div>
+      <div class="right-header">
+        <a class="github-logo" href="https://github.com/muxinc/elements" target="_blank">
+          <img width="32" height="32" src="./images/github-logo.svg" alt="Github logo">
+        </a>
+      </div>
+    </header>
+
+	<h2>&lt;mux-livestream-status&gt;</h2>
+
+	<h3>Default</h3>
+    <mux-livestream-status playback-id="23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I"></mux-livestream-status>
+
+	<h3>Custom styled</h3>
+    <mux-livestream-status class="custom-style" playback-id="23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I"></mux-livestream-status>
+
+	<br/><br/><br/><br/><br/><br/>
+
+    <a href="../">Browse Elements</a>
+  </body>
+</html>

--- a/examples/vanilla-ts-esm/src/mux-livestream-status.ts
+++ b/examples/vanilla-ts-esm/src/mux-livestream-status.ts
@@ -1,0 +1,1 @@
+export * as MuxLivestreamStatus from "@mux/mux-livestream-status";

--- a/packages/mux-livestream-status/.npmignore
+++ b/packages/mux-livestream-status/.npmignore
@@ -1,0 +1,7 @@
+**/*
+!dist/**
+!LICENSE
+dist/cjs.json
+dist/esm.json
+dist/iife.json
+dist/module.json

--- a/packages/mux-livestream-status/CHANGELOG.md
+++ b/packages/mux-livestream-status/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Placeholder

--- a/packages/mux-livestream-status/README.md
+++ b/packages/mux-livestream-status/README.md
@@ -1,0 +1,1 @@
+# Placeholder

--- a/packages/mux-livestream-status/package.json
+++ b/packages/mux-livestream-status/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@mux/mux-livestream-status",
+  "version": "0.1.0-alpha.0",
+  "description": "An element to show the status of a Mux livestream",
+  "main": "./dist/index.cjs.js",
+  "module": "./dist/index.mjs",
+  "browser": "./dist/index.mjs",
+  "unpkg": "./dist/mux-livestream-status.js",
+  "jsdelivr": "./dist/mux-livestream-status.js",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.cjs.js",
+    "default": "./dist/index.cjs.js"
+  },
+  "types": "dist/types-ts3.4/index.d.ts",
+  "typesVersions": {
+    ">=4.3.5": {
+      "*": [
+        "dist/types/index.d.ts"
+      ]
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/muxinc/elements",
+    "directory": "packages/mux-livestream-status"
+  },
+  "author": "Mux, Inc.",
+  "license": "MIT",
+  "scripts": {
+    "clean": "shx rm -rf dist/",
+    "lint": "eslint src/ --ext .js,.jsx,.ts,.tsx",
+    "test": "web-test-runner **/*test.js --port 8003 --coverage --config test/web-test-runner.config.mjs --root-dir ../..",
+    "posttest": "replace 'SF:src/' 'SF:packages/mux-livestream-status/src/' coverage/lcov.info --silent",
+    "dev:iife": "yarn build:iife --watch=forever",
+    "dev:cjs": "yarn build:cjs --watch=forever",
+    "dev:esm": "yarn build:esm --watch=forever",
+    "dev:esm-module": "yarn build:esm-module --watch=forever",
+    "dev:types": "yarn build:types -w",
+    "dev": "npm-run-all --parallel dev:types dev:cjs dev:esm dev:esm-module dev:iife",
+    "build:esm": "esbuild src/index.ts --target=es2019 --bundle --sourcemap --metafile=./dist/esm.json --format=esm --outdir=dist --out-extension:.js=.mjs --external:@mux/*",
+    "build:esm-module": "esbuild src/index.ts --target=es2019 --bundle --sourcemap --metafile=./dist/module.json --format=esm --outfile=./dist/mux-livestream-status.mjs",
+    "build:cjs": "esbuild src/index.ts --target=es2019 --bundle --sourcemap --metafile=./dist/cjs.json --format=cjs --outdir=dist --out-extension:.js=.cjs.js --external:@mux/*",
+    "build:iife": "esbuild src/index.ts --target=es2019 --bundle --sourcemap --metafile=./dist/iife.json --format=iife --outfile=./dist/mux-livestream-status.js",
+    "build:types": "tsc --declaration --emitDeclarationOnly --outDir './dist/types'",
+    "postbuild:types": "downlevel-dts ./dist/types ./dist/types-ts3.4",
+    "build": "npm-run-all --parallel 'build:esm --minify' 'build:iife --minify' 'build:cjs --minify' 'build:esm-module --minify'",
+    "create-release-notes": "create-release-notes ./CHANGELOG.md",
+    "publish-release": "../../scripts/publish.sh"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@mux/test-esm-exports": "0.1.0",
+    "@open-wc/testing": "^3.0.3",
+    "@typescript-eslint/eslint-plugin": "^5.48.0",
+    "@typescript-eslint/parser": "^5.48.0",
+    "@web/dev-server-esbuild": "^0.3.2",
+    "@web/dev-server-import-maps": "^0.0.6",
+    "@web/test-runner": "^0.13.26",
+    "downlevel-dts": "^0.11.0",
+    "esbuild": "^0.15.7",
+    "eslint": "^8.24.0",
+    "npm-run-all": "^4.1.5",
+    "replace": "^1.2.1",
+    "shared-polyfills": "0.1.0",
+    "shx": "^0.3.4",
+    "typescript": "^4.9.4"
+  }
+}

--- a/packages/mux-livestream-status/src/index.ts
+++ b/packages/mux-livestream-status/src/index.ts
@@ -1,0 +1,114 @@
+import { globalThis } from 'shared-polyfills';
+import { DEFAULT_POLL_INTERVAL, Unsubscribe } from './shared';
+import { subscribeLivestreamStatus } from './subscribeLivestreamStatus';
+
+const attributes = {
+  PLAYBACK_ID: 'playback-id',
+  POLL_INTERVAL: 'poll-interval',
+  STATUS: 'status',
+};
+const attributeNames = Object.freeze(Object.values(attributes));
+
+class MuxLivestreamStatusElement extends globalThis.HTMLElement {
+  // TODO: name this better
+  #unsubscribeFn: Unsubscribe | undefined = undefined;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  static get observedAttributes() {
+    return attributeNames;
+  }
+
+  get status() {
+    return this.getAttribute(attributes.STATUS) ?? '';
+  }
+
+  set status(value: string) {
+    if (this.status === value) return;
+    this.setAttribute(attributes.STATUS, value);
+  }
+
+  get playbackId() {
+    return this.getAttribute(attributes.PLAYBACK_ID) ?? '';
+  }
+
+  set playbackId(value: string) {
+    if (this.playbackId === value) return;
+    this.setAttribute(attributes.PLAYBACK_ID, value);
+  }
+
+  get pollInterval() {
+    return this.hasAttribute(attributes.POLL_INTERVAL)
+      ? +(this.getAttribute(attributes.POLL_INTERVAL) as string)
+      : DEFAULT_POLL_INTERVAL;
+  }
+
+  set pollInterval(value: number) {
+    if (this.pollInterval === value) return;
+    this.setAttribute(attributes.POLL_INTERVAL, `${value}`);
+  }
+
+  attributeChangedCallback(name: string) {
+    // no status attribute designates that we don't have a
+    // status for this playback-id yet (it might not exist...)
+    if (name === attributes.PLAYBACK_ID) {
+      this.removeAttribute('status');
+    }
+
+    if (name === attributes.PLAYBACK_ID || name === attributes.POLL_INTERVAL) {
+      this.#unsubscribe();
+      this.#subscribe();
+    }
+  }
+
+  connectedCallback() {
+    this.#subscribe();
+  }
+
+  disconnectedCallback() {
+    this.#unsubscribe();
+  }
+
+  #subscribe = () => {
+    // we already have a subscription
+    if (this.#unsubscribeFn) return;
+
+    // required
+    if (!this.playbackId || !this.pollInterval) return;
+
+    this.#unsubscribeFn = subscribeLivestreamStatus(
+      this.playbackId,
+      this.pollInterval,
+      (status) => {
+        this.status = status;
+        (this.shadowRoot as ShadowRoot).textContent = status;
+        this.dispatchEvent(
+          new CustomEvent('change', {
+            detail: status,
+          })
+        );
+      },
+      (error) => {
+        this.dispatchEvent(
+          new CustomEvent('error', {
+            detail: error,
+          })
+        );
+      }
+    );
+  };
+
+  #unsubscribe = () => {
+    this.#unsubscribeFn?.();
+    this.#unsubscribeFn = undefined;
+  };
+}
+
+if (!globalThis.customElements.get('mux-livestream-status')) {
+  globalThis.customElements.define('mux-livestream-status', MuxLivestreamStatusElement);
+}
+
+export default MuxLivestreamStatusElement;

--- a/packages/mux-livestream-status/src/shared.ts
+++ b/packages/mux-livestream-status/src/shared.ts
@@ -1,0 +1,5 @@
+export type Status = 'active' | 'idle';
+export type Unsubscribe = () => void;
+
+export const DEFAULT_POLL_INTERVAL = 10;
+export const MINIMUM_POLL_INTERVAL = 3;

--- a/packages/mux-livestream-status/src/subscribeLivestreamStatus.ts
+++ b/packages/mux-livestream-status/src/subscribeLivestreamStatus.ts
@@ -1,0 +1,54 @@
+import { MINIMUM_POLL_INTERVAL, Status, Unsubscribe } from './shared';
+
+export type Subscribe = (
+  playbackId: string,
+  pollInterval: number, // in seconds
+  callback: (status: Status) => void,
+  errorCb: (errorMsg: unknown) => void
+) => Unsubscribe;
+
+export const subscribeLivestreamStatus: Subscribe = (playbackId, pollInterval, callback, errorCb) => {
+  const url = `https://stream.mux.com/${playbackId}.m3u8`;
+  const controller = new AbortController();
+  let timeoutId = -1;
+
+  const fetchStatus: () => Promise<void> = async () => {
+    if (controller.signal.aborted) return;
+
+    return (
+      fetch(url, { signal: controller.signal })
+        .then((response) => {
+          switch (response.status) {
+            case 200:
+              callback('active');
+              break;
+            case 412:
+              // "disabled" livestreams will also report 412 as idle
+              callback('idle');
+              break;
+            default:
+              errorCb(`${response.status}: Problem with Playback ID ${playbackId}`);
+          }
+        })
+        .catch(errorCb)
+        // start our polling again regardless of response / error
+        .finally(poll)
+    );
+  };
+
+  const poll = () => {
+    if (controller.signal.aborted) return;
+    // TS assumes we're calling the node version of setTimeout
+    // TODO: how should we properly handle this?
+    // @ts-ignore
+    timeoutId = setTimeout(fetchStatus, Math.max(pollInterval * 1000, MINIMUM_POLL_INTERVAL * 1000));
+  };
+
+  fetchStatus();
+
+  // returns an unsubscribe() function
+  return () => {
+    controller.abort();
+    clearTimeout(timeoutId);
+  };
+};

--- a/packages/mux-livestream-status/test/index.test.js
+++ b/packages/mux-livestream-status/test/index.test.js
@@ -1,0 +1,43 @@
+import { assert, fixture, aTimeout } from '@open-wc/testing';
+import MuxLivestreamStatus from '../src/index.ts';
+
+describe('<mux-livestream-status>', () => {
+  it('shows correct status if livestream is live', async function () {
+    this.timeout(3000);
+    const statusEl = await fixture(`<mux-livestream-status
+        playback-id="23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I"
+      ></mux-livestream-status>`);
+    let changeEventFired = false;
+    statusEl.addEventListener('change', () => (changeEventFired = true));
+    await aTimeout(2000);
+    assert.isTrue(changeEventFired, 'change event fired');
+    assert.equal(statusEl.status, 'active', 'status is "active"');
+  });
+
+  it('shows correct status if livestream is idle', async function () {
+    // TODO: which livestream can we safely use to test this
+    // currently using one of Adams
+    this.timeout(3000);
+    const statusEl = await fixture(`<mux-livestream-status
+        playback-id="6BC2NFpXHw7jnWiZ202PpAkPrlGQZOFqKYbRcSlLaE700"
+      ></mux-livestream-status>`);
+    let changeEventFired = false;
+    statusEl.addEventListener('change', () => (changeEventFired = true));
+    await aTimeout(2000);
+    assert.isTrue(changeEventFired, 'change event fired');
+    assert.equal(statusEl.status, 'idle', 'status is "idle"');
+  });
+
+  it('calls the error callback if no livestream found', async function () {
+    this.timeout(3000);
+    const statusEl = await fixture(`<mux-livestream-status
+        playback-id="non-existant-id"
+      ></mux-livestream-status>`);
+    let errorEventFired = false;
+    statusEl.addEventListener('error', () => (errorEventFired = true));
+    await aTimeout(2000);
+    assert.isTrue(errorEventFired, 'error event fired');
+  });
+
+  // TODO: test unsubscribe function / abort
+});

--- a/packages/mux-livestream-status/test/web-test-runner.config.mjs
+++ b/packages/mux-livestream-status/test/web-test-runner.config.mjs
@@ -1,0 +1,23 @@
+import { esbuildPlugin } from '@web/dev-server-esbuild';
+import { importMapsPlugin } from '@web/dev-server-import-maps';
+
+export default {
+  nodeResolve: true,
+  plugins: [
+    importMapsPlugin({
+      inject: {
+        importMap: {
+          imports: {
+            // see shared/test-esm-exports/README.md for more information on this configuration
+            '/test/': '/packages/mux-livestream-status/test/',
+          },
+        },
+      },
+    }),
+    esbuildPlugin({ ts: true }),
+  ],
+  coverageConfig: {
+    report: true,
+    include: ['src/**/*'],
+  },
+};

--- a/packages/mux-livestream-status/tsconfig.json
+++ b/packages/mux-livestream-status/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "preserveWatchOutput": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "incremental": true,
+    "target": "ES2019",
+    "module": "es6",
+    "declaration": true,
+    "sourceMap": true,
+    "composite": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "moduleResolution": "Node",
+    "baseUrl": "./packages",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "typeRoots": ["node_modules/@types", "../../types"]
+  },
+  "include": ["src/**/*", "../../types"]
+}


### PR DESCRIPTION
An element for showing the status of a Mux Livestream, limited to "active" and "idle" states.

Example usage:
```
<mux-livestream-status playback-id="{my_playback_id}" poll-interval="10"></mux-livestream-status>
```

The element will set a `status="..."` property that can be used for styling purposes.

<img width="339" alt="image" src="https://user-images.githubusercontent.com/9952680/216613134-c212a859-f59b-43eb-86fe-aec321c14323.png">

Has a hard minumum polling frequency (3 seconds currently).