### PR TITLE
Refactor blockLayout function to conditionally render elements

### DIFF
--- a/packages/mux-uploader/src/layouts/block.ts
+++ b/packages/mux-uploader/src/layouts/block.ts
@@ -3,26 +3,47 @@ import { document } from '../polyfills';
 import '../mux-uploader-file-select';
 import { fileSelectFragment } from '../mux-uploader-file-select';
 
+function shouldRenderElement(selector: string): boolean {
+  return !document.querySelector(selector);
+}
+
+function renderElement(selector: string, template: string): string {
+  return shouldRenderElement(selector) ? template : '';
+}
+
+function shouldRenderWrapper(nodrop: boolean, selector: string): string {
+  return !nodrop && !document.querySelector(selector) ? 'mux-uploader-drop overlay' : 'div';
+}
+
 export default function blockLayout(nodrop: boolean) {
-  const wrapper = nodrop ? 'div' : 'mux-uploader-drop overlay';
+  const wrapper = shouldRenderWrapper(nodrop, 'mux-uploader-drop');
 
-  return document.createRange().createContextualFragment(`
-    <style>
-      /* Add your styles here */
-    </style>
-
-    <${wrapper}>
-      <mux-uploader-status></mux-uploader-status>
-      <mux-uploader-retry></mux-uploader-retry>
-
-      <mux-uploader-file-select>
+  const renderStatus = renderElement('mux-uploader-status', '<mux-uploader-status></mux-uploader-status>');
+  const renderRetry = renderElement('mux-uploader-retry', '<mux-uploader-retry></mux-uploader-retry>');
+  const renderPercentageProgress = renderElement(
+    'mux-uploader-progress[type="percentage"]',
+    '<mux-uploader-progress type="percentage"></mux-uploader-progress>'
+  );
+  const renderFileSelect = renderElement(
+    'mux-uploader-file-select',
+    `<mux-uploader-file-select>
         <slot name="file-select">
           ${fileSelectFragment}
         </slot>
-      </mux-uploader-file-select>
+      </mux-uploader-file-select>`
+  );
+  const renderProgress = renderElement(
+    'mux-uploader-progress:not([type])',
+    '<mux-uploader-progress></mux-uploader-progress>'
+  );
 
-      <mux-uploader-progress type="percentage"></mux-uploader-progress>
-      <mux-uploader-progress></mux-uploader-progress>
+  return document.createRange().createContextualFragment(`
+    <${wrapper}>
+      ${renderStatus}
+      ${renderRetry}
+      ${renderFileSelect}
+      ${renderPercentageProgress}
+      ${renderProgress}
     </${wrapper}>
   `);
 }

--- a/packages/mux-uploader/src/layouts/block.ts
+++ b/packages/mux-uploader/src/layouts/block.ts
@@ -1,30 +1,39 @@
 import { document } from '../polyfills';
+import type MuxUploaderElement from '../mux-uploader';
 
 import '../mux-uploader-file-select';
 import { fileSelectFragment } from '../mux-uploader-file-select';
 
-function shouldRenderElement(selector: string): boolean {
-  return !document.querySelector(selector);
+function shouldRenderElement(contextElement: HTMLElement, selector: string): boolean {
+  const root = contextElement.getRootNode() as ShadowRoot | Document;
+  return !root.querySelector(selector);
 }
 
-function renderElement(selector: string, template: string): string {
-  return shouldRenderElement(selector) ? template : '';
+function renderElement(contextElement: HTMLElement, selector: string, template: string): string {
+  return shouldRenderElement(contextElement, selector) ? template : '';
 }
 
-function shouldRenderWrapper(nodrop: boolean, selector: string): string {
-  return !nodrop && !document.querySelector(selector) ? 'mux-uploader-drop overlay' : 'div';
+function shouldRenderWrapper(contextElement: MuxUploaderElement, selector: string): string {
+  const root = contextElement.getRootNode() as ShadowRoot | Document;
+  return !contextElement.nodrop && !root.querySelector(selector) ? 'mux-uploader-drop overlay' : 'div';
 }
 
-export default function blockLayout(nodrop: boolean) {
-  const wrapper = shouldRenderWrapper(nodrop, 'mux-uploader-drop');
+export default function blockLayout(contextElement: MuxUploaderElement) {
+  const wrapper = shouldRenderWrapper(contextElement, 'mux-uploader-drop');
 
-  const renderStatus = renderElement('mux-uploader-status', '<mux-uploader-status></mux-uploader-status>');
-  const renderRetry = renderElement('mux-uploader-retry', '<mux-uploader-retry></mux-uploader-retry>');
+  const renderStatus = renderElement(
+    contextElement,
+    'mux-uploader-status',
+    '<mux-uploader-status></mux-uploader-status>'
+  );
+  const renderRetry = renderElement(contextElement, 'mux-uploader-retry', '<mux-uploader-retry></mux-uploader-retry>');
   const renderPercentageProgress = renderElement(
+    contextElement,
     'mux-uploader-progress[type="percentage"]',
     '<mux-uploader-progress type="percentage"></mux-uploader-progress>'
   );
   const renderFileSelect = renderElement(
+    contextElement,
     'mux-uploader-file-select',
     `<mux-uploader-file-select>
         <slot name="file-select">
@@ -33,6 +42,7 @@ export default function blockLayout(nodrop: boolean) {
       </mux-uploader-file-select>`
   );
   const renderProgress = renderElement(
+    contextElement,
     'mux-uploader-progress:not([type])',
     '<mux-uploader-progress></mux-uploader-progress>'
   );

--- a/packages/mux-uploader/src/mux-uploader.ts
+++ b/packages/mux-uploader/src/mux-uploader.ts
@@ -155,7 +155,7 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
     if (oldLayout) {
       oldLayout.remove();
     }
-    const newLayout = blockLayout(this.nodrop);
+    const newLayout = blockLayout(this);
     this.shadowRoot!.appendChild(newLayout);
   }
 


### PR DESCRIPTION
This PR introduces several improvements to the `blockLayout` to prevent unnecessary rendering of elements when they already exist in the DOM.

1. Introduced the `shouldRenderElement` function, which checks if an element with the given selector exists in the DOM. If it does not exist, the function returns `true`, indicating that the element should be rendered.

2. Introduced the `renderElement` function, which utilizes `shouldRenderElement` to conditionally render elements based on their presence in the DOM. This function simplifies the process of adding new elements without duplicating the logic for checking whether they should be rendered.

3. Refactored the `blockLayout` function to use the `renderElement` function for conditionally rendering the following elements:
   - `mux-uploader-status`
   - `mux-uploader-retry`
   - `mux-uploader-progress[type="percentage"]`
   - `mux-uploader-file-select`
   - `mux-uploader-progress:not([type])`

4. Introduced the `shouldRenderWrapper` function to conditionally render the `mux-uploader-drop overlay` element based on the `nodrop` value and its presence in the DOM. If `nodrop` is `true` or the element already exists in the DOM, a `div` will be used as a wrapper instead.