### PR TITLE
test: fix turbo dependency copy polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "lint": "turbo run lint --filter '!./examples/*'",
     "test": "turbo run test --filter '!./examples/*'",
     "dev": "turbo run dev --filter '!./examples/*'",
-    "copypolyfills": "turbo run copypolyfills --filter '!./examples/*'",
     "build:packages": "turbo run build --filter '!./examples/*'",
     "build": "turbo run build",
     "i18n": "turbo run i18n",

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,7 @@
     },
     "dev": {
       "cache": false,
-      "dependsOn": ["copypolyfills", "build:types", "^build"]
+      "dependsOn": ["build:types", "^build"]
     },
     "copypolyfills": {
       "outputs": ["src/polyfills/**/*"],
@@ -23,7 +23,7 @@
     },
     "build:types": {
       "outputs": ["dist/types/**/*", "dist/types-ts3.4/**/*"],
-      "dependsOn": ["^build:types"]
+      "dependsOn": ["copypolyfills", "^build:types"]
     },
     "build:packages": {
       "outputs": ["dist/**/*"],
@@ -31,7 +31,7 @@
     },
     "build": {
       "outputs": ["dist/**/*", "build/**/*", ".next/**/*", ".svelte-kit/**/*", ".vercel/**/*"],
-      "dependsOn": ["copypolyfills", "build:types", "^build"]
+      "dependsOn": ["build:types", "^build"]
     }
   }
 }


### PR DESCRIPTION
reasoning is that build:types has a dependency on the polyfills to be there.
build has a depdency on build:types so we can remove some `copypolyfills` strings