### PR TITLE
fix: force theme to be ltr direction

### DIFF
--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -38,6 +38,7 @@ a {
 media-theme {
   width: 100%;
   height: 100%;
+  direction: ltr;
 }
 
 ::part(top),


### PR DESCRIPTION
if the player is set to rtl direction, some functionality breaks, so, we want to force it to always be ltr

If we set it on the :host, then if someone sets direction on mux-player itself, it'll get overridden. So, instead, to force it to always be ltr, we set it on the media-theme element itself.