### PR TITLE
fix: cap level controller import in cjs build

### DIFF
--- a/packages/playback-core/src/min-cap-level-controller.ts
+++ b/packages/playback-core/src/min-cap-level-controller.ts
@@ -1,6 +1,9 @@
-import type Hls from 'hls.js';
+import Hls from './hls';
+import type { HlsInterface } from './hls';
 import type { Level } from 'hls.js';
-import { CapLevelController } from 'hls.js';
+
+// The hls.js commonJS module doesn't export CapLevelController, so get it from the default config.
+const CapLevelController = Hls.DefaultConfig.capLevelController;
 
 /**
  * A custom HLS.js CapLevelController that behaves like the default one, except
@@ -10,7 +13,7 @@ class MinCapLevelController extends CapLevelController {
   // Never cap below this level.
   static minMaxResolution = 720;
 
-  constructor(hls: Hls) {
+  constructor(hls: HlsInterface) {
     super(hls);
   }
 


### PR DESCRIPTION
`CapLevelController` doesn't seem to be exported directly in the CJS bundle, 
https://cdn.jsdelivr.net/npm/hls.js@1.5.17/dist/hls.js

See in
https://cdn.jsdelivr.net/npm/@mux/playback-core@0.28.0/dist/index.cjs.js

```js
var ye=require("hls.js"),Z=class Z extends ye.CapLevelController{constructor(t){super(t)}get levels(){var t;return(t=this.hls.levels)!=null?t:[]}getValidLevels(t){return this.levels.filter((r,n)=>this.isLevelAllowed(r)&&n<=t)}getMaxLevel(t){let r=super.getMaxLevel(t),n=this.getValidLevels(t);if(!n[r])return r;let o=Math.min(n[r].width,n[r].height),a=Z.minMaxResolution;return o>=a?r:ye.CapLevelController.getMaxLevelByMediaSize(n,a*(16/9),a)}};Z.minMaxRe
```

<img width="672" alt="SCR-20241217-lobb" src="https://github.com/user-attachments/assets/b0a7ec13-9cca-4726-9cea-8ac71b620a69" />
