### PR TITLE
feat: clean up type attr. Handle dynamic updates better.

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxUploader.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxUploader.tsx
@@ -40,6 +40,7 @@ function MuxUploaderPage({ location }: Props) {
           noStatus={state.noStatus}
           noRetry={state.noRetry}
           pausable={state.pausable}
+          type={state.type}
           dynamicChunkSize={state.dynamicChunkSize}
           useLargeFileWorkaround={state.useLargeFileWorkaround}
           maxFileSize={state.maxFileSize}

--- a/packages/mux-uploader-react/src/index.tsx
+++ b/packages/mux-uploader-react/src/index.tsx
@@ -29,7 +29,7 @@ interface GenericEventListener<T extends Event = CustomEvent> {
 export type MuxUploaderProps = {
   id?: string;
   endpoint?: MuxUploaderElement['endpoint'];
-  type?: ProgressTypes;
+  type?: ProgressTypes[keyof ProgressTypes];
   noDrop?: boolean;
   noProgress?: boolean;
   noStatus?: boolean;

--- a/packages/mux-uploader/src/layouts/block.ts
+++ b/packages/mux-uploader/src/layouts/block.ts
@@ -13,14 +13,20 @@ function conditionalRender(flag: boolean | undefined, component: string): string
   return flag ? '' : component;
 }
 
+const attributeRender = (name: string, value: any): string => {
+  if (value == null || value === false) return '';
+  const valueStr = value === true ? '' : `${value}`;
+  return `${name}="${valueStr}"`;
+};
+
 export default function blockLayout(contextElement: MuxUploaderElement): DocumentFragment {
-  const { noDrop, noProgress, noStatus, noRetry, pausable } = contextElement;
+  const { noDrop, noProgress, noStatus, noRetry, pausable, type } = contextElement;
   const wrapper = noDrop ? 'div' : 'mux-uploader-drop overlay part="drop"';
   const progressElements = conditionalRender(
     noProgress,
     `
       <mux-uploader-progress part="progress progress-percentage" type="percentage"></mux-uploader-progress>
-      <mux-uploader-progress part="progress progress-bar" type="bar"></mux-uploader-progress>
+      <mux-uploader-progress part="progress progress-bar" ${attributeRender('type', type)}></mux-uploader-progress>
     `
   );
   const statusElement = conditionalRender(noStatus, '<mux-uploader-status part="status"></mux-uploader-status>');

--- a/packages/mux-uploader/src/mux-uploader-drop.ts
+++ b/packages/mux-uploader/src/mux-uploader-drop.ts
@@ -113,6 +113,10 @@ class MuxUploaderDropElement extends globalThis.HTMLElement {
       );
 
       this.setupDragEvents(opts);
+
+      this.toggleAttribute('upload-in-progress', this.#uploaderEl.hasAttribute('upload-in-progress'));
+      this.toggleAttribute('upload-complete', this.#uploaderEl.hasAttribute('upload-complete'));
+      this.toggleAttribute('file-ready', this.#uploaderEl.hasAttribute('file-ready'));
     }
   }
 

--- a/packages/mux-uploader/src/mux-uploader-file-select.ts
+++ b/packages/mux-uploader/src/mux-uploader-file-select.ts
@@ -28,6 +28,7 @@ export const fileSelectFragment = /*html*/ `
     color: #fff;
     background: #000;
   }
+
   </style>
 
   <button id="file-select" type="button" part="file-select-button">Upload a video</button>
@@ -38,6 +39,10 @@ const template = document.createElement('template');
 template.innerHTML = /*html*/ `
   <style>
     :host { display: inline-block; }
+
+    :host([file-ready]) > slot  {
+      display: none;
+    }
   </style>
 
   <slot>
@@ -82,9 +87,7 @@ class MuxUploaderFileSelectElement extends globalThis.HTMLElement {
       this.#uploaderEl.addEventListener(
         'file-ready',
         () => {
-          if (this.filePickerEl) {
-            this.filePickerEl.style.display = 'none';
-          }
+          this.toggleAttribute('file-ready', true);
         },
         opts
       );
@@ -103,12 +106,14 @@ class MuxUploaderFileSelectElement extends globalThis.HTMLElement {
       this.#uploaderEl.addEventListener(
         'reset',
         () => {
-          if (this.filePickerEl) {
-            this.filePickerEl.style.display = 'block';
-          }
+          this.toggleAttribute('file-ready', false);
         },
         opts
       );
+
+      this.toggleAttribute('upload-in-progress', this.#uploaderEl.hasAttribute('upload-in-progress'));
+      this.toggleAttribute('upload-complete', this.#uploaderEl.hasAttribute('upload-complete'));
+      this.toggleAttribute('file-ready', this.#uploaderEl.hasAttribute('file-ready'));
     }
   }
 

--- a/packages/mux-uploader/src/mux-uploader-pause.ts
+++ b/packages/mux-uploader/src/mux-uploader-pause.ts
@@ -97,7 +97,12 @@ class MuxUploaderPauseElement extends globalThis.HTMLElement {
           );
         }
       });
+
       this.pauseButton.addEventListener('click', this.triggerPause, opts);
+
+      this.toggleAttribute('upload-in-progress', this.#uploaderEl.hasAttribute('upload-in-progress'));
+      this.toggleAttribute('upload-complete', this.#uploaderEl.hasAttribute('upload-complete'));
+      this.toggleAttribute('upload-error', this.#uploaderEl.hasAttribute('upload-error'));
     }
   }
 

--- a/packages/mux-uploader/src/mux-uploader-progress.ts
+++ b/packages/mux-uploader/src/mux-uploader-progress.ts
@@ -124,6 +124,8 @@ class MuxUploaderProgressElement extends globalThis.HTMLElement {
       this.#uploaderEl.addEventListener('reset', this.onReset);
       this.#uploaderEl.addEventListener('progress', this.onProgress);
       this.#uploaderEl.addEventListener('success', this.onSuccess);
+      this.toggleAttribute('upload-in-progress', this.#uploaderEl.hasAttribute('upload-in-progress'));
+      this.toggleAttribute('upload-complete', this.#uploaderEl.hasAttribute('upload-complete'));
     }
   }
 

--- a/packages/mux-uploader/src/mux-uploader-retry.ts
+++ b/packages/mux-uploader/src/mux-uploader-retry.ts
@@ -45,6 +45,8 @@ class MuxUploaderRetryElement extends globalThis.HTMLElement {
       this.#uploaderEl.addEventListener('reset', () => this.toggleAttribute('upload-error', false));
       this.retryButton?.addEventListener('click', this.triggerReset, opts);
       this.retryButton?.addEventListener('keyup', this.handleKeyup, opts);
+
+      this.toggleAttribute('upload-error', this.#uploaderEl.hasAttribute('upload-error'));
     }
   }
 

--- a/packages/mux-uploader/src/mux-uploader-status.ts
+++ b/packages/mux-uploader/src/mux-uploader-status.ts
@@ -41,6 +41,10 @@ class MuxUploaderStatusElement extends globalThis.HTMLElement {
       this.#uploaderEl.addEventListener('uploadstart', this.clearStatusMessage, opts);
       this.#uploaderEl.addEventListener('offline', this.onOffline, opts);
       this.#uploaderEl.addEventListener('online', this.clearStatusMessage, opts);
+
+      this.toggleAttribute('upload-in-progress', this.#uploaderEl.hasAttribute('upload-in-progress'));
+      this.toggleAttribute('upload-complete', this.#uploaderEl.hasAttribute('upload-complete'));
+      this.toggleAttribute('upload-error', this.#uploaderEl.hasAttribute('upload-error'));
     }
   }
 

--- a/packages/mux-uploader/src/mux-uploader.ts
+++ b/packages/mux-uploader/src/mux-uploader.ts
@@ -3,6 +3,7 @@ import { globalThis, document } from './polyfills';
 import { UpChunk } from '@mux/upchunk';
 
 import blockLayout from './layouts/block';
+import { ProgressTypes } from './constants';
 
 const rootTemplate = document.createElement('template');
 
@@ -83,6 +84,7 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
   static get observedAttributes() {
     return [
       'pausable',
+      'type',
       'no-drop',
       'no-progress',
       'no-status',
@@ -108,6 +110,7 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
 
     this.hiddenFileInput?.addEventListener('change', () => {
       const file = this.hiddenFileInput?.files?.[0];
+      this.toggleAttribute('file-ready', !!file);
 
       if (file) {
         this.dispatchEvent(
@@ -151,6 +154,19 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
       this.removeAttribute('endpoint');
     }
     this._endpoint = value;
+  }
+
+  get type() {
+    return (this.getAttribute('type') ?? undefined) as ProgressTypes[keyof ProgressTypes] | undefined;
+  }
+
+  set type(val: ProgressTypes[keyof ProgressTypes] | undefined) {
+    if (val == this.type) return;
+    if (!val) {
+      this.removeAttribute('type');
+    } else {
+      this.setAttribute('type', val);
+    }
   }
 
   get noDrop(): boolean {
@@ -266,12 +282,12 @@ class MuxUploaderElement extends globalThis.HTMLElement implements MuxUploaderEl
   }
 
   updateLayout() {
-    const oldLayout = this.shadowRoot!.querySelector('mux-uploader-drop, div');
+    const oldLayout = this.shadowRoot?.querySelector('mux-uploader-drop, div');
     if (oldLayout) {
       oldLayout.remove();
     }
     const newLayout = blockLayout(this);
-    this.shadowRoot!.appendChild(newLayout);
+    this.shadowRoot?.appendChild(newLayout);
   }
 
   setError(message: string) {


### PR DESCRIPTION
Primary purpose of this PR is to account for changes to props/attrs after initial load. Because of the underlying architecture, there are still potential edge cases around state vs. UI mismatches after upload has begun (e.g. pausing state + progress state, though progress will update on the next progress event to handle some of those cases).