### PR TITLE
fix: theme attributes

### DIFF
--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -258,6 +258,7 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
 
     initVideoApi(this);
 
+    this.#setUpThemeAttributes();
     this.#setUpErrors();
     this.#setUpCaptionsButton();
     this.#userInactive = this.mediaController?.hasAttribute('user-inactive') ?? true;
@@ -306,6 +307,40 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
 
   #render(props: Record<string, any> = {}) {
     render(template(getProps(this, { ...this.#state, ...props })), this.shadowRoot as Node);
+  }
+
+  #setUpThemeAttributes() {
+    // Forward `theme-` prefixed attributes to the theme.
+    // e.g. `theme-control-bar-vertical` for the Micro theme.
+    const observer = new MutationObserver((mutationList) => {
+      for (const { type, attributeName } of mutationList) {
+        if (type === 'attributes' && attributeName?.startsWith('theme-')) {
+          const themeAttrName = attributeName.replace(/^theme-/, '');
+          const value = this.getAttribute(attributeName);
+          if (value != null) {
+            this.mediaTheme?.setAttribute(themeAttrName, value);
+          } else {
+            this.mediaTheme?.removeAttribute(themeAttrName);
+          }
+        }
+      }
+    });
+
+    observer.observe(this, {
+      attributes: true,
+    });
+
+    this.getAttributeNames()
+      .filter((attributeName) => attributeName.startsWith('theme-'))
+      .forEach((attributeName) => {
+        const themeAttrName = attributeName.replace(/^theme-/, '');
+        const value = this.getAttribute(attributeName);
+        if (value != null) {
+          this.mediaTheme?.setAttribute(themeAttrName, value);
+        } else {
+          this.mediaTheme?.removeAttribute(themeAttrName);
+        }
+      });
   }
 
   #setUpErrors() {

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -135,6 +135,19 @@ function getThemeTemplate(el: MuxPlayerElement) {
   }
 }
 
+function getMetadataFromAttrs(el: MuxPlayerElement) {
+  return el
+    .getAttributeNames()
+    .filter((attrName) => attrName.startsWith('metadata-'))
+    .reduce((currAttrs, attrName) => {
+      const value = el.getAttribute(attrName);
+      if (value !== null) {
+        currAttrs[attrName.replace(/^metadata-/, '').replace(/-/g, '_')] = value;
+      }
+      return currAttrs;
+    }, {} as { [key: string]: string });
+}
+
 const MuxVideoAttributeNames = Object.values(MuxVideoAttributes);
 const VideoAttributeNames = Object.values(VideoAttributes);
 const PlayerAttributeNames = Object.values(PlayerAttributes);
@@ -279,22 +292,10 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
     return this.mediaTheme?.shadowRoot?.querySelector('media-controller');
   }
 
-  get metadataFromAttrs() {
-    return this.getAttributeNames()
-      .filter((attrName) => attrName.startsWith('metadata-'))
-      .reduce((currAttrs, attrName) => {
-        const value = this.getAttribute(attrName);
-        if (value !== null) {
-          currAttrs[attrName.replace(/^metadata-/, '').replace(/-/g, '_')] = value;
-        }
-        return currAttrs;
-      }, {} as { [key: string]: string });
-  }
-
   connectedCallback() {
     const muxVideo = this.shadowRoot?.querySelector('mux-video') as MuxVideoElement;
     if (muxVideo) {
-      muxVideo.metadata = this.metadataFromAttrs;
+      muxVideo.metadata = getMetadataFromAttrs(this);
     }
   }
 
@@ -1158,7 +1159,7 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
       logger.error('underlying media element missing when trying to set metadata. metadata will not be set.');
       return;
     }
-    this.media.metadata = { ...this.metadataFromAttrs, ...val };
+    this.media.metadata = { ...getMetadataFromAttrs(this), ...val };
   }
 
   async addCuePoints<T = any>(cuePoints: { time: number; value: T }[]) {


### PR DESCRIPTION
this change makes it so we can forward attributes to the themes from the Mux player interface.

`theme-` prefixed makes sense I think because we don't really know which attributes the custom theme could support.