### PR TITLE
fix(mux-player): Hide cast button by default when using DRM.

### DIFF
--- a/packages/mux-player/src/styles.css
+++ b/packages/mux-player/src/styles.css
@@ -14,7 +14,7 @@
   --media-airplay-button-display: var(--airplay-button);
   --media-pip-button-display: var(--pip-button);
   --media-fullscreen-button-display: var(--fullscreen-button);
-  --media-cast-button-display: var(--cast-button);
+  --media-cast-button-display: var(--cast-button, var(--_cast-button-drm-display));
   --media-playback-rate-button-display: var(--playback-rate-button);
   --media-playback-rate-selectmenu-display: var(--playback-rate-selectmenu);
   --media-volume-range-display: var(--volume-range);
@@ -72,7 +72,7 @@ media-poster-image:not([src]):not([placeholdersrc]) {
   --media-airplay-button-display: var(--airplay-button, var(--top-airplay-button));
   --media-pip-button-display: var(--pip-button, var(--top-pip-button));
   --media-fullscreen-button-display: var(--fullscreen-button, var(--top-fullscreen-button));
-  --media-cast-button-display: var(--cast-button, var(--top-cast-button));
+  --media-cast-button-display: var(--cast-button, var(--top-cast-button, var(--_cast-button-drm-display)));
   --media-playback-rate-button-display: var(--playback-rate-button, var(--top-playback-rate-button));
   --media-playback-rate-selectmenu-display: var(
     --captions-selectmenu,
@@ -103,7 +103,7 @@ media-poster-image:not([src]):not([placeholdersrc]) {
   --media-airplay-button-display: var(--airplay-button, var(--center-airplay-button));
   --media-pip-button-display: var(--pip-button, var(--center-pip-button));
   --media-fullscreen-button-display: var(--fullscreen-button, var(--center-fullscreen-button));
-  --media-cast-button-display: var(--cast-button, var(--center-cast-button));
+  --media-cast-button-display: var(--cast-button, var(--center-cast-button, var(--_cast-button-drm-display)));
   --media-playback-rate-button-display: var(--playback-rate-button, var(--center-playback-rate-button));
   --media-playback-rate-selectmenu-display: var(
     --playback-rate-selectmenu,
@@ -133,7 +133,7 @@ media-poster-image:not([src]):not([placeholdersrc]) {
   --media-airplay-button-display: var(--airplay-button, var(--bottom-airplay-button));
   --media-pip-button-display: var(--pip-button, var(--bottom-pip-button));
   --media-fullscreen-button-display: var(--fullscreen-button, var(--bottom-fullscreen-button));
-  --media-cast-button-display: var(--cast-button, var(--bottom-cast-button));
+  --media-cast-button-display: var(--cast-button, var(--bottom-cast-button, var(--_cast-button-drm-display)));
   --media-playback-rate-button-display: var(--playback-rate-button, var(--bottom-playback-rate-button));
   --media-playback-rate-selectmenu-display: var(
     --playback-rate-selectmenu,

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -8,8 +8,16 @@ import { i18n, stylePropsToString } from './utils';
 import type { MuxTemplateProps } from './types';
 import { StreamTypes, toMuxVideoURL } from '@mux/playback-core';
 
+const getPropsCSS = (props: MuxTemplateProps) => {
+  const { tokens } = props;
+  if (!tokens.drm) return '';
+  // See styles.css for usage.
+  return ':host { --_cast-button-drm-display: none; }';
+};
+
 export const template = (props: MuxTemplateProps) => html`
   <style>
+    ${getPropsCSS(props)}
     ${cssStr}
   </style>
   ${content(props)}

--- a/packages/mux-player/test/player.text-tracks.test.js
+++ b/packages/mux-player/test/player.text-tracks.test.js
@@ -38,20 +38,21 @@ window.addEventListener('error', windowErrorHandler);
     // Wait for us to have at least one showing subtitle/caption
     await waitUntil(
       () => Array.prototype.some.call(player.textTracks, (track) => track.mode === 'showing'),
-      'did not have showing tracks in time'
+      'did not have showing tracks in time',
+      { timeout: 2000 }
     );
     // Make sure we're playing
     await waitUntil(() => !player.paused, 'did not unpause in time');
     // Find the currently showing track
     const track = Array.prototype.find.call(player.textTracks, (textTrack) => textTrack.mode === 'showing');
     // Wait for it to have cues added
-    await waitUntil(() => track.cues.length, 2000);
+    await waitUntil(() => track.cues.length, 'cues not added in time', { timeout: 2000 });
     const firstCue = track.cues[0];
     assert.equal(firstCue.line, 'auto', 'the first cue.line is set to auto');
 
     // Seek to the first Cue so it will be visible/active
     player.currentTime = firstCue.startTime + 0.1;
-    await waitUntil(() => track.activeCues.length, 2000);
+    await waitUntil(() => track.activeCues.length, 'cues not active in time', { timeout: 2000 });
     const activeCue = track.activeCues[0];
 
     // Confirm we're inactive initially, as this is a precondition for the test passing.
@@ -62,14 +63,14 @@ window.addEventListener('error', windowErrorHandler);
     player.mediaController.toggleAttribute('userinactive', false);
     player.dispatchEvent(new Event('userinactivechange'));
     // Waiting for the condition and then asserting it due to async behavior
-    await waitUntil(() => activeCue.line !== 'auto', 2000);
+    await waitUntil(() => activeCue.line !== 'auto', 'cues not shifted in time', { timeout: 2000 });
     assert.equal(activeCue.line, -4, 'the line is shifted to -4 when user is active');
 
     // Test going from user active to userinactive active cue unshift
     player.mediaController.toggleAttribute('userinactive', true);
     player.dispatchEvent(new Event('userinactivechange'));
     // Waiting for the condition and then asserting it due to async behavior
-    await waitUntil(() => activeCue.line !== -4, 2000);
+    await waitUntil(() => activeCue.line !== -4, 'cues not shifted back in time', { timeout: 2000 });
     assert.equal(activeCue.line, 'auto', 'the line is reset to auto when userinactive');
   });
 
@@ -225,7 +226,7 @@ describe('Feature: cuePoints', async () => {
     assert.deepEqual(muxPlayerEl.activeCuePoint, expectedCuePoint);
   });
 
-  it('clears cuepoints when playback-id is updated', async () => {
+  it('clears cuepoints when playback-id is updated', async function () {
     this.timeout(10000);
     const cuePoints = [
       { time: 0, value: { label: 'CTA 1', showDuration: 10 } },


### PR DESCRIPTION
Since DRM-protected content requires a custom receiver app for casting (https://support.google.com/widevine/answer/6072130?hl=en), hide the cast button by default whenever we encounter a drm token. Went ahead and introduced a simple generic concept (props-driven css) and a pattern (internal css vars as defaults) that we can conform to for these cases.