### PR TITLE
fix(mux-player): Make error dialog not accessible when hidden

### DIFF
--- a/packages/mux-player/src/themes/gerwig/gerwig.html
+++ b/packages/mux-player/src/themes/gerwig/gerwig.html
@@ -393,6 +393,7 @@
 
     media-error-dialog:not([mediaerrorcode]) {
       opacity: 0;
+      visibility: hidden;
     }
 
     media-loading-indicator {


### PR DESCRIPTION
A customer noticed in an audit that not hiding the error dialog via `visibility` caused some accessibility issues as it was still reachable in some cases. I couldn't see an issue with proactively setting it to `hidden` while we intend to hide it anyway, so have updated it.