### PR TITLE
chore(mux-uploader): Reflect state across multiple components

### DIFF
--- a/packages/mux-uploader/src/mux-uploader-drop.ts
+++ b/packages/mux-uploader/src/mux-uploader-drop.ts
@@ -105,6 +105,26 @@ class MuxUploaderDropElement extends globalThis.HTMLElement {
         opts
       );
 
+      this.#uploaderEl.addEventListener('uploadstart', () => this.setAttribute('upload-in-progress', ''), opts);
+
+      this.#uploaderEl.addEventListener(
+        'success',
+        () => {
+          this.removeAttribute('upload-in-progress');
+          this.setAttribute('upload-complete', '');
+        },
+        opts
+      );
+
+      this.#uploaderEl.addEventListener(
+        'reset',
+        () => {
+          this.removeAttribute('upload-in-progress');
+          this.removeAttribute('upload-complete');
+        },
+        opts
+      );
+
       this.setupDragEvents(opts);
     }
   }

--- a/packages/mux-uploader/src/mux-uploader-file-select.ts
+++ b/packages/mux-uploader/src/mux-uploader-file-select.ts
@@ -89,6 +89,17 @@ class MuxUploaderFileSelectElement extends globalThis.HTMLElement {
         opts
       );
 
+      this.#uploaderEl.addEventListener('uploadstart', () => this.setAttribute('upload-in-progress', ''), opts);
+
+      this.#uploaderEl.addEventListener(
+        'success',
+        () => {
+          this.removeAttribute('upload-in-progress');
+          this.setAttribute('upload-complete', '');
+        },
+        opts
+      );
+
       this.#uploaderEl.addEventListener(
         'reset',
         () => {

--- a/packages/mux-uploader/src/mux-uploader.ts
+++ b/packages/mux-uploader/src/mux-uploader.ts
@@ -210,6 +210,7 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
   resetState() {
     this.removeAttribute('upload-error');
     this.removeAttribute('upload-in-progress');
+    this.removeAttribute('upload-complete');
     // Reset file to ensure change/input events will fire, even if selecting the same file (CJP).
     this.hiddenFileInput.value = '';
   }
@@ -263,6 +264,9 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
       });
 
       upload.on('success', (event) => {
+        this.removeAttribute('upload-in-progress');
+        this.setAttribute('upload-complete', '');
+
         this.dispatchEvent(new CustomEvent('success', event));
       });
     } catch (err) {

--- a/packages/mux-uploader/test/uploader-drop.test.js
+++ b/packages/mux-uploader/test/uploader-drop.test.js
@@ -56,5 +56,6 @@ describe('<mux-uploader-drop>', () => {
 
     const { detail } = await oneEvent(uploader, 'file-ready');
     assert.equal(detail, file, 'file matches');
+    assert.equal(uploader.hasAttribute('upload-in-progress'), true, 'upload-in-progress attr is set');
   });
 });

--- a/packages/mux-uploader/test/uploader.test.js
+++ b/packages/mux-uploader/test/uploader.test.js
@@ -165,6 +165,8 @@ describe('<mux-uploader>', () => {
     assert.equal(server.lastRequest.url, 'https://mock-upload-endpoint.com', 'request url matches');
 
     await oneEvent(uploader, 'success');
+    assert.equal(uploader.hasAttribute('upload-in-progress'), false, 'upload-in-progress attr is not set');
+    assert.equal(uploader.hasAttribute('upload-complete'), true, 'upload-complete attr is set');
   });
 
   it('completes a mock upload with an asynchronous endpoint function', async function () {


### PR DESCRIPTION
This allows for additional styles to be applied on more components based on the current upload state of the selected file.