### PR TITLE
fix(mux-player news): on demand ad tag url

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxNewsPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxNewsPlayer.tsx
@@ -10,19 +10,25 @@ function MuxNewsPlayerPage() {
       imageUrl: "https://image.mux.com/gZh02tKCI015W6k2XdYSh4srGnksYvsoT1uHsYOlv4Blo/thumbnail.webp",
       title: "Test video title 1",
       playbackId: "gZh02tKCI015W6k2XdYSh4srGnksYvsoT1uHsYOlv4Blo",
-      adTagUrl: "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_preroll_skippable&sz=640x480&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=",
+      // adTagUrl: "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_preroll_skippable&sz=640x480&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=",
+      adTagUrl: () => "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_preroll_skippable&sz=640x480&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=",
+      // adTagUrl: () => Promise.resolve("https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_preroll_skippable&sz=640x480&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator="),
     },
     {
       imageUrl: "https://image.mux.com/VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA/thumbnail.webp",
       title: "Test video title 2",
       playbackId: "VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA",
-      adTagUrl: "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpreonly&ciu_szs=300x250%2C728x90&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&correlator=",
+      // adTagUrl: "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpreonly&ciu_szs=300x250%2C728x90&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&correlator=",
+      adTagUrl: () => "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpreonly&ciu_szs=300x250%2C728x90&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&correlator=",
+      // adTagUrl: () => Promise.resolve("https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpreonly&ciu_szs=300x250%2C728x90&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&correlator="),
     },
     {
       imageUrl: "https://image.mux.com/maVbJv2GSYNRgS02kPXOOGdJMWGU1mkA019ZUjYE7VU7k/thumbnail.webp",
       title: "Test video title 3",
       playbackId: "maVbJv2GSYNRgS02kPXOOGdJMWGU1mkA019ZUjYE7VU7k",
-      adTagUrl: "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpreonlybumper&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&correlator=",
+      // adTagUrl: "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpreonlybumper&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&correlator=",
+      adTagUrl: () => "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpreonlybumper&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&correlator=",
+      // adTagUrl: () => Promise.resolve("https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpreonlybumper&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&correlator="),
     },
   ];
 
@@ -46,8 +52,8 @@ function MuxNewsPlayerPage() {
         }}
         strategy="afterInteractive"
       />
-      
-      {sdkReady && 
+
+      {sdkReady &&
         <MuxNewsPlayer
           allowAdBlocker={true}
           videoList={relatedVideos}

--- a/packages/mux-player-react/src/news/index.tsx
+++ b/packages/mux-player-react/src/news/index.tsx
@@ -85,8 +85,8 @@ const MuxNewsPlayer = ({ videoList, ...props }: PlaylistProps) => {
       {...props}
       ref={mediaElRef}
       key={`player-${playerKey}`}
-      adTagUrl={currentAdTagUrlString}
       playbackId={currentAdTagUrlString ? videoList[currentIndex].playbackId : undefined}
+      adTagUrl={currentAdTagUrlString}
       onEnded={(event) => {
         if (currentIndex < videoList.length - 1) {
           setEndScreenVisible(true);

--- a/packages/mux-player-react/src/news/playlist-end-screen.tsx
+++ b/packages/mux-player-react/src/news/playlist-end-screen.tsx
@@ -1,32 +1,33 @@
 import React, { useEffect, useState } from 'react';
-import { VideoItem, PlaylistVideos } from '.';
+import { VideoItem } from '.';
 import style from './playlist-end-screen.css';
 
-interface PlaylistEndScreenProps {
-  video: VideoItem;
-  relatedVideos: PlaylistVideos;
-  isVisible: boolean;
+type PlaylistEndScreenProps = {
+  currentIndex: number;
+  relatedVideos: VideoItem[];
+  visible: boolean;
   selectVideoCallback: (index: number) => void;
-  timerCallback: () => void;
-}
+};
 
 const PlaylistEndScreen = ({
-  video,
+  currentIndex = 0,
   relatedVideos,
-  isVisible,
+  visible,
   selectVideoCallback,
-  timerCallback,
 }: PlaylistEndScreenProps) => {
   const [count, setCount] = useState(3);
+  const video = relatedVideos[currentIndex];
 
   useEffect(() => {
-    if (!isVisible) {
+    if (!visible) {
       setCount(3);
       return;
     }
 
+    // For the countdown, simply select the "next" video. If at the end, cycle back to the 0th video.
     if (count < 0) {
-      timerCallback();
+      const nextIndex = (currentIndex + 1) % relatedVideos.length;
+      selectVideoCallback(nextIndex);
       return;
     }
     const timer = setInterval(() => {
@@ -34,14 +35,14 @@ const PlaylistEndScreen = ({
     }, 1000);
 
     return () => clearInterval(timer);
-  }, [count, isVisible]);
+  }, [count, visible]);
 
   return (
     <>
       <style>{style}</style>
-      <div className="playlist" style={{ display: isVisible ? 'grid' : 'none' }}>
-        <div className="overlay" style={{ display: isVisible ? 'grid' : 'none' }} />
-        <div className="post-video-section" style={{ display: isVisible ? 'grid' : 'none', zIndex: 99 }}>
+      <div className="playlist" style={{ display: visible ? 'grid' : 'none' }}>
+        <div className="overlay" style={{ display: visible ? 'grid' : 'none' }} />
+        <div className="post-video-section" style={{ display: visible ? 'grid' : 'none', zIndex: 99 }}>
           <div className="video-section">
             <div className="video-container">
               <h2 className="title">Video</h2>


### PR DESCRIPTION
* Add support for dynamic adTagUrl (sync or async functions) for on demand ad bids use cases.
* Some cleanup of ended playlist component implementation
* Update example for testing