### PR TITLE
chore: remove hard coded stream types

### DIFF
--- a/examples/create-react-app-with-typescript/src/pages/MuxAudio.tsx
+++ b/examples/create-react-app-with-typescript/src/pages/MuxAudio.tsx
@@ -13,7 +13,6 @@ function MuxAudioPage() {
 
       <MuxAudio
         playbackId="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
-        streamType="on-demand"
         controls
         muted
       />

--- a/examples/create-react-app-with-typescript/src/pages/MuxPlayer.tsx
+++ b/examples/create-react-app-with-typescript/src/pages/MuxPlayer.tsx
@@ -22,7 +22,6 @@ function MuxPlayerPage() {
           video_title: "Star Wars: Episode 3",
           viewer_user_id: "user-id-6789",
         }}
-        streamType="on-demand"
         muted
       />
 

--- a/examples/create-react-app-with-typescript/src/pages/MuxPlayerLazy.tsx
+++ b/examples/create-react-app-with-typescript/src/pages/MuxPlayerLazy.tsx
@@ -21,7 +21,6 @@ function MuxPlayerPage() {
           video_title: "Star Wars: Episode 3",
           viewer_user_id: "user-id-6789",
         }}
-        streamType="on-demand"
         muted
       />
 

--- a/examples/create-react-app-with-typescript/src/pages/MuxVideo.tsx
+++ b/examples/create-react-app-with-typescript/src/pages/MuxVideo.tsx
@@ -20,7 +20,6 @@ function MuxVideoPage() {
           video_title: "Star Wars: Episode 3",
           viewer_user_id: "user-id-6789",
         }}
-        streamType="on-demand"
         controls
         muted
       />

--- a/examples/nextjs-with-typescript/pages/MuxAudio.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxAudio.tsx
@@ -26,7 +26,6 @@ function MuxAudioPage() {
         //   viewer_user_id: "user-id-6789",
         // }}
         // envKey="mux-data-env-key"
-        streamType="on-demand"
         controls
         autoPlay={autoplay}
         muted={muted}

--- a/examples/nextjs-with-typescript/pages/MuxPlayerChapters.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayerChapters.tsx
@@ -27,7 +27,6 @@ function MuxPlayerPage() {
 
       <MuxPlayer
         playbackId="23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I"
-        streamType="on-demand"
         preload="auto"
         onLoadedMetadata={({ target }) => {
           addChaptersToPlayer(target as MuxPlayerElement);

--- a/examples/nextjs-with-typescript/pages/MuxPlayerCuePoints.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayerCuePoints.tsx
@@ -27,7 +27,6 @@ function MuxPlayerPage() {
 
       <MuxPlayer
         playbackId="23s11nz72DsoN657h4314PjKKjsF2JG33eBQQt6B95I"
-        streamType="on-demand"
         preload="auto"
         onLoadedMetadata={({ target }) => {
           addCuePointsToPlayer(target as MuxPlayerElement);

--- a/examples/nextjs-with-typescript/pages/MuxPlayerLazyBlurUp.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayerLazyBlurUp.tsx
@@ -32,7 +32,6 @@ function MuxPlayerLazyPage({ playbackId, blurDataURL, aspectRatio }) {
         playbackId={playbackId}
         placeholder={blurDataURL}
         style={{ aspectRatio }}
-        streamType="on-demand"
       />
   );
 }
@@ -59,7 +58,6 @@ export default MuxPlayerLazyPage;
         playbackId={playbackId}
         placeholder={blurDataURL}
         style={{ aspectRatio }}
-        streamType="on-demand"
       />
     </>
   );

--- a/examples/nextjs-with-typescript/pages/MuxPlayerPosterSlot.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayerPosterSlot.tsx
@@ -23,7 +23,6 @@ function MuxPlayerPage() {
       <MuxPlayer
         ref={mediaElRef}
         playbackId="VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA"
-        streamType="on-demand"
         autoPlay={autoplay}
         muted={muted}
         onPlay={() => {

--- a/examples/nextjs-with-typescript/pages/MuxPlayerTheme.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayerTheme.tsx
@@ -30,7 +30,6 @@ function MuxPlayerPage() {
         //   viewer_user_id: "user-id-6789",
         // }}
         // envKey="mux-data-env-key"
-        streamType="on-demand"
         autoPlay={autoplay}
         muted={muted}
         onPlay={() => {

--- a/examples/nextjs-with-typescript/pages/MuxVideo.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxVideo.tsx
@@ -32,7 +32,6 @@ function MuxVideoPage() {
         //   viewer_user_id: "user-id-6789",
         // }}
         // envKey="mux-data-env-key"
-        streamType="on-demand"
         controls
         autoPlay={autoplay}
         muted={muted}

--- a/packages/mux-player-react/README.md
+++ b/packages/mux-player-react/README.md
@@ -37,7 +37,6 @@ import MuxPlayer from '@mux/mux-player-react';
     video_title: 'Bick Buck Bunny',
     viewer_user_id: 'user-id-bc-789',
   }}
-  streamType="on-demand"
 />;
 ```
 
@@ -56,7 +55,6 @@ import MuxPlayer from '@mux/mux-player-react/lazy';
     video_title: 'Bick Buck Bunny',
     viewer_user_id: 'user-id-bc-789',
   }}
-  streamType="on-demand"
 />;
 ```
 

--- a/packages/mux-video-react/README.md
+++ b/packages/mux-video-react/README.md
@@ -66,7 +66,6 @@ const MuxVideoExample = () => {
           video_title: 'Super Interesting Video',
           viewer_user_id: 'user-id-bc-789',
         }}
-        streamType="on-demand"
         controls
         autoPlay
         muted


### PR DESCRIPTION
Changes only made to examples and readme's. We've already removed them from our main docs examples so just mimicking here. There are some tests with `streamType` still explicitly defined.