### PR TITLE
fix: track src being removed bug

### DIFF
--- a/packages/playback-core/src/text-tracks.ts
+++ b/packages/playback-core/src/text-tracks.ts
@@ -101,11 +101,15 @@ export function setupTextTracks(
       if (!track.cues?.length) {
         const trackEl = mediaEl.querySelector('track[label="thumbnails"]');
         // Force a reload of the cues if they've been removed
-        const src = trackEl?.getAttribute('src') ?? '';
-        trackEl?.removeAttribute('src');
-        setTimeout(() => {
-          trackEl?.setAttribute('src', src);
-        }, 0);
+        const src = trackEl?.getAttribute('src');
+        // It's possible src is not set or we just removed it in a previous
+        // execution of this function. Prevent setting an empty src.
+        if (src) {
+          trackEl?.removeAttribute('src');
+          setTimeout(() => {
+            trackEl?.setAttribute('src', src);
+          }, 0);
+        }
       }
       // Force hidden mode if it's not hidden
       if (track.mode !== 'hidden') {


### PR DESCRIPTION
I ran into this issue where the thumbnails track src was being removed because of a race condition.

the `forceHiddenThumbnails` was called twice before the setTimeout callback so it ended up setting an empty src.
let me know if that doesn't make sense.