### PR TITLE
fix: allow extension less Mux m3u8 url as src

### DIFF
--- a/packages/playback-core/src/util.ts
+++ b/packages/playback-core/src/util.ts
@@ -91,12 +91,25 @@ export const inferMimeTypeFromURL = (url: string) => {
   }
 
   const extDelimIdx = pathname.lastIndexOf('.');
-  if (extDelimIdx < 0) return '';
+  if (extDelimIdx < 0) {
+    if (isExtensionLessMuxM3U8URL(url)) {
+      return ExtensionMimeTypeMap.M3U8; // Treat extension-less Mux URLs as HLS
+    }
+    return '';
+  }
 
   const ext = pathname.slice(extDelimIdx + 1);
   const upperExt = ext.toUpperCase();
 
   return isKeyOf(upperExt, ExtensionMimeTypeMap) ? ExtensionMimeTypeMap[upperExt] : '';
+};
+
+const isExtensionLessMuxM3U8URL = (url: string): boolean => {
+  // Match https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008
+  // and https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008?foo=bar
+  // and https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008?foo=bar&baz=qux
+  // but not https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008.m3u8
+  return /^https?:\/\/(stream\.mux\.com)\/[a-zA-Z0-9]+(?!\.m3u8)/.test(url.trim());
 };
 
 export type MuxJWT = {

--- a/packages/playback-core/test/util.test.js
+++ b/packages/playback-core/test/util.test.js
@@ -52,6 +52,20 @@ describe('Module: util', () => {
       const actual = getType({ src: `http://foo.com/bar.${extension}`, type: MimeTypeShorthandMap.HLS });
       assert.equal(actual, expected);
     });
+
+    it('should support Mux extensionless m3u8 URLs', () => {
+      const expected = ExtensionMimeTypeMap.M3U8;
+      // Mux extensionless m3u8 URLs should be treated as M3U8
+      const actual = getType({ src: 'https://stream.mux.com/abc123' });
+      assert.equal(actual, expected);
+    });
+
+    it('should support Mux extensionless m3u8 URLs with custom domain', () => {
+      const expected = ExtensionMimeTypeMap.M3U8;
+      // Mux extensionless m3u8 URLs with custom domain should be treated as M3U8
+      const actual = getType({ src: 'https://stream.abc.com/abc123', customDomain: 'abc.com' });
+      assert.equal(actual, expected);
+    });
   });
 
   describe('parseJwt', () => {


### PR DESCRIPTION
this allows 
https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008
https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008?foo=bar
instead of 
https://stream.mux.com/Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008.m3u8

this is needed for react-player to have a difference in the source to choose which provider.
the one where they add the .m3u8 goes to hls-video, without the extension goes to mux-player.