### PR TITLE
fix(playback-core): Switch back to using the unminified hls.js module…

### DIFF
--- a/packages/playback-core/src/hls.ts
+++ b/packages/playback-core/src/hls.ts
@@ -1,9 +1,10 @@
-// @ts-ignore
-import HlsMin from 'hls.js/dist/hls.min.js';
+import Hls from 'hls.js';
+// // @ts-ignore
+// import HlsMin from 'hls.js/dist/hls.min.js';
 import type HlsClassType from 'hls.js';
 
-type Hls = typeof HlsClassType & HlsClassType;
-const Hls: Hls = HlsMin as unknown as Hls;
+// type Hls = typeof HlsClassType & HlsClassType;
+// const Hls: Hls = HlsMin as unknown as Hls;
 
 export default Hls;
 export type HlsInterface = HlsClassType;

--- a/packages/playback-core/src/hls.ts
+++ b/packages/playback-core/src/hls.ts
@@ -1,10 +1,4 @@
 import Hls from 'hls.js';
-// // @ts-ignore
-// import HlsMin from 'hls.js/dist/hls.min.js';
 import type HlsClassType from 'hls.js';
-
-// type Hls = typeof HlsClassType & HlsClassType;
-// const Hls: Hls = HlsMin as unknown as Hls;
-
 export default Hls;
 export type HlsInterface = HlsClassType;


### PR DESCRIPTION
…, since this appears to cause edge case issues with initial times after ts segment transmuxing.

To test Next.js usage:
- confirm playbackId `8xhTU2GpKuskv1eCx8rdp3PodlGb6dABCf27f4BsmW8` does not continually load the 0th segment before playback
- confirm that playback begins at time 0
- confirm that you can seek back to time 0 after playback has begun

**NOTE**: We originally used the minified version of hls.js due to issues with svelte-kit and Vue minified builds, with a root cause of how its web worker was integrated. This appears to be resolved since hls.js has migrated its build setup to rollup. Confirmed locally that there were no issues with svelte-kit, but make sure to do additional smoke testing for our Vue and Svelte apps before any approval. For reference, see:

- https://github.com/muxinc/elements/issues/541
- https://github.com/video-dev/hls.js/issues/5107
