### PR TITLE
fix(playback-core): Make sure seekable TimeRanges is populated when updating state.

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -1100,12 +1100,17 @@ export const loadMedia = (
     }
   };
 
-  let prevSeekableStart: number;
-  let prevSeekableEnd: number;
+  let prevSeekableStart: number | undefined;
+  let prevSeekableEnd: number | undefined;
 
   const seekableChange = () => {
-    const nextSeekableStart = getSeekable(mediaEl)?.start(0);
-    const nextSeekableEnd = getSeekable(mediaEl)?.end(0);
+    const seekableTimeRanges = getSeekable(mediaEl);
+    let nextSeekableStart: number | undefined;
+    let nextSeekableEnd: number | undefined;
+    if (seekableTimeRanges.length > 0) {
+      nextSeekableStart = seekableTimeRanges.start(0);
+      nextSeekableEnd = seekableTimeRanges.end(0);
+    }
     if (prevSeekableEnd !== nextSeekableEnd || prevSeekableStart !== nextSeekableStart) {
       mediaEl.dispatchEvent(new CustomEvent('seekablechange', { composed: true }));
     }


### PR DESCRIPTION
Suspect this is the root cause of (non-fatal) error logs showing up in test runs (including CI).