### PR TITLE
fix(mux-video,mux-audio): reload core on DOM connect

### DIFF
--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -375,6 +375,13 @@ class MuxAudioElement extends CustomAudioElement implements Partial<MuxMediaProp
     }
   }
 
+  connectedCallback(): void {
+    super.connectedCallback?.();
+    if (this.nativeEl && this.src && !this.#core) {
+      this.#requestLoad();
+    }
+  }
+
   disconnectedCallback() {
     this.unload();
   }

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -604,7 +604,8 @@ class MuxVideoElement extends CustomVideoElement implements Partial<MuxMediaProp
   }
 
   connectedCallback(): void {
-    if (this.src && !this.#core) {
+    super.connectedCallback?.();
+    if (this.nativeEl && this.src && !this.#core) {
       this.#requestLoad();
     }
   }

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -603,7 +603,13 @@ class MuxVideoElement extends CustomVideoElement implements Partial<MuxMediaProp
     }
   }
 
-  disconnectedCallback() {
+  connectedCallback(): void {
+    if (this.src && !this.#core) {
+      this.#requestLoad();
+    }
+  }
+
+  disconnectedCallback(): void {
     this.unload();
   }
 }


### PR DESCRIPTION
Currently, we do an "unload"/teardown of core (and everything that happens in it/is created by it "under the hood") whenever our custom media elements are disconnected from the DOM. Ideally, this would not be the way we handle cleanups, as we're currently treating disconnect as a "`destroy()`" method. This causes issues with more advanced UIs/use cases, especially common in app frameworks where an element may be moved around the DOM for UI/UX purposes without the intention of destroying it. Unfortunately, it looks like we have some dangling references that result in a fairly large memory footprint per media element if we don't do this teardown. As a "middle ground" solution until we can identify a reasonable and reliable resolution of this larger memory management GC issue, we will simply (conditionally) "reload"/re-initialize core when the media element is (re)connected to the DOM.