### PR TITLE
fix(mux-uploader): fixing dropzone styling regressions

### DIFF
--- a/packages/mux-uploader/src/mux-uploader-drop.ts
+++ b/packages/mux-uploader/src/mux-uploader-drop.ts
@@ -52,10 +52,10 @@ template.innerHTML = /*html*/ `
 </div>
 
 <slot name="heading" part="heading">
-  <span id="heading">Drop a video file here to upload</span>
+  <span>Drop a video file here to upload</span>
 </slot>
 <slot name="separator" part="separator">
-  <span id="separator">or</span>
+  <span>or</span>
 </slot>
 <slot></slot>
 `;
@@ -68,7 +68,8 @@ const Attributes = {
 class MuxUploaderDropElement extends globalThis.HTMLElement {
   #overlayTextEl: HTMLElement;
   #uploaderEl: MuxUploaderElement | null | undefined;
-  #headingEl: HTMLSpanElement | null | undefined;
+  #headingEl: HTMLSlotElement | null | undefined;
+  #separatorEl: HTMLSlotElement | null | undefined;
 
   #abortController: AbortController | undefined;
 
@@ -78,7 +79,8 @@ class MuxUploaderDropElement extends globalThis.HTMLElement {
     shadowRoot.appendChild(template.content.cloneNode(true));
 
     this.#overlayTextEl = shadowRoot.getElementById('overlay-label') as HTMLElement;
-    this.#headingEl = shadowRoot.querySelector('#heading') as HTMLSpanElement;
+    this.#headingEl = shadowRoot.querySelector('slot[name="heading"]') as HTMLSlotElement;
+    this.#separatorEl = shadowRoot.querySelector('slot[name="separator"]') as HTMLSlotElement;
   }
 
   connectedCallback() {
@@ -87,6 +89,21 @@ class MuxUploaderDropElement extends globalThis.HTMLElement {
 
     if (this.#uploaderEl) {
       const opts = { signal: this.#abortController.signal };
+
+      this.#uploaderEl.addEventListener(
+        'file-ready',
+        () => {
+          if (this.#headingEl) {
+            this.#headingEl.style.display = 'none';
+          }
+
+          if (this.#separatorEl) {
+            this.#separatorEl.style.display = 'none';
+          }
+        },
+        opts
+      );
+
       this.setupDragEvents(opts);
     }
   }
@@ -152,10 +169,6 @@ class MuxUploaderDropElement extends globalThis.HTMLElement {
         //@ts-ignore
         const { files } = dataTransfer;
         const file = files[0];
-
-        if (this.#headingEl) {
-          this.#headingEl.style.display = 'none';
-        }
 
         const uploaderController = this.#uploaderEl ?? this;
 

--- a/packages/mux-uploader/src/mux-uploader-drop.ts
+++ b/packages/mux-uploader/src/mux-uploader-drop.ts
@@ -21,6 +21,7 @@ template.innerHTML = /*html*/ `
   slot[name='heading'] > * {
     margin-bottom: 0.75rem;
     font-size: 1.75rem;
+    text-align: center;
   }
 
   slot[name='separator'] > * {

--- a/packages/mux-uploader/src/mux-uploader-progress.ts
+++ b/packages/mux-uploader/src/mux-uploader-progress.ts
@@ -9,14 +9,16 @@ const ariaDescription = 'Media upload progress bar';
 template.innerHTML = /*html*/ `
 <style>
   :host {
-    position: relative;
-    display: contents;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
   }
 
   .bar-type {
     background: #e6e6e6;
     border-radius: 100px;
-    position: relative;
     height: var(--progress-bar-height, 4px);
     width: 100%;
   }

--- a/packages/mux-uploader/src/mux-uploader-progress.ts
+++ b/packages/mux-uploader/src/mux-uploader-progress.ts
@@ -6,10 +6,11 @@ import { formatProgress } from './utils/progress';
 const template = document.createElement('template');
 const ariaDescription = 'Media upload progress bar';
 
-template.innerHTML = `
+template.innerHTML = /*html*/ `
 <style>
   :host {
     position: relative;
+    display: contents;
   }
 
   .bar-type {
@@ -64,8 +65,7 @@ template.innerHTML = `
 
   #percentage-type {
     font-size: inherit;
-    margin-bottom: 16px;
-    color: black;
+    margin: 0 0 1em;
   }
 </style>
 
@@ -121,6 +121,7 @@ class MuxUploaderProgressElement extends globalThis.HTMLElement {
       this.#uploaderEl.addEventListener('uploadstart', this.onUploadStart, opts);
       this.#uploaderEl.addEventListener('reset', this.onReset);
       this.#uploaderEl.addEventListener('progress', this.onProgress);
+      this.#uploaderEl.addEventListener('success', this.onSuccess);
     }
   }
 
@@ -160,6 +161,11 @@ class MuxUploaderProgressElement extends globalThis.HTMLElement {
         break;
       }
     }
+  };
+
+  onSuccess = () => {
+    this.removeAttribute('upload-in-progress');
+    this.setAttribute('upload-complete', '');
   };
 
   onReset = () => {


### PR DESCRIPTION
Introducing the `<mux-uploader-drop>` element as a default presentation brought a few problems with how the elements were styled as the upload progressed. This PR fixes those regressions.