### PR TITLE
fix: media-tracks types not polluting global HTMLMediaElement

### DIFF
--- a/packages/mux-player/tsconfig.json
+++ b/packages/mux-player/tsconfig.json
@@ -20,5 +20,5 @@
     "forceConsistentCasingInFileNames": true,
     "typeRoots": ["node_modules/@types", "../../types/media-chrome.d.ts"]
   },
-  "include": ["src/**/*", "../../types/media-chrome.d.ts"]
+  "include": ["src/**/*", "../../types/media-chrome.d.ts", "../../node_modules/media-tracks/dist/global.d.ts"]
 }

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -69,7 +69,7 @@
     "@mux/playback-core": "0.22.0",
     "castable-video": "~1.0.5",
     "custom-media-element": "~1.1.3",
-    "media-tracks": "~0.2.4"
+    "media-tracks": "~0.3.0"
   },
   "devDependencies": {
     "@mux/test-esm-exports": "0.1.0",

--- a/packages/mux-video/src/index.ts
+++ b/packages/mux-video/src/index.ts
@@ -27,7 +27,6 @@ import type {
   PlaybackCore,
   PlaybackEngine,
   Autoplay,
-  MediaTracks,
   ExtensionMimeTypeMap,
   ValueOf,
   MaxResolutionValue,
@@ -525,7 +524,7 @@ class MuxVideoBaseElement extends CustomVideoElement implements Partial<MuxMedia
   }
 
   load() {
-    this.#core = initialize(this as Partial<MuxMediaProps> & MediaTracks, this.nativeEl, this.#core);
+    this.#core = initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
   }
 
   unload() {

--- a/packages/playback-core/src/types.ts
+++ b/packages/playback-core/src/types.ts
@@ -2,7 +2,6 @@
 /// <reference path="../dist/types/mux-embed.d.ts" />
 import type { Options } from 'mux-embed';
 import type { MediaError } from './errors';
-import type { VideoTrack, AudioTrack, VideoTrackList, AudioTrackList } from 'media-tracks';
 import type { HlsConfig } from 'hls.js';
 import type Hls from 'hls.js';
 
@@ -177,13 +176,6 @@ export type MuxMediaPropTypes = {
   error?: HTMLMediaElement['error'] | MediaError;
   _hlsConfig?: Partial<HlsConfig>;
 };
-
-export interface MediaTracks {
-  videoTracks: VideoTrackList;
-  audioTracks: AudioTrackList;
-  addAudioTrack(kind: string, label?: string, language?: string): AudioTrack;
-  addVideoTrack(kind: string, label?: string, language?: string): VideoTrack;
-}
 
 export type HTMLMediaElementProps = Partial<Pick<HTMLMediaElement, 'src' | 'preload' | 'error' | 'seekable'>>;
 

--- a/packages/playback-core/tsconfig.json
+++ b/packages/playback-core/tsconfig.json
@@ -20,5 +20,5 @@
     "forceConsistentCasingInFileNames": true,
     "typeRoots": ["node_modules/@types"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "../../node_modules/media-tracks/dist/global.d.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10541,10 +10541,10 @@ media-chrome@~2.0.1:
   resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-2.0.1.tgz#f7d6af2c82fb80d7f82ed50a86fad2216c66ceee"
   integrity sha512-6hoC5OY993t4o/YKYXn7YoWUAKG1UFAhnDXNN6kRRa5mnuL+Cwct/2Md16S4jjmTSmN5XjhEWwfCVM5NLHavOA==
 
-media-tracks@~0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/media-tracks/-/media-tracks-0.2.4.tgz#aee3bd69bdc8f246b44af5245f7b0a68d4c94540"
-  integrity sha512-P/TbDCYTFH5gxpQ6r99iabXOwjsFwzKRgK7wiwo64Ii6nHXYhHtwEP7A7ufmEKxkNCoHc4j3Z2hvs+lXL4wPeQ==
+media-tracks@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-tracks/-/media-tracks-0.3.0.tgz#0f16a611268ceb1139800634be97c58ce9d7e45c"
+  integrity sha512-kicD8eOFwe6nD7jn7iM/0yuLzWuo6abWHURYwY7NhxL1dBif+lt0on4rLTs6VhKwAEE/BjT3wr+0vn1w8SBpag==
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
this fixes a TS issue where if one imported the media-tracks mixin the HTMLMediaElement type would get all the new media tracks methods automatically. it's probably not a huge deal but right is right.

related PR https://github.com/muxinc/media-tracks/pull/12

if you do mixin media tracks in the global HTMLMediaElement you must import or include
`media-tracks/dist/global.d.ts` which will merge in the media-tracks methods...

cc @cjpillsbury 