### PR TITLE
fix: Add className types for all Mux Uploader react subcomponents.

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxUploaderSeparateComponents.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxUploaderSeparateComponents.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import Head from 'next/head';
+import MuxUploader, { MuxUploaderDrop, MuxUploaderFileSelect, MuxUploaderProgress, MuxUploaderRetry, MuxUploaderStatus } from '@mux/mux-uploader-react';
+import { useState, ChangeEvent } from "react";
+
+const onUploadStart = console.log.bind(null, 'uploadStart');
+const onChunkAttempt = console.log.bind(null, "chunkAttempt");
+const onChunkSuccess = console.log.bind(null, "chunkSuccess");
+const onProgress = console.log.bind(null, "progress");
+const onSuccess = console.log.bind(null, "success");
+
+const onUploadError = ({ detail }) => {
+  console.log(detail.message);
+}
+
+function MuxUploaderPage() {
+  const [url, setUrl] = useState("");
+
+  const handleChange = (event: ChangeEvent) => {
+    const target = event.target as HTMLInputElement;
+    setUrl(target.value);
+  }
+
+  return (
+    <>
+      <Head>
+        <title>&lt;MuxUploader/&gt; Demo</title>
+      </Head>
+      <MuxUploaderDrop muxUploader="uploader" overlay overlayText="You're doing great!">
+        <h2>Enter your upload GCS url:</h2>
+
+        <input type="text" style={{
+          marginBottom: "20px",
+          width: "min(100%, 400px)",
+          boxSizing: "border-box"
+        }} placeholder="https://storage.googleapis.com/..." onChange={handleChange} />
+
+        <MuxUploader
+          style={{ display: "none", height: "200px" }}
+          className="foo"
+          id="uploader"
+          noDrop
+          noProgress
+          noStatus
+          noRetry
+          endpoint={url}
+          onUploadStart={onUploadStart}
+          onChunkAttempt={onChunkAttempt}
+          onChunkSuccess={onChunkSuccess}
+          onSuccess={onSuccess}
+          onUploadError={onUploadError}
+          onProgress={onProgress}
+        />
+      </MuxUploaderDrop>
+      <MuxUploaderFileSelect muxUploader="uploader" ></MuxUploaderFileSelect>
+      <MuxUploaderProgress muxUploader="uploader" >What should be here?</MuxUploaderProgress>
+      <MuxUploaderRetry muxUploader="uploader" ></MuxUploaderRetry>
+      <MuxUploaderStatus muxUploader="uploader" ></MuxUploaderStatus>
+
+      <Link href="/"><a>Browse Elements</a></Link>
+    </>
+  );
+}
+
+export default MuxUploaderPage;

