### PR TITLE
fix: default-hidden-captions order bug for React

### DIFF
--- a/examples/astro/src/pages/mux-player-react-lazy.astro
+++ b/examples/astro/src/pages/mux-player-react-lazy.astro
@@ -13,7 +13,7 @@ import MuxPlayer from '@mux/mux-player-react/lazy';
     streamType="on-demand"
     autoplay={true}
     muted={true}
-    playbackId="Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008"
+    playbackId="ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s"
     metadata={{
       video_title: 'Elephants Dream',
     }}

--- a/examples/astro/src/pages/mux-player-react.astro
+++ b/examples/astro/src/pages/mux-player-react.astro
@@ -13,7 +13,7 @@ import MuxPlayer from '@mux/mux-player-react';
     streamType="on-demand"
     autoplay={true}
     muted={true}
-    playbackId="Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008"
+    playbackId="ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s"
     metadata={{
       video_title: 'Elephants Dream',
     }}

--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -120,7 +120,7 @@ const DEFAULT_INITIAL_STATE: Partial<MuxPlayerProps> = Object.freeze({
   crossOrigin: undefined,
   customDomain: undefined,
   tokens: undefined,
-  playbackId: undefined,
+  playbackId: 'ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s',
   streamType: undefined,
   storyboardSrc: undefined,
   theme: undefined,

--- a/examples/nextjs-with-typescript/pages/MuxPlayerPosterSlot.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayerPosterSlot.tsx
@@ -25,6 +25,7 @@ function MuxPlayerPage() {
         playbackId="VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA"
         autoPlay={autoplay}
         muted={muted}
+        defaultHiddenCaptions={true}
         onPlay={() => {
           setPaused(false);
         }}

--- a/examples/vanilla-ts-esm/public/mux-player-audio-tracks.html
+++ b/examples/vanilla-ts-esm/public/mux-player-audio-tracks.html
@@ -41,7 +41,7 @@
     <mux-player
       id="muxPlayer"
       stream-type="on-demand"
-      playback-id="Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008"
+      playback-id="ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s"
     ></mux-player>
 
     <br>

--- a/examples/vanilla-ts-esm/public/mux-player-error.html
+++ b/examples/vanilla-ts-esm/public/mux-player-error.html
@@ -38,7 +38,7 @@
       </div>
     </header>
 
-    <!-- Correct playbackid: Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008 -->
+    <!-- Correct playbackid: ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s -->
     <mux-player
       stream-type="on-demand"
       playback-id="Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB00"
@@ -54,7 +54,7 @@
       const loadVideoBtn = document.getElementById('load-video-btn');
 
       loadVideoBtn.addEventListener('click', () => {
-        player.playbackId = 'Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008';
+        player.playbackId = 'ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s';
       });
     </script>
 

--- a/examples/vanilla-ts-esm/public/mux-player-theme-classic.html
+++ b/examples/vanilla-ts-esm/public/mux-player-theme-classic.html
@@ -42,7 +42,7 @@
     <mux-player
       theme="classic"
       stream-type="on-demand"
-      playback-id="Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008"
+      playback-id="ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s"
     ></mux-player>
     
     <mux-player

--- a/examples/vanilla-ts-esm/public/mux-player.html
+++ b/examples/vanilla-ts-esm/public/mux-player.html
@@ -42,7 +42,7 @@
 
     <mux-player
       stream-type="on-demand"
-      playback-id="Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008"
+      playback-id="ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s"
     >
       <track label="Japanese" kind="captions" srclang="ja" src="./vtt/elephantsdream/captions.ja.vtt"></track>
       <track default kind="chapters" src="./vtt/elephantsdream/chapters.vtt"></track>
@@ -67,7 +67,7 @@
 
     <mux-player
       stream-type="on-demand"
-      playback-id="Sc89iWAyNkhJ3P1rQ02nrEdCFTnfT01CZ2KmaEcxXfB008"
+      playback-id="ihZa7qP1zY8oyLSQW9TS602VgwQvNdyIvlk9LInEGU2s"
       proudly-display-mux-badge
     ></mux-player>
 

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -275,6 +275,7 @@ const MuxPlayer = React.forwardRef<
     <MuxPlayerInternal
       /** @TODO Fix types relationships (CJP) */
       ref={playerRef as typeof innerPlayerRef}
+      defaultHiddenCaptions={props.defaultHiddenCaptions}
       playerSoftwareName={playerSoftwareName}
       playerSoftwareVersion={playerSoftwareVersion}
       playerInitTime={playerInitTime}


### PR DESCRIPTION
fix #1062

I could not reproduce the bug anymore in React but I believe this should improve it even more.

This makes sure the first attribute is set to `default-hidden-captions` in React so that is immediately available in the first render of the theme.