### PR TITLE
fix(mux-player): add buttons to mobile live audio view

### DIFF
--- a/packages/mux-player/src/themes/gerwig/gerwig.html
+++ b/packages/mux-player/src/themes/gerwig/gerwig.html
@@ -989,8 +989,9 @@
           <media-control-bar part="control-bar top">{{>TitleDisplay}}</media-control-bar>
         </template>
         <media-control-bar part="control-bar bottom">
+          {{>PlayButton}} {{>LiveButton section="bottom"}} {{>MuteButton}}
           <template if="breakpointsm">
-            {{>PlayButton}} {{>LiveButton section="bottom"}} {{>MuteButton}} {{>VolumeRange}}
+            {{>VolumeRange}}
             <template if="targetlivewindow > 0"> {{>SeekBackwardButton}} {{>SeekForwardButton}} </template>
           </template>
           <template if="targetlivewindow > 0"> {{>TimeDisplay}} {{>TimeRange}} </template>


### PR DESCRIPTION
We weren't showing many buttons on mobile for live audio. This adds the play, live and mute button, but keeps the volume slider for larger views.