### PR TITLE
feat(mux-uploader): support max file size

### DIFF
--- a/packages/mux-uploader/src/mux-uploader.ts
+++ b/packages/mux-uploader/src/mux-uploader.ts
@@ -13,7 +13,7 @@ rootTemplate.innerHTML = /*html*/ `
   }
 </style>
 
-<input id="hidden-file-input" type="file" />
+<input id="hidden-file-input" type="file" accept="video/*" />
 <mux-uploader-sr-text></mux-uploader-sr-text>
 `;
 

--- a/packages/mux-uploader/src/mux-uploader.ts
+++ b/packages/mux-uploader/src/mux-uploader.ts
@@ -114,7 +114,7 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
   }
 
   static get observedAttributes() {
-    return ['no-drop', 'no-progress', 'no-status', 'no-retry'];
+    return ['no-drop', 'no-progress', 'no-status', 'no-retry', 'max-file-size'];
   }
 
   protected get hiddenFileInput() {
@@ -190,6 +190,19 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
     }
   }
 
+  get maxFileSize(): number | undefined {
+    const maxFileSize = this.getAttribute('max-file-size');
+    return maxFileSize !== null ? parseInt(maxFileSize) : undefined;
+  }
+
+  set maxFileSize(value: number | undefined) {
+    if (value) {
+      this.setAttribute('max-file-size', value.toString());
+    } else {
+      this.removeAttribute('max-file-size');
+    }
+  }
+
   resetState() {
     this.removeAttribute('upload-error');
     this.removeAttribute('upload-in-progress');
@@ -219,6 +232,11 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
       endpoint,
       dynamicChunkSize,
       file: evt.detail,
+      ...(this.maxFileSize !== undefined
+        ? {
+            maxFileSize: this.maxFileSize,
+          }
+        : {}),
     });
 
     this.dispatchEvent(new CustomEvent('uploadstart', { detail: { file: upload.file, chunkSize: upload.chunkSize } }));

--- a/packages/mux-uploader/test/uploader.test.js
+++ b/packages/mux-uploader/test/uploader.test.js
@@ -166,4 +166,14 @@ describe('<mux-uploader>', () => {
 
     await oneEvent(uploader, 'success');
   });
+
+  it('should set and get maxFileSize attribute correctly', async () => {
+    const uploader = await fixture(`<mux-uploader></mux-uploader>`);
+
+    uploader.maxFileSize = 1000000;
+    assert.equal(uploader.maxFileSize, 1000000, 'maxFileSize matches');
+
+    uploader.removeAttribute('max-file-size');
+    assert.equal(uploader.maxFileSize, undefined);
+  });
 });


### PR DESCRIPTION
This PR adds support for the `maxFileSize` feature provided by UpChunk. We introduce a new attribute called `max-file-size` for the `mux-uploader` custom element. This attribute allows users to set a maximum file size limit for the uploaded files. When the `max-file-size` attribute is set, its value will be passed down to UpChunk's `createUpload` method as the `maxFileSize` property.

### Changes

- Added a `maxFileSize` getter and setter to the `MuxUploaderElement` class
- Updated the `handleUpload` method to conditionally include the `maxFileSize` property in the options object passed to UpChunk's `createUpload` method

### Benefits

By supporting UpChunk's `maxFileSize` feature, developers can now easily enforce file size restrictions directly from the `mux-uploader` custom element, improving the user experience and reducing the need for additional client-side validation.
