### PR TITLE
tests: fix tests by using Chrome --headless=old

### DIFF
--- a/packages/mux-active-viewer-count/test/web-test-runner.config.mjs
+++ b/packages/mux-active-viewer-count/test/web-test-runner.config.mjs
@@ -1,5 +1,6 @@
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { importMapsPlugin } from '@web/dev-server-import-maps';
+import { chromeLauncher } from '@web/test-runner';
 
 export default {
   nodeResolve: true,
@@ -23,4 +24,5 @@ export default {
     report: true,
     include: ['src/**/*'],
   },
+  browsers: [chromeLauncher({ launchOptions: { args: ['--headless=old'] } })],
 };

--- a/packages/mux-audio/test/web-test-runner.config.mjs
+++ b/packages/mux-audio/test/web-test-runner.config.mjs
@@ -1,5 +1,6 @@
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { importMapsPlugin } from '@web/dev-server-import-maps';
+import { chromeLauncher } from '@web/test-runner';
 
 export default {
   nodeResolve: true,
@@ -23,4 +24,5 @@ export default {
     report: true,
     include: ['src/**/*'],
   },
+  browsers: [chromeLauncher({ launchOptions: { args: ['--headless=old'] } })],
 };

--- a/packages/mux-player/test/web-test-runner.config.mjs
+++ b/packages/mux-player/test/web-test-runner.config.mjs
@@ -1,5 +1,6 @@
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { importMapsPlugin } from '@web/dev-server-import-maps';
+import { chromeLauncher } from '@web/test-runner';
 import { playwrightLauncher } from '@web/test-runner-playwright';
 
 const config = {
@@ -25,6 +26,7 @@ const config = {
     include: ['src/**/*'],
   },
   testsFinishTimeout: 600000,
+  browsers: [chromeLauncher({ launchOptions: { args: ['--headless=old'] } })],
 };
 
 if (process.argv.some((arg) => arg.includes('--all'))) {

--- a/packages/mux-uploader/package.json
+++ b/packages/mux-uploader/package.json
@@ -73,6 +73,7 @@
     "@open-wc/testing": "^4.0.0",
     "@web/dev-server-esbuild": "^1.0.2",
     "@web/dev-server-import-maps": "^0.2.1",
+    "@web/test-runner": "^0.18.2",
     "copyfiles": "^2.4.1",
     "downlevel-dts": "^0.11.0",
     "esbuild": "^0.19.8",

--- a/packages/mux-uploader/test/web-test-runner.config.mjs
+++ b/packages/mux-uploader/test/web-test-runner.config.mjs
@@ -1,5 +1,6 @@
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { importMapsPlugin } from '@web/dev-server-import-maps';
+import { chromeLauncher } from '@web/test-runner';
 
 export default {
   testFramework: {
@@ -29,4 +30,5 @@ export default {
     report: true,
     include: ['src/**/*'],
   },
+  browsers: [chromeLauncher({ launchOptions: { args: ['--headless=old'] } })],
 };

--- a/packages/mux-video/test/web-test-runner.config.mjs
+++ b/packages/mux-video/test/web-test-runner.config.mjs
@@ -1,5 +1,6 @@
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { importMapsPlugin } from '@web/dev-server-import-maps';
+import { chromeLauncher } from '@web/test-runner';
 
 export default {
   nodeResolve: true,
@@ -23,4 +24,5 @@ export default {
     report: true,
     include: ['src/**/*'],
   },
+  browsers: [chromeLauncher({ launchOptions: { args: ['--headless=old'] } })],
 };

--- a/packages/playback-core/test/web-test-runner.config.mjs
+++ b/packages/playback-core/test/web-test-runner.config.mjs
@@ -1,5 +1,6 @@
 import { esbuildPlugin } from '@web/dev-server-esbuild';
 import { importMapsPlugin } from '@web/dev-server-import-maps';
+import { chromeLauncher } from '@web/test-runner';
 
 export default {
   nodeResolve: true,
@@ -23,4 +24,5 @@ export default {
     report: true,
     include: ['src/**/*'],
   },
+  browsers: [chromeLauncher({ launchOptions: { args: ['--headless=old'] } })],
 };


### PR DESCRIPTION
locally this seemed to do the trick. issues caused by the new headless mode I suppose 