### PR TITLE
fix: audio track API for 1 track

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -536,6 +536,7 @@ export const loadMedia = (
     | 'subtitleTrack'
     | 'userConfig'
     | 'audioTrack'
+    | 'audioTracks'
     | 'autoLevelEnabled'
     | 'nextLevel'
     | 'levels'


### PR DESCRIPTION
reverts a bug fix in https://github.com/muxinc/elements/pull/759

it was a good patch but it prevented the audio tracks API to be populated if there was just 1 audio track.
it's still expected that with 1 audio track, the API returns an item for video.audioTracks[0].

this change adds that back in.

the root issue in hls.js I believe was that we were trying to select an audio track with a string ID and hls.js works with numeric ID's.
this change also adds a check if hls.js audioTracks has the ID to which the player tries to switch.