### PR TITLE
fix: type error in metadata response

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -229,6 +229,8 @@ export const fetchAndDispatchMuxMetadata = async (metadataUrl: string, mediaEl: 
     const json = await resp.json();
     const metadata: Record<string, string> = {};
 
+    if (!json?.[0]?.metadata) return;
+
     for (const item of json[0].metadata) {
       if (item.key && item.value) {
         metadata[item.key] = item.value;


### PR DESCRIPTION
this would only happen for a mp4 and the type error is in a try catch so it didn't cause a breaking app.