### PR TITLE
feat: add adblocker bypass option, expose player props, and conditional captions menu

### DIFF
--- a/examples/nextjs-with-typescript/pages/mux-video-ads-react.tsx
+++ b/examples/nextjs-with-typescript/pages/mux-video-ads-react.tsx
@@ -47,6 +47,9 @@ function MuxVideoPage() {
         setSdkLoaded(true);  // Mark SDK as loaded
         console.log("Google IMA SDK loaded");
       };
+      script.onerror = () => {
+        setSdkLoaded(true);
+      };
       document.head.appendChild(script);
     };
     

--- a/examples/nextjs-with-typescript/pages/playlist-page.tsx
+++ b/examples/nextjs-with-typescript/pages/playlist-page.tsx
@@ -16,6 +16,9 @@ function MuxVideoPage() {
         setSdkLoaded(true);  // Mark SDK as loaded
         console.log("Google IMA SDK loaded");
       };
+      script.onerror = () => {
+        setSdkLoaded(true);
+      };
       document.head.appendChild(script);
     };
 
@@ -58,10 +61,10 @@ function MuxVideoPage() {
   return (
     <>
       <Head>
-        <title>&lt;Playlist/&gt; Demo</title>
+        <title>&lt;Playlist/&gt; Demo 3</title>
       </Head>
       
-      {sdkLoaded && <MuxNewsPlayer videoList={relatedVideos} />}
+      {sdkLoaded && <MuxNewsPlayer allowPlaybackWithAdBlocker={true} videoList={relatedVideos} />}
 
     </>
   );

--- a/packages/mux-player-react/MuxNewsPlayer.md
+++ b/packages/mux-player-react/MuxNewsPlayer.md
@@ -63,6 +63,9 @@ export default function YourComponent() {
         setSdkLoaded(true);
         console.log("Google IMA SDK loaded");
       };
+      script.onerror = () => {
+        setSdkLoaded(true);
+      };
       document.head.appendChild(script);
     };
 
