### PR TITLE
fix: remove default playerInitTime

### DIFF
--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -270,7 +270,6 @@ const MuxPlayer = React.forwardRef<
   const innerPlayerRef = useRef<MuxPlayerElement>(null);
   const playerRef = useCombinedRefs(innerPlayerRef, ref);
   const [remainingProps] = usePlayer(innerPlayerRef, props);
-  const [playerInitTime] = useState(props.playerInitTime ?? generatePlayerInitTime());
 
   return (
     <MuxPlayerInternal
@@ -279,7 +278,6 @@ const MuxPlayer = React.forwardRef<
       defaultHiddenCaptions={props.defaultHiddenCaptions}
       playerSoftwareName={playerSoftwareName}
       playerSoftwareVersion={playerSoftwareVersion}
-      playerInitTime={playerInitTime}
       {...remainingProps}
     />
   );


### PR DESCRIPTION
fix #1117

alternative is to use `suppressHydrationWarning` https://github.com/muxinc/elements/pull/1116

I was first under the impression that we were sprouting this attribute from internally but it looks like it's set as a default prop value. 