### PR TITLE
Feat/arbitrary src params

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -379,6 +379,12 @@ function MuxPlayerPage({ location }: Props) {
         maxResolution={state.maxResolution}
         minResolution={state.minResolution}
         renditionOrder={state.renditionOrder}
+        // To test/apply extra playlist params to resultant src URL (CJP)
+        // extraPlaylistParams={{
+        //   foo: 'str',
+        //   bar: true,
+        //   baz: 1,
+        // }}
         preload={state.preload}
         streamType={state.streamType}
         targetLiveWindow={state.targetLiveWindow}

--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -380,7 +380,7 @@ function MuxPlayerPage({ location }: Props) {
         minResolution={state.minResolution}
         renditionOrder={state.renditionOrder}
         // To test/apply extra playlist params to resultant src URL (CJP)
-        // extraPlaylistParams={{
+        // extraSourceParams={{
         //   foo: 'str',
         //   bar: true,
         //   baz: 1,

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -51,6 +51,7 @@ type MuxMediaPropTypes = {
   disableCookies: boolean;
   // metadata: Partial<Options["data"]>;
   metadata: { [k: string]: any };
+  extraPlaylistParams: Record<string, any>;
   beaconCollectionDomain: string;
   customDomain: string;
   playbackId: string;
@@ -180,10 +181,12 @@ const usePlayer = (
     playbackRates,
     currentTime,
     themeProps,
+    extraPlaylistParams,
     ...remainingProps
   } = props;
   useObjectPropEffect('playbackRates', playbackRates, ref);
   useObjectPropEffect('metadata', metadata, ref);
+  useObjectPropEffect('extraPlaylistParams', extraPlaylistParams, ref);
   useObjectPropEffect('themeProps', themeProps, ref);
   useObjectPropEffect('tokens', tokens, ref);
   useObjectPropEffect('playbackId', playbackId, ref);

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -51,7 +51,7 @@ type MuxMediaPropTypes = {
   disableCookies: boolean;
   // metadata: Partial<Options["data"]>;
   metadata: { [k: string]: any };
-  extraPlaylistParams: Record<string, any>;
+  extraSourceParams: Record<string, any>;
   beaconCollectionDomain: string;
   customDomain: string;
   playbackId: string;
@@ -181,12 +181,12 @@ const usePlayer = (
     playbackRates,
     currentTime,
     themeProps,
-    extraPlaylistParams,
+    extraSourceParams,
     ...remainingProps
   } = props;
   useObjectPropEffect('playbackRates', playbackRates, ref);
   useObjectPropEffect('metadata', metadata, ref);
-  useObjectPropEffect('extraPlaylistParams', extraPlaylistParams, ref);
+  useObjectPropEffect('extraSourceParams', extraSourceParams, ref);
   useObjectPropEffect('themeProps', themeProps, ref);
   useObjectPropEffect('tokens', tokens, ref);
   useObjectPropEffect('playbackId', playbackId, ref);

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -74,7 +74,7 @@ const PlayerAttributes = {
   THEME: 'theme',
   DEFAULT_STREAM_TYPE: 'default-stream-type',
   TARGET_LIVE_WINDOW: 'target-live-window',
-  EXTRA_PLAYLIST_PARAMS: 'extra-playlist-params',
+  EXTRA_SOURCE_PARAMS: 'extra-source-params',
   NO_VOLUME_PREF: 'no-volume-pref',
 };
 
@@ -157,7 +157,7 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
     ...state,
     // NOTE: since the attribute value is used as the "source of truth" for the property getter,
     // moving this below the `...state` spread so it resolves to the default value when unset (CJP)
-    extraPlaylistParams: el.extraPlaylistParams,
+    extraSourceParams: el.extraSourceParams,
   };
 
   return props;
@@ -1226,24 +1226,25 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
     }
   }
 
-  get extraPlaylistParams() {
-    if (!this.hasAttribute(PlayerAttributes.EXTRA_PLAYLIST_PARAMS)) {
+  get extraSourceParams() {
+    if (!this.hasAttribute(PlayerAttributes.EXTRA_SOURCE_PARAMS)) {
       return DEFAULT_EXTRA_PLAYLIST_PARAMS;
     }
 
-    return [
-      ...new URLSearchParams(this.getAttribute(PlayerAttributes.EXTRA_PLAYLIST_PARAMS) as string).entries(),
-    ].reduce((paramsObj, [k, v]) => {
-      paramsObj[k] = v;
-      return paramsObj;
-    }, {} as Record<string, any>);
+    return [...new URLSearchParams(this.getAttribute(PlayerAttributes.EXTRA_SOURCE_PARAMS) as string).entries()].reduce(
+      (paramsObj, [k, v]) => {
+        paramsObj[k] = v;
+        return paramsObj;
+      },
+      {} as Record<string, any>
+    );
   }
 
-  set extraPlaylistParams(value: Record<string, any>) {
+  set extraSourceParams(value: Record<string, any>) {
     if (value == null) {
-      this.removeAttribute(PlayerAttributes.EXTRA_PLAYLIST_PARAMS);
+      this.removeAttribute(PlayerAttributes.EXTRA_SOURCE_PARAMS);
     } else {
-      this.setAttribute(PlayerAttributes.EXTRA_PLAYLIST_PARAMS, new URLSearchParams(value).toString());
+      this.setAttribute(PlayerAttributes.EXTRA_SOURCE_PARAMS, new URLSearchParams(value).toString());
     }
   }
 

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -154,8 +154,10 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
     customDomain: el.getAttribute(MuxVideoAttributes.CUSTOM_DOMAIN) ?? undefined,
     title: el.getAttribute(PlayerAttributes.TITLE),
     novolumepref: el.hasAttribute(PlayerAttributes.NO_VOLUME_PREF),
-    extraPlaylistParams: el.extraPlaylistParams,
     ...state,
+    // NOTE: since the attribute value is used as the "source of truth" for the property getter,
+    // moving this below the `...state` spread so it resolves to the default value when unset (CJP)
+    extraPlaylistParams: el.extraPlaylistParams,
   };
 
   return props;
@@ -1225,10 +1227,10 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
   }
 
   get extraPlaylistParams() {
-    // NOTE: the official type definition for the 0th `URLSearchParams` constructor argument is stricter than what is actually
-    // allowed and commonly used (e.g. a key with a boolean or number value). Ignoring to allow these cases. (CJP)
-    // @ts-ignore
-    if (!this.hasAttribute(PlayerAttributes.EXTRA_PLAYLIST_PARAMS)) return DEFAULT_EXTRA_PLAYLIST_PARAMS;
+    if (!this.hasAttribute(PlayerAttributes.EXTRA_PLAYLIST_PARAMS)) {
+      return DEFAULT_EXTRA_PLAYLIST_PARAMS;
+    }
+
     return [
       ...new URLSearchParams(this.getAttribute(PlayerAttributes.EXTRA_PLAYLIST_PARAMS) as string).entries(),
     ].reduce((paramsObj, [k, v]) => {

--- a/packages/mux-player/src/types.d.ts
+++ b/packages/mux-player/src/types.d.ts
@@ -41,7 +41,7 @@ export type MuxTemplateProps = Partial<MuxPlayerProps> & {
   maxResolution?: MaxResolutionValue;
   minResolution?: MinResolutionValue;
   renditionOrder?: RenditionOrderValue;
-  extraPlaylistParams?: Record<string, any>;
+  extraSourceParams?: Record<string, any>;
   tokens: {
     playback?: string;
     thumbnail?: string;

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -539,6 +539,37 @@ describe('<mux-player>', () => {
     assert.equal(player.maxResolution, '720p');
   });
 
+  it('should apply extra-playlist-params as arbitrary search params on src', async function () {
+    const player = await fixture(`<mux-player
+      stream-type="on-demand"
+      extra-playlist-params="foo=str&bar=true&baz=1"
+      playback-id="r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA"
+    ></mux-player>`);
+    const muxVideo = player.media;
+
+    // NOTE: While you may use any value for the setter, the current impl will convert all values to string equivalents (CJP)
+    const expectedExtraPlaylistParams = { foo: 'str', bar: 'true', baz: '1' };
+    assert.deepEqual(player.extraPlaylistParams, expectedExtraPlaylistParams);
+    const actualSrcUrl = new URL(muxVideo.src);
+    const expectedSrcUrl = new URL(
+      'https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8?foo=str&bar=true&baz=1'
+    );
+    assert.equal(actualSrcUrl.searchParams.size, expectedSrcUrl.searchParams.size);
+    expectedSrcUrl.searchParams.forEach((value, key) => {
+      assert.equal(actualSrcUrl.searchParams.get(key), value);
+    });
+
+    player.removeAttribute('extra-playlist-params');
+    assert.deepEqual(player.extraPlaylistParams, { redundant_streams: true });
+
+    player.extraPlaylistParams = {
+      foo: 'str',
+      bar: true,
+      baz: 1,
+    };
+    assert.deepEqual(player.extraPlaylistParams, expectedExtraPlaylistParams);
+  });
+
   describe('buffered behaviors', function () {
     it('should have an empty TimeRanges value by default', async function () {
       const playerEl = await fixture('<mux-player stream-type="on-demand"></mux-player>');

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -542,14 +542,18 @@ describe('<mux-player>', () => {
   it('should apply extra-playlist-params as arbitrary search params on src', async function () {
     const player = await fixture(`<mux-player
       stream-type="on-demand"
-      extra-playlist-params="foo=str&bar=true&baz=1"
+      extra-source-params="foo=str&bar=true&baz=1"
       playback-id="r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA"
     ></mux-player>`);
     const muxVideo = player.media;
 
     // NOTE: While you may use any value for the setter, the current impl will convert all values to string equivalents (CJP)
     const expectedExtraPlaylistParams = { foo: 'str', bar: 'true', baz: '1' };
-    assert.deepEqual(player.extraPlaylistParams, expectedExtraPlaylistParams);
+    assert.deepEqual(
+      player.extraSourceParams,
+      expectedExtraPlaylistParams,
+      'should reflect value when set via attribute'
+    );
     const actualSrcUrl = new URL(muxVideo.src);
     const expectedSrcUrl = new URL(
       'https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8?foo=str&bar=true&baz=1'
@@ -559,15 +563,23 @@ describe('<mux-player>', () => {
       assert.equal(actualSrcUrl.searchParams.get(key), value);
     });
 
-    player.removeAttribute('extra-playlist-params');
-    assert.deepEqual(player.extraPlaylistParams, { redundant_streams: true });
+    player.removeAttribute('extra-source-params');
+    assert.deepEqual(
+      player.extraSourceParams,
+      { redundant_streams: true },
+      'should reset to default params when attribute is removed'
+    );
 
-    player.extraPlaylistParams = {
+    player.extraSourceParams = {
       foo: 'str',
       bar: true,
       baz: 1,
     };
-    assert.deepEqual(player.extraPlaylistParams, expectedExtraPlaylistParams);
+    assert.deepEqual(
+      player.extraSourceParams,
+      expectedExtraPlaylistParams,
+      'should reflect value when set via property'
+    );
   });
 
   describe('buffered behaviors', function () {

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -239,7 +239,7 @@ type MuxVideoURLProps = Partial<{
     storyboard: string;
     thumbnail: string;
   }>;
-  extraPlaylistParams: Record<string, any>;
+  extraSourceParams: Record<string, any>;
 }>;
 
 export const toMuxVideoURL = ({
@@ -249,7 +249,7 @@ export const toMuxVideoURL = ({
   minResolution,
   renditionOrder,
   tokens: { playback: token } = {},
-  extraPlaylistParams = {},
+  extraSourceParams = {},
 }: MuxVideoURLProps = {}) => {
   if (!playbackIdWithParams) return undefined;
   const [playbackId, queryPart = ''] = toPlaybackIdParts(playbackIdWithParams);
@@ -284,7 +284,7 @@ export const toMuxVideoURL = ({
     if (renditionOrder) {
       url.searchParams.set('rendition_order', renditionOrder);
     }
-    Object.entries(extraPlaylistParams).forEach(([k, v]) => {
+    Object.entries(extraSourceParams).forEach(([k, v]) => {
       if (v == undefined) return;
       url.searchParams.set(k, v);
     });

--- a/packages/playback-core/test/index.test.js
+++ b/packages/playback-core/test/index.test.js
@@ -216,7 +216,7 @@ describe('playback core', function () {
       toMuxVideoURL({
         playbackId: '123?redundant_streams=true',
         minResolution: '720p',
-        extraPlaylistParams: {
+        extraSourceParams: {
           extra_extra: 'readallaboutit',
         },
       }),


### PR DESCRIPTION
Mux Player `extraPlaylistParams` (prop) / `extra-playlist-params` (attr) allows users to specify any arbitrary search/query params for the resultant `src` URL (based on, e.g. `playbackId` and other specific props/attrs used to construct the URL).