### PR TITLE
examples: remove unneeded cast framework script

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -344,7 +344,6 @@ function MuxPlayerPage({ location }: Props) {
         <title>&lt;MuxPlayer/&gt; Demo</title>
       </Head>
 
-      <Script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1" />
       <MuxPlayer
         ref={mediaElRef}
         style={stylesState}

--- a/examples/nextjs-with-typescript/pages/MuxPlayerLazy.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayerLazy.tsx
@@ -316,7 +316,6 @@ function MuxPlayerPage({ location }: Props) {
         <title>&lt;MuxPlayer/&gt; Demo</title>
       </Head>
 
-      <Script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1" />
       <MuxPlayer
         ref={mediaElRef}
         style={stylesState}

--- a/examples/nextjs-with-typescript/pages/mux-player.tsx
+++ b/examples/nextjs-with-typescript/pages/mux-player.tsx
@@ -25,7 +25,6 @@ function MuxPlayerWCPage() {
       </Head>
 
       <div>
-        <script defer src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
         <mux-player
           // style={{ aspectRatio: "16 / 9" }}
           playback-id={playbackId}

--- a/examples/vanilla-ts-esm/public/mux-player-audio-tracks.html
+++ b/examples/vanilla-ts-esm/public/mux-player-audio-tracks.html
@@ -5,10 +5,6 @@
     <title>&lt;mux-player&gt; audio tracks example</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
     <link rel="stylesheet" href="./styles.css">
-    <script
-      defer
-      src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
-    ></script>
     <script type="module" src="./dist/mux-player.js"></script>
     <style>
       mux-player {

--- a/examples/vanilla-ts-esm/public/mux-player-audio.html
+++ b/examples/vanilla-ts-esm/public/mux-player-audio.html
@@ -5,10 +5,6 @@
     <title>&lt;mux-player audio&gt; example</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
     <link rel="stylesheet" href="./styles.css">
-    <script
-      defer
-      src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
-    ></script>
     <script type="module" src="./dist/mux-player.js"></script>
     <style>
       mux-player {

--- a/examples/vanilla-ts-esm/public/mux-player-cuepoints.html
+++ b/examples/vanilla-ts-esm/public/mux-player-cuepoints.html
@@ -5,10 +5,6 @@
     <title>&lt;mux-player&gt; example</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
     <link rel="stylesheet" href="./styles.css">
-    <script
-      defer
-      src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
-    ></script>
     <script type="module" src="./dist/mux-player.js"></script>
     <style>
       mux-player {

--- a/examples/vanilla-ts-esm/public/mux-player-poster-slot.html
+++ b/examples/vanilla-ts-esm/public/mux-player-poster-slot.html
@@ -5,10 +5,6 @@
     <title>&lt;mux-player&gt; poster slot example</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
     <link rel="stylesheet" href="./styles.css">
-    <script
-      defer
-      src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
-    ></script>
     <script type="module" src="./dist/mux-player.js"></script>
     <style>
       mux-player {

--- a/examples/vanilla-ts-esm/public/mux-player-renditions.html
+++ b/examples/vanilla-ts-esm/public/mux-player-renditions.html
@@ -5,10 +5,6 @@
     <title>&lt;mux-player&gt; renditions example</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
     <link rel="stylesheet" href="./styles.css">
-    <script
-      defer
-      src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
-    ></script>
     <script type="module" src="./dist/mux-player.js"></script>
     <style>
       mux-player {

--- a/examples/vanilla-ts-esm/public/mux-player-theme-classic.html
+++ b/examples/vanilla-ts-esm/public/mux-player-theme-classic.html
@@ -5,10 +5,6 @@
     <title>&lt;mux-player&gt; theme Classic</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
     <link rel="stylesheet" href="./styles.css">
-    <script
-      defer
-      src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
-    ></script>
     <script type="module" src="./dist/mux-player-classic-theme.js"></script>
     <script type="module" src="./dist/mux-player.js"></script>
     <style>

--- a/examples/vanilla-ts-esm/public/mux-player-theme.html
+++ b/examples/vanilla-ts-esm/public/mux-player-theme.html
@@ -5,10 +5,6 @@
     <title>&lt;mux-player&gt; example</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
     <link rel="stylesheet" href="./styles.css">
-    <script
-      defer
-      src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
-    ></script>
     <script type="module" src="./dist/mux-player-microvideo-theme.js"></script>
     <script type="module" src="./dist/mux-player.js"></script>
     <style>

--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -5,10 +5,6 @@
     <title>&lt;mux-player&gt; example</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
     <link rel="stylesheet" href="./styles.css">
-    <script
-      defer
-      src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"
-    ></script>
     <script type="module" src="./dist/mux-player.js"></script>
     <style>
       mux-player {


### PR DESCRIPTION
this script is not needed anymore, castable-video loads it automatically.

also if the script is loaded twice it causes an error in the console but doesn't break the player or page.

![SCR-20231206-rbt](https://github.com/muxinc/elements/assets/360826/bc25c3c4-140e-4b93-9634-4ba659e325f7)

this is only an issue when the users script is loaded after castable-video already appended its own script.
Next.js script tag is loaded afterInteractive, that's why it is causing the error log.

if it's loaded before castable-video checks that and prevents loading
see https://github.com/muxinc/castable-video/blob/0e5f322d4d1b7dd53215e4102d5712f8aa2721aa/castable-utils.js#L50-L50