### PR TITLE
fix: use webkit pseudo element for captions movement, where available

### DIFF
--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -460,8 +460,10 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
   #setUpCaptionsMovement() {
     // Any Safari
     const isSafari = /.*Version\/.*Safari\/.*/.test(navigator.userAgent);
+    const isFirefox = /Firefox/i.test(navigator.userAgent);
 
-    if (isSafari) return;
+    // skip if not firefox
+    if (!isFirefox) return;
 
     let selectedTrack: TextTrack;
     const cuesmap = new WeakMap();

--- a/packages/mux-player/src/media-theme-mux.html
+++ b/packages/mux-player/src/media-theme-mux.html
@@ -73,7 +73,7 @@
     media-controller ::slotted([slot='media']) {
       --media-webkit-text-track-transition: transform 0.433s ease-out 0.3s;
     }
-    media-controller:is(:not([user-inactive])) ::slotted([slot='media']) {
+    media-controller:is([media-paused],:not([user-inactive])) ::slotted([slot='media']) {
       /* 42px is the height of the control bar and progress bar
        * with an additional 5px as a buffer, to get 47px */
       --media-webkit-text-track-transform: translateY(-47px);

--- a/packages/mux-player/src/media-theme-mux.html
+++ b/packages/mux-player/src/media-theme-mux.html
@@ -71,11 +71,13 @@
     /* 0.433s is the transition duration for VTT Regions.
      * Borrowed here, so the captions don't move too fast. */
     media-controller ::slotted([slot='media']) {
-      --media-webkit-text-track-transform: transform 0.433s 0.15s;
+      --media-webkit-text-track-transition: transform 0.433s ease-out 0.3s;
     }
-    media-controller:is([media-paused],:not([user-inactive])) ::slotted([slot='media']) {
-      --media-webkit-text-track-transform: translateY(-3.25em);
-      --media-webkit-text-track-transition: transform 0.433s;
+    media-controller:is(:not([user-inactive])) ::slotted([slot='media']) {
+      /* 42px is the height of the control bar and progress bar
+       * with an additional 5px as a buffer, to get 47px */
+      --media-webkit-text-track-transform: translateY(-47px);
+      --media-webkit-text-track-transition: transform 0.15s ease;
     }
 
     media-captions-selectmenu {

--- a/packages/mux-player/src/media-theme-mux.html
+++ b/packages/mux-player/src/media-theme-mux.html
@@ -67,6 +67,17 @@
       --captions-selectmenu: none;
     }
 
+
+    /* 0.433s is the transition duration for VTT Regions.
+     * Borrowed here, so the captions don't move too fast. */
+    media-controller ::slotted([slot='media']) {
+      --media-webkit-text-track-transform: transform 0.433s 0.15s;
+    }
+    media-controller:is([media-paused],:not([user-inactive])) ::slotted([slot='media']) {
+      --media-webkit-text-track-transform: translateY(-3.25em);
+      --media-webkit-text-track-transition: transform 0.433s;
+    }
+
     media-captions-selectmenu {
       --media-listbox-background: var(--_secondary-color);
       --media-listbox-selected-background: rgba(255, 255, 255, 0.28);

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -2,6 +2,7 @@ import { fixture, assert, aTimeout, waitUntil, oneEvent } from '@open-wc/testing
 import '../src/index.ts';
 
 const isSafari = /.*Version\/.*Safari\/.*/.test(navigator.userAgent);
+const isFirefox = /Firefox/i.test(navigator.userAgent);
 
 // Media Chrome uses a ResizeObserver which ends up throwing in Firefox and Safari in some cases
 // so we want to catch those. It is supposedly not a blocker if this error is thrown.
@@ -956,8 +957,8 @@ describe('<mux-player> seek to live behaviors', function () {
   });
 });
 
-// skip these cue shifting tests as its disabled in Safari
-(isSafari ? describe.skip : describe)('<mux-player> should move cues up', function () {
+// skip these cue shifting tests except in Firefox
+(isFirefox ? describe : describe.skip)('<mux-player> should move cues up', function () {
   this.timeout(12000);
 
   it('when user the user active', async function () {

--- a/packages/mux-video/src/CustomVideoElement.js
+++ b/packages/mux-video/src/CustomVideoElement.js
@@ -63,6 +63,11 @@ template.innerHTML = `
     object-fit: var(--media-object-fit, contain);
     object-position: var(--media-object-position, 50% 50%);
   }
+
+  video::-webkit-media-text-track-container {
+    transform: var(--media-webkit-text-track-transform);
+    transition: var(--media-webkit-text-track-transform);
+  }
 </style>
 <video is="castable-video" part="video" crossorigin></video>
 <slot></slot>

--- a/packages/mux-video/src/CustomVideoElement.js
+++ b/packages/mux-video/src/CustomVideoElement.js
@@ -66,7 +66,7 @@ template.innerHTML = `
 
   video::-webkit-media-text-track-container {
     transform: var(--media-webkit-text-track-transform);
-    transition: var(--media-webkit-text-track-transform);
+    transition: var(--media-webkit-text-track-transition);
   }
 </style>
 <video is="castable-video" part="video" crossorigin></video>


### PR DESCRIPTION
While a single solution for all browsers is nice, we've had some reports of captions briefly showing up at the top of the video display area, which is unexpected. Therefore, we should switch back to the pseudo element technique for Chrome and Safari while keeping the programmatic line technique in use for Firefox, since it doesn't have anything else available.

This uses a transform on the text track container pseudo element and will transition it at 0.433s so that the transition is nice and smooth. This number was borrowed from the WebVTT specification. Also, when hiding, add a slight delay.

Fixes #660.