@@ -141,6 +144,9 @@ export default function VideoMuxNewsPlayerPage() {
       script.onload = () => {
         setSdkLoaded(true);
         console.log("Google IMA SDK loaded");
+      };
+      script.onerror = () => {
+        setSdkLoaded(true);
       };
       document.head.appendChild(script);
     };

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -74,6 +74,7 @@ type MuxMediaPropTypes = {
 };
 
 export type MuxPlayerProps = {
+  allowPlaybackWithAdBlocker?: boolean;
   className?: string;
   hotkeys?: string;
   nohotkeys?: boolean;

--- a/packages/mux-player-react/src/mux-news-player.tsx
+++ b/packages/mux-player-react/src/mux-news-player.tsx
@@ -1,6 +1,7 @@
 /* eslint @typescript-eslint/triple-slash-reference: "off" */
 /// <reference types="google_interactive_media_ads_types" preserve="true"/>
 import React, { useRef, useState } from 'react';
+import type { MuxPlayerProps } from '@mux/mux-player-react'; // ✅ import prop types
 import PlaylistEndScreen from './playlist-end-screen';
 import '@mux/mux-video-ads';
 import MuxPlayer from '@mux/mux-player-react';
@@ -18,16 +19,16 @@ export interface VideoItem {
 
 export type PlaylistVideos = VideoItem[];
 
-export interface PlaylistProps {
+export interface PlaylistProps extends Omit<MuxPlayerProps, 'playbackId' | 'adTagUrl'> {
   videoList: PlaylistVideos;
+  allowPlaybackWithAdBlocker?: boolean;
 }
 
-export const MuxNewsPlayer = ({ videoList }: PlaylistProps) => {
+export const MuxNewsPlayer = ({ videoList, allowPlaybackWithAdBlocker, ...muxPlayerProps }: PlaylistProps) => {
   const mediaElRef = useRef<any>(null);
   const [autoplay, setAutoplay] = useState<'muted' | boolean>(INITIAL_AUTOPLAY);
   const [muted, setMuted] = useState(INITIAL_MUTED);
   const [paused, setPaused] = useState<boolean | undefined>(true);
-  const [sdkLoaded, setSdkLoaded] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isEndScreenVisible, setIsEndScreenVisible] = useState(false);
   const [playerKey, setPlayerKey] = useState(0);
@@ -52,6 +53,8 @@ export const MuxNewsPlayer = ({ videoList }: PlaylistProps) => {
     <div>
       <NewsTheme />
       <MuxPlayer
+        {...muxPlayerProps}
+        allowPlaybackWithAdBlocker={allowPlaybackWithAdBlocker}
         ref={mediaElRef}
         theme="news-theme"
         themeProps={{ controlBarVertical: true, controlBarPlace: 'start start' }}

--- a/packages/mux-player-react/src/themes/news-theme.tsx
+++ b/packages/mux-player-react/src/themes/news-theme.tsx
@@ -102,7 +102,7 @@ export default function NewsTheme() {
 
   <!-- Rendition Menu -->
   <style>
-    media-rendition-menu {
+    media-rendition-menu, media-captions-menu {
       position: absolute;
       border-radius: 0.3rem;
       right: 12px;
@@ -149,7 +149,7 @@ export default function NewsTheme() {
 
   <media-rendition-menu anchor="auto" hidden>
   </media-rendition-menu>
-
+  <media-captions-menu hidden anchor="auto"></media-captions-menu>
   <!-- Time Range / Progress Bar -->
 
   <style>
@@ -496,6 +496,7 @@ export default function NewsTheme() {
       </svg>
 
     </media-rendition-menu-button>
+    <media-captions-menu-button></media-captions-menu-button>
     </template>
 
     <!-- Fullscreen Button -->
@@ -584,7 +585,6 @@ export default function NewsTheme() {
         </g>
       </svg>
     </media-fullscreen-button>
-
   </media-control-bar>`,
         }}
       />

--- a/packages/mux-player/src/index.ts
+++ b/packages/mux-player/src/index.ts
@@ -187,6 +187,7 @@ function getProps(el: MuxPlayerElement, state?: any): MuxTemplateProps {
     // NOTE: since the attribute value is used as the "source of truth" for the property getter,
     // moving this below the `...state` spread so it resolves to the default value when unset (CJP)
     extraSourceParams: el.extraSourceParams,
+    allowPlaybackWithAdBlocker: el.getAttribute('allow-playback-with-ad-blocker'),
   };
 
   return props;
@@ -343,6 +344,7 @@ class MuxPlayerElement extends VideoApiElement implements MuxPlayerElement {
       if (!isFocusedElementInPlayer) event.preventDefault();
     },
   };
+  allowPlaybackWithAdBlocker: any;
 
   static get NAME() {
     return playerSoftwareName;

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -105,6 +105,7 @@ const getTagSpecificProps = (tag: string, props: MuxTemplateProps) => {
     'cast-src': !!props.src ? props.src : props.playbackId ? toMuxVideoURL(props) : false,
     'cast-receiver': props.castReceiver ?? false,
     'drm-token': props.tokens?.drm ?? false,
+    'allow-playback-with-ad-blocker': props.allowPlaybackWithAdBlocker ?? false,
     exportparts: 'video',
   };
 

--- a/packages/mux-player/src/types.d.ts
+++ b/packages/mux-player/src/types.d.ts
@@ -60,6 +60,7 @@ export type MuxTemplateProps = Partial<MuxPlayerProps> & {
   muxVideoElement: string;
   adTagUrl: string | undefined;
   adBreak: boolean;
+  allowPlaybackWithAdBlocker?: boolean;
 };
 
 export type DialogOptions = {


### PR DESCRIPTION
This PR introduces the following improvements:
	•	New `allowPlaybackWithAdBlocker` prop
Allows the player to continue playback even when an adblocker is detected.
	  •	If false (default): shows a blocking popup when an adblocker is present.
	  •	If true: bypasses the restriction and allows normal playback.
	•	Exposes underlying player props on MuxNewsPlayer
Enables more granular configuration and control over the embedded player through MuxNewsPlayer.
	•	Conditional captions menu
Adds a captions menu that appears only when text tracks are available.
	•	Allows users to disable captions if they prefer not to see them.
