### PR TITLE
feat: add startLevel prop to mux-video-react

### DIFF
--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -24,7 +24,7 @@ const playerSoftwareVersion = getPlayerVersion();
 const playerSoftwareName = 'mux-video-react';
 
 const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>((props, ref) => {
-  const { playbackId, src: outerSrc, children, autoPlay, preload, streamType, ...restProps } = props;
+  const { playbackId, src: outerSrc, children, autoPlay, preload, streamType, startLevel, ...restProps } = props;
 
   const [playerInitTime] = useState(generatePlayerInitTime());
   const [src, setSrc] = useState<MuxMediaProps['src']>(toMuxVideoURL(playbackId) ?? outerSrc);
@@ -89,6 +89,7 @@ MuxVideo.propTypes = {
   type: PropTypes.oneOf(allMediaTypes),
   streamType: PropTypes.oneOf(Object.values(StreamTypes)),
   startTime: PropTypes.number,
+  startLevel: PropTypes.number,
 };
 
 export default MuxVideo;

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -369,11 +369,14 @@ function useNative(
 
 export const setupHls = (
   props: Partial<
-    Pick<MuxMediaPropsInternal, 'debug' | 'streamType' | 'type' | 'startTime' | 'metadata' | 'preferCmcd'>
+    Pick<
+      MuxMediaPropsInternal,
+      'debug' | 'streamType' | 'type' | 'startTime' | 'metadata' | 'preferCmcd' | 'startLevel'
+    >
   >,
   mediaEl: Pick<HTMLMediaElement, 'canPlayType'>
 ) => {
-  const { debug, streamType, startTime: startPosition = -1, metadata, preferCmcd } = props;
+  const { debug, streamType, startTime: startPosition = -1, metadata, preferCmcd, startLevel } = props;
   const type = getType(props);
   const hlsType = type === ExtensionMimeTypeMap.M3U8;
   const shouldUseNative = useNative(props, mediaEl);
@@ -403,6 +406,7 @@ export const setupHls = (
       debug,
       startPosition,
       cmcd,
+      startLevel,
       ...defaultConfig,
       ...streamTypeConfig,
     }) as HlsInterface;

--- a/packages/playback-core/src/types.ts
+++ b/packages/playback-core/src/types.ts
@@ -143,6 +143,7 @@ export type MuxMediaPropTypes = {
   autoplay?: Autoplay;
   preferCmcd: ValueOf<CmcdTypes> | undefined;
   error?: HTMLMediaElement['error'] | MediaError;
+  startLevel?: number;
 };
 
 export interface MediaTracks {

--- a/packages/playback-core/test/index.test.js
+++ b/packages/playback-core/test/index.test.js
@@ -270,5 +270,20 @@ describe('playback core', function () {
       assert(Number.isNaN(getTargetLiveWindow(mediaEl)), 'should have a default targetLiveWindow of NaN');
       assert(Number.isNaN(getLiveEdgeStart(mediaEl)), 'should have a default liveEdgeStart of NaN');
     });
+
+    it('should set startLevel', async function () {
+      const START_LEVEL = 100;
+
+      const video = document.createElement('video');
+      const core = initialize(
+        {
+          src: 'https://stream.mux.com/23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I.m3u8',
+          startLevel: START_LEVEL,
+        },
+        video
+      );
+
+      assert.equal(core.engine.startLevel, START_LEVEL);
+    });
   });
 });


### PR DESCRIPTION
Hey team,

A small PR that allows you to add the startLevel prop in the MuxVideo react component.

API doc - https://github.com/video-dev/hls.js/blob/master/docs/API.md#startlevel