### PR TITLE
fix(mux-player): Only match theme by id if element is a template.

### DIFF
--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -153,7 +153,10 @@ function getThemeTemplate(el: MuxPlayerElement) {
   if (themeName) {
     // @ts-ignore
     const templateElement = el.getRootNode()?.getElementById?.(themeName);
-    if (templateElement) return templateElement;
+    // NOTE: Since folks may unknowingly use matching ids for elements other than their theme
+    // (intending to use path two for template identification, below), make sure the matching
+    // element is, in fact, an HTMLTemplateElement (CJP)
+    if (templateElement && templateElement instanceof HTMLTemplateElement) return templateElement;
 
     if (!themeName.startsWith('media-theme-')) {
       themeName = `media-theme-${themeName}`;


### PR DESCRIPTION
Confirmed locally on both next app (theme page) and vanilla by adding a div with a corresponding id. Since these are valid use cases for themes and since the error scenario is fairly impenetrable, this feels like a light lift devex improvement imo.