--- a/examples/nextjs-with-typescript/pages/index.tsx
+++ b/examples/nextjs-with-typescript/pages/index.tsx
@@ -18,6 +18,7 @@ function HomePage() {
         <li><Link href="/MuxPlayerLazyIframe"><a className="player">&lt;MuxPlayer&gt;<br/>(lazy + w/o fullscreen)</a></Link></li>
         <li><Link href="/MuxPlayerLazyBlurUp"><a className="player">&lt;MuxPlayer&gt;<br/>(lazy + @mux/blurup)</a></Link></li>
         <li><Link href="/MuxUploader"><a className="uploader">&lt;MuxUploader&gt;</a></Link></li>
+        <li><Link href="/MuxUploaderSeparateComponents"><a className="uploader">&lt;MuxUploader&gt; (Separate Components)</a></Link></li>
         <li><Link href="/mux-video"><a className="video">&lt;mux-video&gt;<br/>(Web Component)</a></Link></li>
         <li><Link href="/mux-audio"><a className="audio">&lt;mux-audio&gt;<br/>(Web Component)</a></Link></li>
         <li><Link href="/mux-player"><a className="player">&lt;mux-player&gt;<br/>(Web Component)</a></Link></li>

--- a/packages/mux-uploader-react/src/index.tsx
+++ b/packages/mux-uploader-react/src/index.tsx
@@ -31,6 +31,7 @@ export type MuxUploaderProps = {
     ['--progress-bar-fill-color']?: CSSProperties['background'];
     ['--progress-radial-fill-color']?: CSSProperties['stroke'];
   };
+  // className?: string | undefined;
   children?: React.ReactNode;
   dynamicChunkSize?: boolean;
   maxFileSize?: number;

--- a/packages/mux-uploader-react/src/mux-uploader-drop.tsx
+++ b/packages/mux-uploader-react/src/mux-uploader-drop.tsx
@@ -16,7 +16,7 @@ export type MuxUploaderDropProps = {
     ['--overlay-background-color']?: CSSProperties['backgroundColor'];
   };
   children?: React.ReactNode;
-};
+} & Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>, 'ref'>;
 
 const MuxUploaderDropInternal = React.forwardRef<MuxUploaderDropRefAttributes, MuxUploaderDropProps>(
   ({ children, ...props }, ref) => {

--- a/packages/mux-uploader-react/src/mux-uploader-file-select.tsx
+++ b/packages/mux-uploader-react/src/mux-uploader-file-select.tsx
@@ -10,7 +10,7 @@ export type MuxUploaderFileSelectRefAttributes = MuxUploaderFileSelectElement;
 export type MuxUploaderFileSelectProps = {
   muxUploader?: string;
   children?: React.ReactNode;
-};
+} & Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>, 'ref'>;
 
 const MuxUploaderFileSelectInternal = React.forwardRef<MuxUploaderFileSelectRefAttributes, MuxUploaderFileSelectProps>(
   ({ children, ...props }, ref) => {

--- a/packages/mux-uploader-react/src/mux-uploader-progress.tsx
+++ b/packages/mux-uploader-react/src/mux-uploader-progress.tsx
@@ -17,7 +17,7 @@ export type MuxUploaderProgressProps = {
     ['--progress-bar-fill-color']?: CSSProperties['fill'];
     ['--progress-percentage-display']?: CSSProperties['display'];
   };
-};
+} & Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>, 'ref'>;
 
 const MuxUploaderProgressInternal = React.forwardRef<MuxUploaderProgressRefAttributes, MuxUploaderProgressProps>(
   ({ children, ...props }, ref) => {

--- a/packages/mux-uploader-react/src/mux-uploader-retry.tsx
+++ b/packages/mux-uploader-react/src/mux-uploader-retry.tsx
@@ -10,7 +10,7 @@ export type MuxUploaderRetryRefAttributes = MuxUploaderRetryElement;
 export type MuxUploaderRetryProps = {
   muxUploader?: string;
   children?: React.ReactNode;
-};
+} & Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>, 'ref'>;
 
 const MuxUploaderRetryInternal = React.forwardRef<MuxUploaderRetryRefAttributes, MuxUploaderRetryProps>(
   ({ children, ...props }, ref) => {

--- a/packages/mux-uploader-react/src/mux-uploader-status.tsx
+++ b/packages/mux-uploader-react/src/mux-uploader-status.tsx
@@ -10,7 +10,7 @@ export type MuxUploaderStatusRefAttributes = MuxUploaderStatusElement;
 export type MuxUploaderStatusProps = {
   muxUploader?: string;
   children?: React.ReactNode;
-};
+} & Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>, 'ref'>;
 
 const MuxUploaderStatusInternal = React.forwardRef<MuxUploaderStatusRefAttributes, MuxUploaderStatusProps>(
   ({ children, ...props }, ref) => {


### PR DESCRIPTION
fixes #856 

Also adds a basic example of using Mux Uploader React subcomponents to nextjs demo app: https://elements-demo-nextjs-git-fork-cjpillsbury-fix-mux-up-6f414e-mux.vercel.app/MuxUploaderSeparateComponents