### PR TITLE
fix: Mux-player childList observer behavior

### DIFF
--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -155,7 +155,7 @@ class VideoApiElement extends globalThis.HTMLElement implements VideoApiElement 
 
           mutation.addedNodes.forEach((node) => {
             const element = node as HTMLElement;
-            if (!element?.slot) {
+            if (!element?.slot && element.parentElement === this) {
               this.media?.append(getOrInsertNodeClone(this.#mediaChildrenMap, node));
             }
           });

--- a/packages/mux-player/src/video-api.ts
+++ b/packages/mux-player/src/video-api.ts
@@ -155,7 +155,7 @@ class VideoApiElement extends globalThis.HTMLElement implements VideoApiElement 
 
           mutation.addedNodes.forEach((node) => {
             const element = node as HTMLElement;
-            if (!element?.slot && element.parentElement === this) {
+            if (!element?.slot) {
               this.media?.append(getOrInsertNodeClone(this.#mediaChildrenMap, node));
             }
           });
@@ -164,7 +164,7 @@ class VideoApiElement extends globalThis.HTMLElement implements VideoApiElement 
     };
 
     const observer = new MutationObserver(mutationCallback);
-    observer.observe(this, { childList: true, subtree: true });
+    observer.observe(this, { childList: true });
   }
 
   /**


### PR DESCRIPTION
https://github.com/muxinc/elements/issues/1038

My fix is based on the assumption that this part of code is correct. And only top level children should be copied.
![image](https://github.com/user-attachments/assets/0a6aab3a-f30f-4c5c-8f1c-fde632e11b0f)
