### PR TITLE
Correct package dependencies

### DIFF
--- a/examples/nextjs-with-typescript/package.json
+++ b/examples/nextjs-with-typescript/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@mux/assets": ">=0.1.0",
     "@mux/blurhash": "^0.1.1",
+    "@mux/mux-audio": ">=0.2.0",
     "@mux/mux-audio-react": ">=0.2.0",
     "@mux/mux-player": ">=1.0.0-beta.0",
     "@mux/mux-player-react": ">=1.0.0-beta.0",

--- a/packages/mux-audio-react/package.json
+++ b/packages/mux-audio-react/package.json
@@ -57,6 +57,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
+    "@types/prop-types": "^15.7.5",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "@typescript-eslint/eslint-plugin": "^5.48.0",

--- a/packages/mux-elements-codemod/package.json
+++ b/packages/mux-elements-codemod/package.json
@@ -29,6 +29,7 @@
     "shelljs": "^0.8.5"
   },
   "devDependencies": {
+    "@types/minimist": "^1.2.2",
     "@types/shelljs": "^0.8.11",
     "@typescript-eslint/eslint-plugin": "^5.48.0",
     "@typescript-eslint/parser": "^5.48.0",

--- a/packages/mux-player-react/package.json
+++ b/packages/mux-player-react/package.json
@@ -70,6 +70,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
+    "@types/prop-types": "^15.7.5",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "downlevel-dts": "^0.11.0",

--- a/packages/mux-uploader-react/package.json
+++ b/packages/mux-uploader-react/package.json
@@ -57,6 +57,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
+    "@types/prop-types": "^15.7.5",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "downlevel-dts": "^0.11.0",

--- a/packages/mux-uploader/package.json
+++ b/packages/mux-uploader/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@mux/test-esm-exports": "0.1.0",
+    "@open-wc/testing": "^3.0.3",
     "@web/dev-server-import-maps": "^0.0.6",
     "copyfiles": "^2.4.1",
     "downlevel-dts": "^0.11.0",

--- a/packages/mux-video-react/package.json
+++ b/packages/mux-video-react/package.json
@@ -57,6 +57,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
+    "@types/prop-types": "^15.7.5",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "@typescript-eslint/eslint-plugin": "^5.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3652,7 +3652,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/minimist@^1.2.0":
+"@types/minimist@^1.2.0", "@types/minimist@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
@@ -3687,7 +3687,7 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
   integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
 
-"@types/prop-types@*":
+"@types/prop-types@*", "@types/prop-types@^15.7.5":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==


### PR DESCRIPTION
This PR adds all transitive dependencies. As you can select pnpm mode in node linker config (which introduced in yarn v3), I recommend that you update to yarn v3 whenever possible and use that mode. It's the only non-pnpm package manager option that can prevent problems with transitive dependencies out of the box. And it's much more stable than pnpm.

There is already a not bad explanation, so just quote[^1] that:

> ### Why not NPM or YARN (v1)?
> NPM uses flattened node_modules. The flattened dependency results in many issues, such as:
The algorithm for flattening a dependency tree is complex
 Some of the packages have to be duplicated inside another project's node_modules folder.
Modules have access to packages they do not depend on
 Let's explain this with a basic example. One of your projects needs an express module, and express has a dependency package named "debug".
Your code can require('debug'), even if you do not depend on it explicitly in the package.json file.

[^1]: https://dev.to/ayoub3bidi/lets-settle-things-out-2-npm-vs-yarn-vs-pnpm-5e04