### PR TITLE
fix(mux-player): Use solid accent color in rate menu

### DIFF
--- a/packages/mux-player/src/themes/gerwig/gerwig.html
+++ b/packages/mux-player/src/themes/gerwig/gerwig.html
@@ -197,7 +197,6 @@
 
     media-playback-rate-listbox::part(option-selected) {
       color: #fff;
-      opacity: 0.6;
     }
 
     :host(:not([audio])) media-time-range {


### PR DESCRIPTION
To match the rest of the theme I removed the opacity on the selected items as we hadn't used shades of the accent color elsewhere. This also nicely increases the contrast.

<img width="262" alt="image" src="https://github.com/muxinc/elements/assets/9952680/3f849737-e359-471a-aaad-be0b142b24d2">
<br>
<img width="261" alt="image" src="https://github.com/muxinc/elements/assets/9952680/9c0fa8e0-5e65-45fc-87ad-7ebce78e30c3">
