### PR TITLE
fix(mux-video-react): Don't spread streamType to video to avoid React…

### DIFF
--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -24,7 +24,7 @@ const playerSoftwareVersion = getPlayerVersion();
 const playerSoftwareName = 'mux-video-react';
 
 const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>((props, ref) => {
-  const { playbackId, src: outerSrc, children, autoPlay, preload, ...restProps } = props;
+  const { playbackId, src: outerSrc, children, autoPlay, preload, streamType, ...restProps } = props;
 
   const [playerInitTime] = useState(generatePlayerInitTime());
   const [src, setSrc] = useState<MuxMediaProps['src']>(toMuxVideoURL(playbackId) ?? outerSrc);


### PR DESCRIPTION
… warnings.

fixes #602 