### PR TITLE
fix(mux-uploader): conditionally render mux-uploader-drop

### DIFF
--- a/packages/mux-uploader/src/layouts/block.ts
+++ b/packages/mux-uploader/src/layouts/block.ts
@@ -3,25 +3,26 @@ import { document } from '../polyfills';
 import '../mux-uploader-file-select';
 import { fileSelectFragment } from '../mux-uploader-file-select';
 
-const template = document.createElement('template');
+export default function blockLayout(noDrop: boolean) {
+  const wrapper = noDrop ? 'div' : 'mux-uploader-drop overlay';
 
-template.innerHTML = /*html*/ `
-<style>
-</style>
+  return document.createRange().createContextualFragment(`
+    <style>
+      /* Add your styles here */
+    </style>
 
-<mux-uploader-drop overlay>
-  <mux-uploader-status></mux-uploader-status>
-  <mux-uploader-retry></mux-uploader-retry>
+    <${wrapper}>
+      <mux-uploader-status></mux-uploader-status>
+      <mux-uploader-retry></mux-uploader-retry>
 
-  <mux-uploader-file-select>
-    <slot name="file-select">
-      ${fileSelectFragment}
-    </slot>
-  </mux-uploader-file-select>
+      <mux-uploader-file-select>
+        <slot name="file-select">
+          ${fileSelectFragment}
+        </slot>
+      </mux-uploader-file-select>
 
-  <mux-uploader-progress type="percentage"></mux-uploader-progress>
-  <mux-uploader-progress></mux-uploader-progress>
-</mux-uploader-drop>
-`;
-
-export default template;
+      <mux-uploader-progress type="percentage"></mux-uploader-progress>
+      <mux-uploader-progress></mux-uploader-progress>
+    </${wrapper}>
+  `);
+}

--- a/packages/mux-uploader/src/layouts/block.ts
+++ b/packages/mux-uploader/src/layouts/block.ts
@@ -3,8 +3,8 @@ import { document } from '../polyfills';
 import '../mux-uploader-file-select';
 import { fileSelectFragment } from '../mux-uploader-file-select';
 
