### PR TITLE
fix(mux-uploader): Don't reset state when endpoint is changed.

### DIFF
--- a/packages/mux-uploader/src/mux-uploader.ts
+++ b/packages/mux-uploader/src/mux-uploader.ts
@@ -132,7 +132,6 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
     } else if (value == undefined) {
       this.removeAttribute('endpoint');
     }
-    this.dispatchEvent(new CustomEvent('reset'));
     this._endpoint = value;
   }
 

--- a/packages/mux-uploader/test/uploader.test.js
+++ b/packages/mux-uploader/test/uploader.test.js
@@ -1,5 +1,5 @@
 import { server } from './utils/server';
-import { fixture, assert, oneEvent, aTimeout } from '@open-wc/testing';
+import { fixture, assert, oneEvent, aTimeout, waitUntil } from '@open-wc/testing';
 import '../src/index.ts';
 
 describe('<mux-uploader>', () => {
@@ -165,6 +165,72 @@ describe('<mux-uploader>', () => {
     assert.equal(server.lastRequest.url, 'https://mock-upload-endpoint.com', 'request url matches');
 
     await oneEvent(uploader, 'success');
+  });
+
+  it('completes a mock upload with an asynchronous endpoint function', async function () {
+    const endpointUrl = 'https://mock-upload-endpoint-2.com';
+    server.respondWith('PUT', endpointUrl, [200, { 'Content-Type': 'application/json' }, '{success: true}']);
+
+    const uploader = await fixture(`<mux-uploader></mux-uploader>`);
+    const endpoint = () => Promise.resolve(endpointUrl);
+    uploader.endpoint = endpoint;
+
+    assert.equal(uploader.endpoint, endpoint);
+    Promise.resolve(
+      uploader.dispatchEvent(
+        new CustomEvent('file-ready', {
+          composed: true,
+          bubbles: true,
+          detail: file,
+        })
+      )
+    );
+
+    // It should be in progress and not errored
+    await waitUntil(() => uploader.hasAttribute('upload-in-progress'), 'upload should be in progress');
+    await waitUntil(() => !uploader.hasAttribute('upload-error'), 'upload should not error');
+    await aTimeout(100);
+    server.respond();
+    assert.equal(server.lastRequest.url, endpointUrl, 'request url matches');
+    // NOTE: This didn't work bc the <mux-uploader>'s "upload-in-progress"/"upload-complete" attrs aren't actually updated, only <mux-uploader-progress>
+    // await waitUntil(() => uploader.hasAttribute('upload-complete') && !uploader.hasAttribute('upload-in-progress'));
+    const progressEl = uploader.shadowRoot.querySelector('mux-uploader-progress');
+    // Since we have a chain of awaits, instead of checking for a success event that may have been dispatched between awaits,
+    // we're instead just waiting for expected state changes.
+    await waitUntil(
+      () => progressEl.hasAttribute('upload-complete') && !progressEl.hasAttribute('upload-in-progress'),
+      'upload should eventually complete'
+    );
+  });
+
+  it('should not reset state based on updating the endpoint (since it will not impact the current upload)', async function () {
+    const endpointUrl = 'https://mock-upload-endpoint-2.com';
+    server.respondWith('PUT', endpointUrl, [200, { 'Content-Type': 'application/json' }, '{success: true}']);
+
+    const uploader = await fixture(`<mux-uploader></mux-uploader>`);
+    const endpoint = () => Promise.resolve(endpointUrl);
+    uploader.endpoint = endpoint;
+
+    assert.equal(uploader.endpoint, endpoint);
+    Promise.resolve(
+      uploader.dispatchEvent(
+        new CustomEvent('file-ready', {
+          composed: true,
+          bubbles: true,
+          detail: file,
+        })
+      )
+    );
+
+    // It should be in progress and not errored
+    await waitUntil(() => uploader.hasAttribute('upload-in-progress'), 'upload should be in progress');
+    await waitUntil(() => !uploader.hasAttribute('upload-error'), 'upload should not error');
+    const endpoint2 = () => Promise.resolve(endpointUrl);
+    uploader.endpoint = endpoint2;
+
+    // It should *still* be in progress and not errored
+    await waitUntil(() => uploader.hasAttribute('upload-in-progress'), 'upload should be in progress');
+    await waitUntil(() => !uploader.hasAttribute('upload-error'), 'upload should not error');
   });
 
   it('should set and get maxFileSize attribute correctly', async () => {


### PR DESCRIPTION
We were previously resetting the state (attributes) whenever we set the endpoint. Since changing the endpoint does not impact the current upload, we should only (currently) reset the state based on retries. This is especially relevant when using async functions for our endpoint value, since they must (unnecessarily) be referentially identical (e.g.In React, the endpoint must have a stable reference, unnecessarily requiring `useCallback` to avoid unintentionally resetting mux-uploader state attributes based on a re-render.).