### PR TITLE
feat(mux-uploader): conditional render based on attributes

### DIFF
--- a/packages/mux-uploader/src/layouts/block.ts
+++ b/packages/mux-uploader/src/layouts/block.ts
@@ -2,18 +2,36 @@ import { document } from '../polyfills';
 
 import '../mux-uploader-file-select';
 import { fileSelectFragment } from '../mux-uploader-file-select';
+import MuxUploaderElement from '../mux-uploader';
 
-export default function blockLayout(nodrop: boolean) {
+interface BlockLayoutOptions {
+  nodrop?: boolean;
+  noprogress?: boolean;
+  nostatus?: boolean;
+  noretry?: boolean;
+}
+
+function conditionalRender(flag: boolean | undefined, component: string): string {
+  return flag ? '' : component;
+}
+
+export default function blockLayout(contextElement: MuxUploaderElement): DocumentFragment {
+  const { nodrop, noprogress, nostatus, noretry } = contextElement;
   const wrapper = nodrop ? 'div' : 'mux-uploader-drop overlay';
+  const progressElements = conditionalRender(
+    noprogress,
+    `
+      <mux-uploader-progress type="percentage"></mux-uploader-progress>
+      <mux-uploader-progress></mux-uploader-progress>
+    `
+  );
+  const statusElement = conditionalRender(nostatus, '<mux-uploader-status></mux-uploader-status>');
+  const retryElement = conditionalRender(noretry, '<mux-uploader-retry></mux-uploader-retry>');
 
   return document.createRange().createContextualFragment(`
-    <style>
-      /* Add your styles here */
-    </style>
-
     <${wrapper}>
-      <mux-uploader-status></mux-uploader-status>
-      <mux-uploader-retry></mux-uploader-retry>
+      ${statusElement}
+      ${retryElement}
 
       <mux-uploader-file-select>
         <slot name="file-select">
@@ -21,8 +39,7 @@ export default function blockLayout(nodrop: boolean) {
         </slot>
       </mux-uploader-file-select>
 
-      <mux-uploader-progress type="percentage"></mux-uploader-progress>
-      <mux-uploader-progress></mux-uploader-progress>
+      ${progressElements}
     </${wrapper}>
   `);
 }

--- a/packages/mux-uploader/src/mux-uploader.ts
+++ b/packages/mux-uploader/src/mux-uploader.ts
@@ -120,7 +120,7 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
   }
 
   static get observedAttributes() {
-    return ['nodrop'];
+    return ['nodrop', 'noprogress', 'nostatus', 'noretry'];
   }
 
   protected get hiddenFileInput() {
@@ -150,12 +150,36 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
     this.toggleAttribute('nodrop', Boolean(value));
   }
 
+  get noprogress(): boolean {
+    return this.hasAttribute('noprogress');
+  }
+
+  set noprogress(value: boolean) {
+    this.toggleAttribute('noprogress', Boolean(value));
+  }
+
+  get nostatus(): boolean {
+    return this.hasAttribute('nostatus');
+  }
+
+  set nostatus(value: boolean) {
+    this.toggleAttribute('nostatus', Boolean(value));
+  }
+
+  get noretry(): boolean {
+    return this.hasAttribute('noretry');
+  }
+
+  set noretry(value: boolean) {
+    this.toggleAttribute('noretry', Boolean(value));
+  }
+
   updateLayout() {
     const oldLayout = this.shadowRoot!.querySelector('mux-uploader-drop, div');
     if (oldLayout) {
       oldLayout.remove();
     }
-    const newLayout = blockLayout(this.nodrop);
+    const newLayout = blockLayout(this);
     this.shadowRoot!.appendChild(newLayout);
   }
 

--- a/packages/mux-uploader/test/uploader.test.js
+++ b/packages/mux-uploader/test/uploader.test.js
@@ -53,6 +53,22 @@ describe('<mux-uploader>', () => {
     assert.isNull(progress, 'mux-uploader-progress is null');
   });
 
