### PR TITLE
Fix/stream info for mp4

### DIFF
--- a/packages/mux-video/test/index.test.js
+++ b/packages/mux-video/test/index.test.js
@@ -1,4 +1,4 @@
-import { fixture, assert, aTimeout, oneEvent } from '@open-wc/testing';
+import { fixture, assert, aTimeout, oneEvent, waitUntil } from '@open-wc/testing';
 import MuxVideoElement, { VideoEvents } from '../src/index.ts';
 
 describe('<mux-video>', () => {
@@ -223,6 +223,45 @@ describe('<mux-video>', () => {
       currentPdt.getTime() - player.currentTime * 1000,
       'currentPdt should be ~60 seconds greater than getStartDate'
     );
+  });
+
+  describe('Feature: mp4 playback', async () => {
+    it('supports mp4 src', async () => {
+      const src = 'https://stream.mux.com/a4nOgmxGWg6gULfcBbAa00gXyfcwPnAFldF8RdsNyk8M/low.mp4';
+      let muxVideoEl;
+      try {
+        muxVideoEl = await fixture(`<mux-video
+          src="${src}"
+          preload="auto"
+          autoplay
+        ></mux-video>`);
+      } catch (err) {
+        assert.fail(`mux-video threw an error on instantiating with an mp4 src, ${err}`);
+      }
+      waitUntil(() => !muxVideoEl.paused, 'playback should begin for mp4');
+    });
+
+    it('exposes extended media element stream info for mp4s', async () => {
+      const src = 'https://stream.mux.com/a4nOgmxGWg6gULfcBbAa00gXyfcwPnAFldF8RdsNyk8M/low.mp4';
+      let muxVideoEl;
+      try {
+        muxVideoEl = await fixture(`<mux-video
+          src="${src}"
+          autoplay
+        ></mux-video>`);
+      } catch (err) {
+        assert.fail(`mux-video threw an error on instantiating with an mp4 src, ${err}`);
+      }
+      waitUntil(() => muxVideoEl.streamType, 'should have a streamType of on-demand');
+      waitUntil(
+        () => Number.isNaN(muxVideoEl.targetLiveWindow),
+        'should have a targetLiveWindow of NaN because mp4s are always on-demand'
+      );
+      waitUntil(
+        () => Number.isNaN(muxVideoEl.liveEdgeStart),
+        'should have a liveEdgeStart of NaN because mp4s are always on-demand'
+      );
+    });
   });
 
   describe('Feature: cuePoints', async () => {

--- a/packages/playback-core/test/util.test.js
+++ b/packages/playback-core/test/util.test.js
@@ -1,0 +1,56 @@
+import { assert } from '@open-wc/testing';
+import { ExtensionMimeTypeMap, MimeTypeShorthandMap } from '../src';
+import { getType } from '../src/util';
+
+describe('Module: util', () => {
+  describe('getType', () => {
+    it('should infer m3u8 from .m3u8 src extension', () => {
+      const extension = 'm3u8';
+      const expected = ExtensionMimeTypeMap.M3U8;
+      const actual = getType({ src: `http://foo.com/bar.${extension}` });
+      assert.equal(actual, expected);
+    });
+
+    it('should infer mp4 from .mp4 src extension', () => {
+      const extension = 'mp4';
+      const expected = ExtensionMimeTypeMap.MP4;
+      const actual = getType({ src: `http://foo.com/bar.${extension}` });
+      assert.equal(actual, expected);
+    });
+
+    it('should infer m3u8 from .M3U8 src extension', () => {
+      const extension = 'm3u8';
+      const expected = ExtensionMimeTypeMap.M3U8;
+      const actual = getType({ src: `http://foo.com/bar.${extension.toUpperCase()}` });
+      assert.equal(actual, expected);
+    });
+
+    it('should infer mp4 from .MP4 src extension', () => {
+      const extension = 'mp4';
+      const expected = ExtensionMimeTypeMap.MP4;
+      const actual = getType({ src: `http://foo.com/bar.${extension.toUpperCase()}` });
+      assert.equal(actual, expected);
+    });
+
+    it('should respect explicit type even with .m3u8 src extension', () => {
+      const extension = 'm3u8';
+      const expected = ExtensionMimeTypeMap.MP4;
+      const actual = getType({ src: `http://foo.com/bar.${extension}`, type: ExtensionMimeTypeMap.MP4 });
+      assert.equal(actual, expected);
+    });
+
+    it('should respect explicit type even with .mp4 src extension', () => {
+      const extension = 'mp4';
+      const expected = ExtensionMimeTypeMap.M3U8;
+      const actual = getType({ src: `http://foo.com/bar.${extension}`, type: ExtensionMimeTypeMap.M3U8 });
+      assert.equal(actual, expected);
+    });
+
+    it('should support hls shorthand type even with .mp4 src extension', () => {
+      const extension = 'mp4';
+      const expected = ExtensionMimeTypeMap.M3U8;
+      const actual = getType({ src: `http://foo.com/bar.${extension}`, type: MimeTypeShorthandMap.HLS });
+      assert.equal(actual, expected);
+    });
+  });
+});


### PR DESCRIPTION
Also adds some tests for better regression testing and footprint.
Exports the `muxMediaState` map for better test side effect cleanup (NOTE: Should probably apply this more generally to test beforeEach/afterEach as a followup).