### PR TITLE
Player `theme-*` attributes & `themeProps` property

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxPlayerTheme.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayerTheme.tsx
@@ -23,6 +23,7 @@ function MuxPlayerPage() {
         ref={mediaElRef}
         playbackId="vJzD4ayErsL3z5qs0201rKHfffmQOMWSk58J6A7FtECKs"
         theme="microvideo"
+        themeProps={{ controlBarVertical: true, controlBarPlace: 'start start' }}
         // metadata={{
         //   video_id: "video-id-12345",
         //   video_title: "Mad Max: Fury Road Trailer",

--- a/examples/vanilla-ts-esm/public/mux-player-theme.html
+++ b/examples/vanilla-ts-esm/public/mux-player-theme.html
@@ -9,7 +9,7 @@
       defer
       src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
     ></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome@0.19.0/dist/themes/youtube.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome@0.20.0/dist/themes/microvideo.js/+esm"></script>
     <script type="module" src="./dist/mux-player.js"></script>
     <style>
       mux-player {
@@ -41,7 +41,9 @@
     </header>
 
     <mux-player
-      theme="youtube"
+      theme="microvideo"
+      theme-control-bar-vertical
+      theme-control-bar-place="start start"
       stream-type="on-demand"
       playback-id="VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA"
       start-time="1"

--- a/examples/vanilla-ts-esm/public/mux-player-theme.html
+++ b/examples/vanilla-ts-esm/public/mux-player-theme.html
@@ -9,7 +9,7 @@
       defer
       src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
     ></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome@0.20.0/dist/themes/microvideo.js/+esm"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/media-chrome/dist/themes/microvideo.js/+esm"></script>
     <script type="module" src="./dist/mux-player.js"></script>
     <style>
       mux-player {
@@ -46,7 +46,6 @@
       theme-control-bar-place="start start"
       stream-type="on-demand"
       playback-id="VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA"
-      start-time="1"
     ></mux-player>
 
     <a href="../">Browse Elements</a>

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -76,6 +76,7 @@ export type MuxPlayerProps = {
   title?: string;
   tokens?: Tokens;
   theme?: string;
+  themeProps?: { [k: string]: any };
   onAbort?: GenericEventListener<MuxPlayerElementEventMap['abort']>;
   onCanPlay?: GenericEventListener<MuxPlayerElementEventMap['canplay']>;
   onCanPlayThrough?: GenericEventListener<MuxPlayerElementEventMap['canplaythrough']>;
@@ -163,10 +164,12 @@ const usePlayer = (
     playbackId,
     playbackRates,
     currentTime,
+    themeProps,
     ...remainingProps
   } = props;
   useObjectPropEffect('playbackRates', playbackRates, ref);
   useObjectPropEffect('metadata', metadata, ref);
+  useObjectPropEffect('themeProps', themeProps, ref);
   useObjectPropEffect('tokens', tokens, ref);
   useObjectPropEffect('playbackId', playbackId, ref);
   useObjectPropEffect(

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -66,6 +66,25 @@ const PlayerAttributes = {
   THEME: 'theme',
 };
 
+const ThemeAttributeNames = [
+  'audio',
+  'backward-seek-offset',
+  'default-show-remaining-time',
+  'default-showing-captions',
+  'disabled',
+  'exportparts',
+  'forward-seek-offset',
+  'hide-duration',
+  'hotkeys',
+  'nohotkeys',
+  'playbackrates',
+  'stream-type',
+  'style',
+  'target-live-window',
+  'template',
+  'title',
+];
+
 function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
   const props = {
     // Give priority to playbackId derrived asset URL's if playbackId is set.
@@ -327,6 +346,8 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
       if (!attributeName?.startsWith('theme-')) return;
 
       const themeAttrName = attributeName.replace(/^theme-/, '');
+      if (ThemeAttributeNames.includes(themeAttrName)) return;
+
       const value = this.getAttribute(attributeName);
       if (value != null) {
         this.mediaTheme?.setAttribute(themeAttrName, value);
@@ -683,7 +704,7 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
 
   /**
    * Get the theme attributes in a plain object (camelCase keys).
-   * This includes already defined attributes. e.g. streamType, disabled, etc.
+   * This doesn't include already defined attributes. e.g. streamType, disabled, etc.
    */
   get themeProps() {
     const theme = this.mediaTheme;
@@ -692,6 +713,8 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
     const props: Record<string, any> = {};
 
     for (const name of theme.getAttributeNames()) {
+      if (ThemeAttributeNames.includes(name)) continue;
+
       const value: string | boolean | null = theme.getAttribute(name);
       props[camelCase(name)] = value === '' ? true : value;
     }
@@ -705,8 +728,12 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
   set themeProps(props) {
     this.#init();
 
-    for (const name in props) {
-      const value: string | boolean | null | undefined = props[name];
+    const themeProps = { ...this.themeProps, ...props };
+
+    for (const name in themeProps) {
+      if (ThemeAttributeNames.includes(name)) continue;
+
+      const value: string | boolean | null | undefined = props?.[name];
 
       if (typeof value === 'boolean' || value == null) {
         this.mediaTheme?.toggleAttribute(kebabCase(name), Boolean(value));

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -146,6 +146,19 @@ function getHideDuration(el: MuxPlayerElement) {
   );
 }
 
+function getMetadataFromAttrs(el: MuxPlayerElement) {
+  return el
+    .getAttributeNames()
+    .filter((attrName) => attrName.startsWith('metadata-'))
+    .reduce((currAttrs, attrName) => {
+      const value = el.getAttribute(attrName);
+      if (value !== null) {
+        currAttrs[attrName.replace(/^metadata-/, '').replace(/-/g, '_')] = value;
+      }
+      return currAttrs;
+    }, {} as { [key: string]: string });
+}
+
 const MuxVideoAttributeNames = Object.values(MuxVideoAttributes);
 const VideoAttributeNames = Object.values(VideoAttributes);
 const PlayerAttributeNames = Object.values(PlayerAttributes);
@@ -290,22 +303,10 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
     return this.mediaTheme?.shadowRoot?.querySelector('media-controller');
   }
 
-  get metadataFromAttrs() {
-    return this.getAttributeNames()
-      .filter((attrName) => attrName.startsWith('metadata-'))
-      .reduce((currAttrs, attrName) => {
-        const value = this.getAttribute(attrName);
-        if (value !== null) {
-          currAttrs[attrName.replace(/^metadata-/, '').replace(/-/g, '_')] = value;
-        }
-        return currAttrs;
-      }, {} as { [key: string]: string });
-  }
-
   connectedCallback() {
     const muxVideo = this.shadowRoot?.querySelector('mux-video') as MuxVideoElement;
     if (muxVideo) {
-      muxVideo.metadata = this.metadataFromAttrs;
+      muxVideo.metadata = getMetadataFromAttrs(this);
     }
   }
 
@@ -1166,7 +1167,7 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
       logger.error('underlying media element missing when trying to set metadata. metadata will not be set.');
       return;
     }
-    this.media.metadata = { ...this.metadataFromAttrs, ...val };
+    this.media.metadata = { ...getMetadataFromAttrs(this), ...val };
   }
 
   async addCuePoints<T = any>(cuePoints: { time: number; value: T }[]) {

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -269,6 +269,7 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
 
     initVideoApi(this);
 
+    this.#setUpThemeAttributes();
     this.#setUpErrors();
     this.#setUpCaptionsButton();
     this.#userInactive = this.mediaController?.hasAttribute('user-inactive') ?? true;
@@ -317,6 +318,31 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
 
   #render(props: Record<string, any> = {}) {
     render(template(getProps(this, { ...this.#state, ...props })), this.shadowRoot as Node);
+  }
+
+  #setUpThemeAttributes() {
+    // Forward `theme-` prefixed attributes to the theme.
+    // e.g. `theme-control-bar-vertical` for the Micro theme.
+    const setThemeAttribute = (attributeName: string | null) => {
+      if (!attributeName?.startsWith('theme-')) return;
+
+      const themeAttrName = attributeName.replace(/^theme-/, '');
+      const value = this.getAttribute(attributeName);
+      if (value != null) {
+        this.mediaTheme?.setAttribute(themeAttrName, value);
+      } else {
+        this.mediaTheme?.removeAttribute(themeAttrName);
+      }
+    };
+
+    const observer = new MutationObserver((mutationList) => {
+      for (const { attributeName } of mutationList) {
+        setThemeAttribute(attributeName);
+      }
+    });
+
+    observer.observe(this, { attributes: true });
+    this.getAttributeNames().forEach(setThemeAttribute);
   }
 
   #setUpErrors() {

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -37,6 +37,9 @@ const getHotKeys = (props: MuxTemplateProps) => {
   return hotKeys;
 };
 
+// Warning: remember to update `ThemeAttributeNames` in index.ts
+// if you add or remove attributes in <media-theme>.
+
 export const content = (props: MuxTemplateProps) => html`
   <media-theme
     template="${props.themeTemplate ?? muxTemplate.content.children[0]}"

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -348,6 +348,42 @@ describe('<mux-player>', () => {
     assert.include(actual, expected, 'has expected metadata entries from attrs');
   });
 
+  it('should forward theme attributes to the theme element', async () => {
+    const player = await fixture(`<mux-player
+      stream-type="on-demand"
+      theme-control-bar-vertical
+      theme-control-bar-place="self end"
+    ></mux-player>`);
+
+    assert.equal(player.mediaTheme.attributes['control-bar-vertical'].value, '');
+    assert.equal(player.mediaTheme.attributes['control-bar-place'].value, 'self end');
+  });
+
+  it('should forward themeProps to the theme element', async () => {
+    const player = await fixture(`<mux-player
+      stream-type="on-demand"
+      theme-control-bar-vertical
+      theme-control-bar-place="self end"
+    ></mux-player>`);
+
+    assert.deepEqual(player.themeProps, {
+      controlBarVertical: true,
+      controlBarPlace: 'self end',
+    });
+
+    player.themeProps = {};
+
+    assert.deepEqual(player.themeProps, {});
+
+    player.themeProps = {
+      controlBarPlace: 'self end',
+    };
+
+    assert.deepEqual(player.themeProps, {
+      controlBarPlace: 'self end',
+    });
+  });
+
   it('muted attribute behaves like expected', async function () {
     const player = await fixture(`<mux-player
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"


### PR DESCRIPTION
adds `theme-` prefixed attributes support for forwarding to the underlying `media-theme` element.