### PR TITLE
fix: start-time for live streams

### DIFF
--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -78,7 +78,8 @@ export const content = (props: MuxTemplateProps) => html`
     defaultstreamtype="${props.defaultStreamType ?? false}"
     hotkeys="${getHotKeys(props) || false}"
     nohotkeys="${props.noHotKeys || !props.hasSrc || props.isDialogOpen || false}"
-    noautoseektolive="${!!props.streamType?.includes(StreamTypes.LIVE) && props.targetLiveWindow !== 0}"
+    noautoseektolive="${props.startTime != null ||
+    (!!props.streamType?.includes(StreamTypes.LIVE) && props.targetLiveWindow !== 0)}"
     novolumepref="${props.novolumepref || false}"
     disabled="${!props.hasSrc || props.isDialogOpen}"
     audio="${props.audio ?? false}"


### PR DESCRIPTION
this change also removes the code that would explicitly jump to the live edge in autoplay.ts
It was part of the bug but it is actually not needed, hls.js and native HLS will jump to the live edge automatically.

I tested this change with all the `preload` and `autoplay` options and it worked as expected.

