### PR TITLE
fix: css animation forwards causing UI lag

### DIFF
--- a/packages/mux-player/src/themes/gerwig/gerwig.html
+++ b/packages/mux-player/src/themes/gerwig/gerwig.html
@@ -335,7 +335,10 @@
     [breakpointsm]:is([mediahasplayed], :not([mediapaused])):not([audio])
       .center-controls.pre-playback
       media-play-button {
-      animation: 0.3s linear forwards pre-play-hide;
+      /* Using `forwards` would lead to a laggy UI after the animation got in the end state */
+      animation: 0.3s linear pre-play-hide;
+      opacity: 0;
+      pointer-events: none;
     }
 
     .autoplay-unmute {


### PR DESCRIPTION
when turning off hardware acceleration on Chrome it was reported that the Mux player UI became laggy.

I found one other user on Stackoverflow with the same issue:
https://stackoverflow.com/questions/12991164/maintaining-the-final-state-at-end-of-a-css-animation#comment118487774_12991203

Seems like part of the explanation is found here
https://developer.mozilla.org/en-US/docs/Web/CSS/animation-fill-mode#forwards

> Animated properties behave as if included in a set [will-change](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change) property value. If a new stacking context was created during the animation, the target element retains the stacking context after the animation has finished.