### PR TITLE
fix(playback-core): Update hls.js version to fix multi-DRM playready bug.

### DIFF
--- a/packages/mux-audio/package.json
+++ b/packages/mux-audio/package.json
@@ -76,7 +76,7 @@
     "downlevel-dts": "^0.11.0",
     "esbuild": "^0.24.1",
     "eslint": "^9.17.0",
-    "hls.js": "~1.5.18",
+    "hls.js": "~1.5.19",
     "npm-run-all": "^4.1.5",
     "replace": "^1.2.1",
     "shx": "^0.3.4",

--- a/packages/mux-player/package.json
+++ b/packages/mux-player/package.json
@@ -112,7 +112,7 @@
     "downlevel-dts": "^0.11.0",
     "esbuild": "^0.24.1",
     "eslint": "^9.17.0",
-    "hls.js": "~1.5.18",
+    "hls.js": "~1.5.19",
     "npm-run-all": "^4.1.5",
     "replace": "^1.2.1",
     "shx": "^0.3.4",

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -96,7 +96,7 @@
     "downlevel-dts": "^0.11.0",
     "esbuild": "^0.24.1",
     "eslint": "^9.17.0",
-    "hls.js": "~1.5.18",
+    "hls.js": "~1.5.19",
     "npm-run-all": "^4.1.5",
     "react": "^18.2.0",
     "replace": "^1.2.1",

--- a/packages/playback-core/package.json
+++ b/packages/playback-core/package.json
@@ -57,7 +57,7 @@
     "build": "npm-run-all --parallel 'build:esm --minify' 'build:iife --minify' 'build:cjs --minify' 'build:esm-module --minify'"
   },
   "dependencies": {
-    "hls.js": "~1.5.18",
+    "hls.js": "~1.5.19",
     "mux-embed": "^5.5.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9703,10 +9703,10 @@ header-case@^2.0.4:
     capital-case "^1.0.4"
     tslib "^2.0.3"
 
-hls.js@~1.5.18:
-  version "1.5.18"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.5.18.tgz#f0279072c31ba763efc08b6c7dff0f10f0703db0"
-  integrity sha512-znxR+2jecWluu/0KOBqUcvVyAB5tLff10vjMGrpAlz1eFY+ZhF1bY3r82V+Bk7WJdk03iTjtja9KFFz5BrqjSA==
+hls.js@~1.5.19:
+  version "1.5.19"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-1.5.19.tgz#bc8471a7c712f1314b04b2be4639dd273819d3dc"
+  integrity sha512-C020dKWEJcyvLnrqsFKW4q6D/6IEzKWdhktIS5bgoyEFE8lHgrFBq4RIngdy113abJOlIruhv8qjg7UX8hwxOw==
 
 hoopy@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
For details on the bug and fix, see:
- https://github.com/video-dev/hls.js/issues/6947
- https://github.com/video-dev/hls.js/pull/6946

Full smoke testing of the issue requires a Windows machine with Edgeium and Widevine DRM disabled. If available, please reach out for details on playback ids + tokens to test.