### PR TITLE
Fix/live seek and media chrome upgrade

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -698,7 +698,7 @@ export const loadMedia = (
     const nextSeekableStart = getSeekable(mediaEl)?.start(0);
     const nextSeekableEnd = getSeekable(mediaEl)?.end(0);
     if (prevSeekableEnd !== nextSeekableEnd || prevSeekableStart !== nextSeekableStart) {
-      mediaEl.dispatchEvent(new CustomEvent('seekablechange', { composed: true, bubbles: true }));
+      mediaEl.dispatchEvent(new CustomEvent('seekablechange', { composed: true }));
     }
     prevSeekableStart = nextSeekableStart;
     prevSeekableEnd = nextSeekableEnd;


### PR DESCRIPTION
This resolves some edge cases with live seeking behavior and corresponding UI, which are particularly relevant for new pdt clipping available from Mux Video.

It also implements the `"seekablechange"`, which can be used by Media Chrome to more reliably propagate `mediaSeekable` state changes.