### PR TITLE
Removing CSS in favor of slots/individual components

### DIFF
--- a/packages/mux-uploader/README.md
+++ b/packages/mux-uploader/README.md
@@ -354,25 +354,15 @@ If an error occurs during the upload, an `uploaderror` event will fire.
 
 #### `<mux-uploader>`
 
-| Name                           | CSS Property       | Default Value       | Description                                             | Notes                                                                                             |
-| ------------------------------ | ------------------ | ------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `--uploader-font-family`       | `font-family`      | `Arial`             | font family of the component                            | Applies to other elements as well: upload status and error status                                 |
-| `--uploader-font-size`         | `font-size`        | `16px`              | font size for text within the component                 | Also applies to `<mux-uploader-drop>` i.e. overlay text                                           |
-| `--uploader-background-color`  | `background-color` | `inherit`           | background color of area surrounding the upload         |                                                                                                   |
-| `--button-background-color`    | `background`       | `#fff`              | background color of upload button                       |                                                                                                   |
-| `--button-border-radius`       | `border-radius`    | `4px`               | border radius of the upload button                      |                                                                                                   |
-| `--button-border`              | `border`           | `1px solid #000000` | border of the upload button                             |                                                                                                   |
-| `--button-padding`             | `padding`          | `16px 24px`         | padding of the upload button                            |                                                                                                   |
-| `--button-hover-text`          | `color`            | `#fff`              | text color of upload button on button hover             |                                                                                                   |
-| `--button-hover-background`    | `background`       | `#404040`           | background color of upload button on button hover       |                                                                                                   |
-| `--button-active-text`         | `color`            | `#fff`              | color of upload button text when button is active       |                                                                                                   |
-| `--button-active-background`   | `background`       | `#000000`           | background color of upload button when button is active | Applied via `:active` [pseudo selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:active) |
-| `--progress-bar-fill-color`    | `background`       | `#000000`           | background color for progress bar div                   |                                                                                                   |
-| `--progress-radial-fill-color` | `stroke`           | `black`             | stroke color for circle SVG (wip)                       |                                                                                                   |
-| `--progress-percentage-display`| `display`          | `block`             | display value for percentage progress                   |                                                                                                   |
+| Name                            | CSS Property | Default Value | Description                           | Notes |
+| ------------------------------- | ------------ | ------------- | ------------------------------------- | ----- |
+| `--progress-bar-fill-color`     | `background` | `#000000`     | background color for progress bar div |       |
+| `--progress-bar-height`         | `height`     | `4px`         | height for the progress bar           |       |
+| `--progress-radial-fill-color`  | `stroke`     | `black`       | stroke color for circle SVG (wip)     |       |
+| `--progress-percentage-display` | `display`    | `block`       | display value for percentage progress |       |
 
 #### `<mux-uploader-drop/>`
 
 | Name                         | CSS Property       | Default Value               | Description                         | Notes                                                  |
 | ---------------------------- | ------------------ | --------------------------- | ----------------------------------- | ------------------------------------------------------ |
-| `--overlay-background-color` | `background-color` | `rgba(226, 253, 255, 0.95)` | background color of the overlay div | Visible only when component has `fullscreen` attribute |
+| `--overlay-background-color` | `background-color` | `rgba(226, 253, 255, 0.95)` | background color of the overlay div | |

--- a/packages/mux-uploader/src/mux-uploader-file-select.ts
+++ b/packages/mux-uploader/src/mux-uploader-file-select.ts
@@ -7,11 +7,11 @@ export const fileSelectFragment = /*html*/ `
   #file-select {
     cursor: pointer;
     line-height: 16px;
-    background: var(--button-background-color, #fff);
-    border: var(--button-border, 1px solid #000);
+    background: #fff;
+    border: 1px solid #000;
     color: #000000;
-    padding: var(--button-padding, 16px 24px);
-    border-radius: var(--button-border-radius, 4px);
+    padding: 16px 24px;
+    border-radius: 4px;
     -webkit-transition: all 0.2s ease;
     transition: all 0.2s ease;
     font-family: inherit;
@@ -20,13 +20,13 @@ export const fileSelectFragment = /*html*/ `
   }
 
   #file-select:hover {
-    color: var(--button-hover-text, #fff);
-    background: var(--button-hover-background, #404040);
+    color: #fff;
+    background: #404040;
   }
 
   #file-select:active {
-    color: var(--button-active-text, #fff);
-    background: var(--button-active-background, #000);
+    color: #fff;
+    background: #000;
   }
   </style>
 

--- a/packages/mux-uploader/src/mux-uploader.ts
+++ b/packages/mux-uploader/src/mux-uploader.ts
@@ -8,12 +8,6 @@ const rootTemplate = document.createElement('template');
 
 rootTemplate.innerHTML = /*html*/ `
 <style>
-  :host {
-    font-family: var(--uploader-font-family, Arial);
-    font-size: var(--uploader-font-size, 16px);
-    background-color: var(--uploader-background-color, inherit);
-  }
-
   input[type="file"] {
     display: none;
   }


### PR DESCRIPTION
This PR removes CSS variables from the Mux Uploader package to simplify the styling and improve the maintainability of the code. Changes include:

#### Changes to `mux-uploader-file-select.ts`

- Removed CSS variables for button background color, border, padding, and border radius in favor of hardcoded values.
- Removed CSS variables for button hover text and background in favor of hardcoded values.
- Removed CSS variables for button active text and background in favor of hardcoded values.

#### Changes to `mux-uploader.ts`

- Removed the `:host` block that contained CSS variables for font family, font size, and background color.
