### PR TITLE
feat: Add volume slider to live controls

### DIFF
--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -47,11 +47,11 @@
       playback-id="23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I"
     ></mux-player>
 
-    <!-- <mux-player
+    <mux-player
       stream-type="live:dvr"
       playback-id="v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM"
       title="My amazing video"
-    ></mux-player> -->
+    ></mux-player>
 
     <a href="../">Browse Elements</a>
   </body>

--- a/packages/mux-player/src/themes/gerwig/gerwig.html
+++ b/packages/mux-player/src/themes/gerwig/gerwig.html
@@ -908,7 +908,7 @@
             {{>PlayButton}}
             <template if="targetlivewindow > 0"> {{>SeekBackwardButton}} {{>SeekForwardButton}} </template>
           </template>
-          {{>MuteButton}}
+          {{>MuteButton}} {{>VolumeRange}}
           <div class="spacer"></div>
           {{>RenditionSelect}} {{>AudioTrackSelect}} {{>CaptionsMenuButton}} {{>AirplayButton}} {{>CastButton}}
           <template if="breakpointsm">{{>PipButton}}</template>


### PR DESCRIPTION
The live version of the new theme has a mute button but no volume slider. This is actually how it is in the designs but I think it's an omission and a customer asked where it was. Have added it back in and uncommented out the live preview in our vanilla example.