### PR TITLE
fix: types allow CSS vars in React player style

### DIFF
--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -17,6 +17,11 @@ interface GenericEventListener<T extends Event = CustomEvent> {
   (evt: T): void;
 }
 
+export interface MuxPlayerCSSProperties extends CSSProperties {
+  // Allow any CSS Custom Properties
+  [index: `--${string}`]: any;
+}
+
 export type MuxPlayerRefAttributes = MuxPlayerElement;
 type VideoApiAttributes = {
   currentTime: number;
@@ -31,7 +36,7 @@ type VideoApiAttributes = {
   autoPlay: boolean | string;
   loop: boolean;
   muted: boolean;
-  style: CSSProperties;
+  style: MuxPlayerCSSProperties;
 };
 
 type MuxMediaPropTypes = {


### PR DESCRIPTION
![SCR-20230809-gq9](https://github.com/muxinc/elements/assets/360826/1f15c0c5-64d6-402c-9711-96f976287858)
