### PR TITLE
Fix/narrow cmcd for cache

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -458,6 +458,17 @@ export const setupHls = (
       debug,
       startPosition,
       cmcd,
+      xhrSetup: (xhr, url) => {
+        if (preferCmcd && preferCmcd !== CmcdTypes.QUERY) return;
+        const urlObj = new URL(url);
+        if (!urlObj.searchParams.has('CMCD')) return;
+        const cmcdVal = (urlObj.searchParams.get('CMCD')?.split(',') ?? [])
+          .filter((cmcdKVStr) => cmcdKVStr.startsWith('sid') || cmcdKVStr.startsWith('cid'))
+          .join(',');
+        urlObj.searchParams.set('CMCD', cmcdVal);
+
+        xhr.open('GET', urlObj);
+      },
       ...defaultConfig,
       ...streamTypeConfig,
     }) as HlsInterface;


### PR DESCRIPTION
For the time being, only send `sid` and `cid` CMCD k/v pairs on requests (if cmcd is on and using query params). This should improve cache hits during e.g. seeks and loops due to buffer flushes + refetches.