### PR TITLE
chore: next.js MuxPlayer demo page missing import for classic theme.

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Head from "next/head";
 import Script from 'next/script';
 import MuxPlayer, { MuxPlayerProps, MaxResolution, MinResolution, RenditionOrder } from "@mux/mux-player-react";
+import "@mux/mux-player/themes/classic";
 import "@mux/mux-player/themes/minimal";
 import "@mux/mux-player/themes/microvideo";
 import "@mux/mux-player/themes/gerwig";


### PR DESCRIPTION
probably missed when we flipped the switch to `gerwig`.