### PR TITLE
fix(playback-core): Remove redundant FPS DRM generateRequest() for native playback.

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -867,7 +867,6 @@ export const setupNativeFairplayDRM = (
           );
         }),
       ]).then(([, messageEventMsg]) => messageEventMsg);
-      session.generateRequest(initDataType, initData);
 
       const response = await getLicenseKey(message, toLicenseKeyURL(props, 'fairplay')).catch((errOrResp) => {
         if (errOrResp instanceof Response) {


### PR DESCRIPTION
### Issue TL;DR: 
- This only happens when using FairPlay + Safari + Native HLS playback
- There are two `generateRequest()` for FairPlay DRM + native playback, but there should only be one
- The second causes an error/promise rejection due to the state of the `session`
- This doesn't have any "real" consequences for playback, because the first `generateRequest()` was valid and is used downstream for server request + response + session update
- It should still be resolved because
  - It's wrong
  - It may propagate out to error tools like Sentry, resulting in false positives for error monitoring