### PR TITLE
fix: Don't allow clicks on bg gradients

### DIFF
--- a/packages/mux-player/src/themes/gerwig/gerwig.html
+++ b/packages/mux-player/src/themes/gerwig/gerwig.html
@@ -205,6 +205,7 @@
       padding-bottom: min(100px, 25%);
       background: linear-gradient(#000, transparent);
       opacity: 0.8;
+      pointer-events: none;
     }
 
     :host(:not([audio])) media-control-bar[part~='bottom']::before {
@@ -217,6 +218,7 @@
       background: linear-gradient(transparent, #000);
       opacity: 0.8;
       z-index: 1;
+      pointer-events: none;
     }
 
     media-control-bar[part~='bottom'] > * {


### PR DESCRIPTION
The bg gradients can sometimes swallow clicks. At small sizes the bottom one starts to encroach on the center controls and can swallow clicks if they're towards the bottom of the center play and skip buttons. This could also be fixed by tweaking z-indexes but that could have other effects.