### PR TITLE
fix: bring back cast button for drm protected videos

### DIFF
--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -11,7 +11,7 @@ const getPropsCSS = (props: MuxTemplateProps) => {
   const { tokens } = props;
   if (!tokens.drm) return '';
   // See styles.css for usage.
-  return ':host { --_cast-button-drm-display: none; }';
+  return ':host(:not([cast-receiver])) { --_cast-button-drm-display: none; }';
 };
 
 export const template = (props: MuxTemplateProps) => html`


### PR DESCRIPTION
## Context
I have been writing documentation for building a custom Chromecast sender and receiver for DRM playback. With the help of @luwes we discovered that the Mux player sends everything you need for a custom receiver to play DRM content. Unfortunately it's still not usable because we always hide the cast button when a DRM token is provided.

This PR brings back the cast button for DRM content if you configure a custom cast receiver.


## Testing

### Example code
```
    <mux-player
      id="player"
      playback-id="..."
      playback-token="..."
      drm-token=".."
      cast-receiver=""
    ></mux-player>
```

### In production 
Using the `<mux-player>` with a drm-token attribute will *hide* the cast button
Using the `<mux-player>` with a drm-token attribute and a cast-receiver attribute will *hide* the cast button

### In this PR
Using the `<mux-player>` with a drm-token attribute will *hide* the cast button
Using the `<mux-player>` with a drm-token attribute and a cast-receiver attribute will *show* the cast button
