### PR TITLE
fix(playback-core): Make sure we do not apply holdback to seekable when live streams have ended.

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -709,7 +709,7 @@ export const loadMedia = (
   };
 
   // Make sure we track transitions from infinite to finite durations for seekable changes as well.
-  mediaEl.addEventListener('durationchange', seekableChange);
+  addEventListenerWithTeardown(mediaEl, 'durationchange', seekableChange);
 
   if (mediaEl && shouldUseNative) {
     const type = getType(props);

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -708,6 +708,9 @@ export const loadMedia = (
     prevSeekableEnd = nextSeekableEnd;
   };
 
+  // Make sure we track transitions from infinite to finite durations for seekable changes as well.
+  mediaEl.addEventListener('durationchange', seekableChange);
+
   if (mediaEl && shouldUseNative) {
     const type = getType(props);
     if (typeof src === 'string') {

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -193,7 +193,11 @@ export const updateStreamInfoFromHlsjsLevelDetails = (
         return mediaEl.seekable.start(index);
       },
       end(index: number) {
-        if (index > this.length) return mediaEl.seekable.end(index);
+        // Defer to native seekable for:
+        // 1) "out of range" cases
+        // 2) "finite duration" media (whether live/"DVR" that has ended or on demand)
+        if (index > this.length || index < 0 || Number.isFinite(mediaEl.duration)) return mediaEl.seekable.end(index);
+        // Otherwise rely on the live sync position (but still fall back to native seekable when nullish)
         return hls.liveSyncPosition ?? mediaEl.seekable.end(index);
       },
     });


### PR DESCRIPTION
In other words, seekable should only apply holdback (baked into `hls.liveSyncPosition`) while the live stream is "active"/"still live".