### PR TITLE
fix(playback-core): pseudo-ended eval case where media is not attached.

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -379,7 +379,7 @@ export const isStuckOnLastFragment = (
     'levels' | 'currentLevel'
   >
 ) => {
-  if (!hls) return undefined;
+  if (!hls || !mediaEl.buffered.length) return undefined;
   if (mediaEl.readyState > 2) return false;
   const videoLevelDetails =
     hls.currentLevel >= 0


### PR DESCRIPTION
This would definitely be an edge case, but is hypothetically possible given the async aspects at play here. tl;dr - `buffered` time range length may still be `0` when one of the several events that invoke `maybeDispatchEndedCallback()` is dispatched. This ensures that we don't end up in cases where we are assuming `buffered.length > 0` and also ensures that we treat an empty buffered as under-determined for "pseudo-ended" cases.