### PR TITLE
fix(mux-player): placeholder not applying properly to media-poster-im…

### DIFF
--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -48,7 +48,7 @@ media-poster-image {
   height: 100%;
 }
 
-media-poster-image:not([src]) {
+media-poster-image:not([src]):not([placeholdersrc]) {
   display: none;
 }
 

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -99,7 +99,7 @@ export const content = (props: MuxTemplateProps) => html`
         part="poster"
         exportparts="poster, img"
         src="${props.poster === '' ? false : props.poster ?? false}"
-        placeholder-src="${props.placeholder ?? false}"
+        placeholdersrc="${props.placeholder ?? false}"
       ></media-poster-image>
     </slot>
     <mxp-dialog


### PR DESCRIPTION
…age since v1.0. Update css rules to show poster if placeholder only.