+  it('should toggle the noprogress attribute when setting noprogress', async () => {
+    const uploader = await fixture(`<mux-uploader></mux-uploader>`);
+    uploader.noprogress = true;
+    assert.equal(uploader.hasAttribute('noprogress'), true, 'noprogress attr is set');
+
+    let progress = uploader.shadowRoot.querySelector('mux-uploader-progress');
+
+    assert.isNull(progress, 'mux-uploader-progress is null');
+
+    uploader.noprogress = false;
+    progress = uploader.shadowRoot.querySelector('mux-uploader-progress');
+
+    assert.equal(uploader.hasAttribute('noprogress'), false, 'noprogress attr is removed');
+    assert.isNotNull(progress, 'mux-uploader-progress is not null');
+  });
+
   it('removes retry with noretry param', async function () {
     const uploader = await fixture(`<mux-uploader noretry></mux-uploader>`);
     const retry = uploader.shadowRoot.querySelector('mux-uploader-retry');
@@ -60,11 +76,43 @@ describe('<mux-uploader>', () => {
     assert.isNull(retry, 'mux-uploader-retry is null');
   });
 
+  it('should toggle the noretry attribute when setting noretry', async () => {
+    const uploader = await fixture(`<mux-uploader></mux-uploader>`);
+    uploader.noretry = true;
+    assert.equal(uploader.hasAttribute('noretry'), true, 'noretry attr is set');
+
+    let retry = uploader.shadowRoot.querySelector('mux-uploader-retry');
+
+    assert.isNull(retry, 'mux-uploader-retry is null');
+
+    uploader.noretry = false;
+    retry = uploader.shadowRoot.querySelector('mux-uploader-retry');
+
+    assert.equal(uploader.hasAttribute('noretry'), false, 'noretry attr is removed');
+    assert.isNotNull(retry, 'mux-uploader-retry is not null');
+  });
+
   it('removes status with nostatus param', async function () {
     const uploader = await fixture(`<mux-uploader nostatus></mux-uploader>`);
     const status = uploader.shadowRoot.querySelector('mux-uploader-status');
 
     assert.isNull(status, 'mux-uploader-status is null');
+  });
+
+  it('should toggle the nostatus attribute when setting nostatus', async () => {
+    const uploader = await fixture(`<mux-uploader></mux-uploader>`);
+    uploader.nostatus = true;
+    assert.equal(uploader.hasAttribute('nostatus'), true, 'nostatus attr is set');
+
+    let status = uploader.shadowRoot.querySelector('mux-uploader-status');
+
+    assert.isNull(status, 'mux-uploader-status is null');
+
+    uploader.nostatus = false;
+    status = uploader.shadowRoot.querySelector('mux-uploader-status');
+
+    assert.equal(uploader.hasAttribute('nostatus'), false, 'nostatus attr is removed');
+    assert.isNotNull(status, 'mux-uploader-status is not null');
   });
 
   it('does not init without endpoint', async function () {

--- a/packages/mux-uploader/test/uploader.test.js
+++ b/packages/mux-uploader/test/uploader.test.js
@@ -60,13 +60,6 @@ describe('<mux-uploader>', () => {
     assert.isNull(retry, 'mux-uploader-retry is null');
   });
 
-  it('removes retry with noretry param', async function () {
-    const uploader = await fixture(`<mux-uploader noretry></mux-uploader>`);
-    const retry = uploader.shadowRoot.querySelector('mux-uploader-retry');
-
-    assert.isNull(retry, 'mux-uploader-retry is null');
-  });
-
   it('removes status with nostatus param', async function () {
     const uploader = await fixture(`<mux-uploader nostatus></mux-uploader>`);
     const status = uploader.shadowRoot.querySelector('mux-uploader-status');

--- a/packages/mux-uploader/test/uploader.test.js
+++ b/packages/mux-uploader/test/uploader.test.js
@@ -46,6 +46,34 @@ describe('<mux-uploader>', () => {
     assert.isNotNull(drop, 'mux-uploader-drop is not null');
   });
 
+  it('removes progress with noprogress param', async function () {
+    const uploader = await fixture(`<mux-uploader noprogress></mux-uploader>`);
+    const progress = uploader.shadowRoot.querySelector('mux-uploader-progress');
+
+    assert.isNull(progress, 'mux-uploader-progress is null');
+  });
+
+  it('removes retry with noretry param', async function () {
+    const uploader = await fixture(`<mux-uploader noretry></mux-uploader>`);
+    const retry = uploader.shadowRoot.querySelector('mux-uploader-retry');
+
+    assert.isNull(retry, 'mux-uploader-retry is null');
+  });
+
+  it('removes retry with noretry param', async function () {
+    const uploader = await fixture(`<mux-uploader noretry></mux-uploader>`);
+    const retry = uploader.shadowRoot.querySelector('mux-uploader-retry');
+
+    assert.isNull(retry, 'mux-uploader-retry is null');
+  });
+
+  it('removes status with nostatus param', async function () {
+    const uploader = await fixture(`<mux-uploader nostatus></mux-uploader>`);
+    const status = uploader.shadowRoot.querySelector('mux-uploader-status');
+
+    assert.isNull(status, 'mux-uploader-status is null');
+  });
+
   it('does not init without endpoint', async function () {
     const uploader = await fixture(`<mux-uploader></mux-uploader>`);
 


### PR DESCRIPTION
This PR adds support for conditional rendering of `mux-uploader` components, including `nodrop`, `noprogress`, `nostatus`, and `noretry`. By passing the `MuxUploader` element to the `blockLayout` function, users can now choose to hide specific components based on their needs.

Usage:

```html
<mux-uploader nodrop nostatus></mux-uploader>
```

In this example, `<mux-uploader>` will be rendered without the drop area and status components, while keeping the progress and retry components.