### PR TITLE
fix(mux-player): Hidden select menus cause horizontal scrolling on mobile

### DIFF
--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -42,6 +42,7 @@ media-theme {
   width: 100%;
   height: 100%;
   direction: ltr;
+  overflow: hidden;
 }
 
 media-poster-image {


### PR DESCRIPTION
Our default select menu positions escape the mux player boundaries on mobile until they are shown, at which point they position correctly inside the bounds. We could fix the positions but using `overflow: hidden` would avoid all future scenarios like this.