### PR TITLE
fix(mux-player-react/lazy): display placeholder before JS load

### DIFF
--- a/packages/mux-player-react/src/lazy.tsx
+++ b/packages/mux-player-react/src/lazy.tsx
@@ -52,7 +52,7 @@ const Fallback = (props: FallbackProps) => {
         placeholder={placeholder}
         style={
           {
-            '--mux-player-react-lazy-placeholder': placeholder ? `url(${placeholder});` : '',
+            '--mux-player-react-lazy-placeholder': placeholder ? `url('${placeholder}');` : '',
             ...style,
           } as React.CSSProperties
         }


### PR DESCRIPTION
Before suspense loads the player bundle, we use `--mux-player-react-lazy-placeholder:url({placeholder})` to show the placeholder. However, `{placeholder}` wasn't showing in some cases (especially with the new `@mux/blurup` library) because it was an invalid URL. `'{placeholder}'` is more robust, so this PR adds those quotation marks.