-export default function blockLayout(noDrop: boolean) {
-  const wrapper = noDrop ? 'div' : 'mux-uploader-drop overlay';
+export default function blockLayout(nodrop: boolean) {
+  const wrapper = nodrop ? 'div' : 'mux-uploader-drop overlay';
 
   return document.createRange().createContextualFragment(`
     <style>

--- a/packages/mux-uploader/src/mux-uploader.ts
+++ b/packages/mux-uploader/src/mux-uploader.ts
@@ -88,8 +88,7 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
     shadow.appendChild(rootTemplate.content.cloneNode(true));
 
     // Attach a layout
-    const uploaderHtml = blockLayout.content.cloneNode(true);
-    shadow.appendChild(uploaderHtml);
+    this.updateLayout();
 
     this.hiddenFileInput?.addEventListener('change', () => {
       const file = this.hiddenFileInput?.files?.[0];
@@ -133,6 +132,28 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
     }
     this.dispatchEvent(new CustomEvent('reset'));
     this._endpoint = value;
+  }
+
+  get noDrop(): boolean {
+    return this.hasAttribute('noDrop');
+  }
+
+  set noDrop(value: boolean) {
+    if (value) {
+      this.setAttribute('noDrop', '');
+    } else {
+      this.removeAttribute('noDrop');
+    }
+    this.updateLayout();
+  }
+
+  updateLayout() {
+    const oldLayout = this.shadowRoot!.querySelector('mux-uploader-drop, div');
+    if (oldLayout) {
+      oldLayout.remove();
+    }
+    const newLayout = blockLayout(this.noDrop);
+    this.shadowRoot!.appendChild(newLayout);
   }
 
   get dynamicChunkSize(): DynamicChunkSize {

--- a/packages/mux-uploader/src/mux-uploader.ts
+++ b/packages/mux-uploader/src/mux-uploader.ts
@@ -115,6 +115,14 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
     this.removeEventListener('reset', this.resetState);
   }
 
+  attributeChangedCallback() {
+    this.updateLayout();
+  }
+
+  static get observedAttributes() {
+    return ['nodrop'];
+  }
+
   protected get hiddenFileInput() {
     return this.shadowRoot?.querySelector('#hidden-file-input') as HTMLInputElement;
   }
@@ -134,17 +142,12 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
     this._endpoint = value;
   }
 
-  get noDrop(): boolean {
-    return this.hasAttribute('noDrop');
+  get nodrop(): boolean {
+    return this.hasAttribute('nodrop');
   }
 
-  set noDrop(value: boolean) {
-    if (value) {
-      this.setAttribute('noDrop', '');
-    } else {
-      this.removeAttribute('noDrop');
-    }
-    this.updateLayout();
+  set nodrop(value: boolean) {
+    this.toggleAttribute('nodrop', Boolean(value));
   }
 
   updateLayout() {
@@ -152,7 +155,7 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
     if (oldLayout) {
       oldLayout.remove();
     }
-    const newLayout = blockLayout(this.noDrop);
+    const newLayout = blockLayout(this.nodrop);
     this.shadowRoot!.appendChild(newLayout);
   }
 

--- a/packages/mux-uploader/test/uploader.test.js
+++ b/packages/mux-uploader/test/uploader.test.js
@@ -12,11 +12,22 @@ describe('<mux-uploader>', () => {
       endpoint="https://my-authenticated-url/storage?your-url-params"
     ></mux-uploader>`);
 
+    const drop = uploader.shadowRoot.querySelector('mux-uploader-drop');
+
     assert.equal(
       uploader.getAttribute('endpoint'),
       'https://my-authenticated-url/storage?your-url-params',
       'endpoint matches'
     );
+
+    assert.isNotNull(drop, 'mux-uploader-drop is not null');
+  });
+
+  it('removes dropzone with noDrop param', async function () {
+    const uploader = await fixture(`<mux-uploader noDrop></mux-uploader>`);
+    const drop = uploader.shadowRoot.querySelector('mux-uploader-drop');
+
+    assert.isNull(drop, 'mux-uploader-drop is null');
   });
 
   it('does not init without endpoint', async function () {

--- a/packages/mux-uploader/test/uploader.test.js
+++ b/packages/mux-uploader/test/uploader.test.js
@@ -23,26 +23,26 @@ describe('<mux-uploader>', () => {
     assert.isNotNull(drop, 'mux-uploader-drop is not null');
   });
 
-  it('removes dropzone with noDrop param', async function () {
-    const uploader = await fixture(`<mux-uploader noDrop></mux-uploader>`);
+  it('removes dropzone with nodrop param', async function () {
+    const uploader = await fixture(`<mux-uploader nodrop></mux-uploader>`);
     const drop = uploader.shadowRoot.querySelector('mux-uploader-drop');
 
     assert.isNull(drop, 'mux-uploader-drop is null');
   });
 
-  it('should toggle the noDrop attribute when setting noDrop', async () => {
+  it('should toggle the nodrop attribute when setting nodrop', async () => {
     const uploader = await fixture(`<mux-uploader></mux-uploader>`);
-    uploader.noDrop = true;
-    assert.equal(uploader.hasAttribute('noDrop'), true, 'noDrop attr is set');
+    uploader.nodrop = true;
+    assert.equal(uploader.hasAttribute('nodrop'), true, 'nodrop attr is set');
 
     let drop = uploader.shadowRoot.querySelector('mux-uploader-drop');
 
     assert.isNull(drop, 'mux-uploader-drop is null');
 
-    uploader.noDrop = false;
+    uploader.nodrop = false;
     drop = uploader.shadowRoot.querySelector('mux-uploader-drop');
 
-    assert.equal(uploader.hasAttribute('noDrop'), false, 'noDrop attr is removed');
+    assert.equal(uploader.hasAttribute('nodrop'), false, 'nodrop attr is removed');
     assert.isNotNull(drop, 'mux-uploader-drop is not null');
   });
 

--- a/packages/mux-uploader/test/uploader.test.js
+++ b/packages/mux-uploader/test/uploader.test.js
@@ -30,6 +30,22 @@ describe('<mux-uploader>', () => {
     assert.isNull(drop, 'mux-uploader-drop is null');
   });
 
+  it('should toggle the noDrop attribute when setting noDrop', async () => {
+    const uploader = await fixture(`<mux-uploader></mux-uploader>`);
+    uploader.noDrop = true;
+    assert.equal(uploader.hasAttribute('noDrop'), true, 'noDrop attr is set');
+
+    let drop = uploader.shadowRoot.querySelector('mux-uploader-drop');
+
+    assert.isNull(drop, 'mux-uploader-drop is null');
+
+    uploader.noDrop = false;
+    drop = uploader.shadowRoot.querySelector('mux-uploader-drop');
+
+    assert.equal(uploader.hasAttribute('noDrop'), false, 'noDrop attr is removed');
+    assert.isNotNull(drop, 'mux-uploader-drop is not null');
+  });
+
   it('does not init without endpoint', async function () {
     const uploader = await fixture(`<mux-uploader></mux-uploader>`);
 


### PR DESCRIPTION
If a user prefers to use `<mux-uploader-drop>` outside of the `<mux-uploader>` element, we should allow them to disable the default `<mux-uploader-drop>` element rendered as a child of `<mux-uploader>`

This adds a `noDrop` attribute which would modifiy the defauly layout to render a `div` element as a wrapper instead of `<mux-uploader-drop>`