### PR TITLE
Fix (mux-player-react): missing token props (#821)

### DIFF
--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -63,6 +63,9 @@ type MuxMediaPropTypes = {
   storyboardSrc: string;
   preferCmcd: ValueOf<CmcdTypes> | undefined;
   children?: React.ReactNode;
+  playbackToken?: string;
+  thumbnailToken?: string;
+  storyboardToken?: string;
 };
 
 export type MuxPlayerProps = {
@@ -178,6 +181,9 @@ const usePlayer = (
     paused,
     playbackId,
     playbackRates,
+    playbackToken,
+    thumbnailToken,
+    storyboardToken,
     currentTime,
     themeProps,
     ...remainingProps
@@ -187,6 +193,9 @@ const usePlayer = (
   useObjectPropEffect('themeProps', themeProps, ref);
   useObjectPropEffect('tokens', tokens, ref);
   useObjectPropEffect('playbackId', playbackId, ref);
+  useObjectPropEffect('playbackToken', playbackToken, ref);
+  useObjectPropEffect('thumbnailToken', thumbnailToken, ref);
+  useObjectPropEffect('storyboardToken', storyboardToken, ref);
   useObjectPropEffect(
     'paused',
     paused,


### PR DESCRIPTION
Add missing `playbackToken`, `thumbnailToken` and `storyboardToken` to MuxPlayer react component.