### PR TITLE
fix(mux-player-react): Update order of props setting so playback id always comes first to resolve session-based expectations (e.g. mux data metadata).

### DIFF
--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -69,13 +69,16 @@ const usePlayer = (
     _hlsConfig,
     ...remainingProps
   } = props;
+  // NOTE: We should set playbackId before all other props to ensure that any playback/view session-specific props are applied to the approrpiate
+  // session. "Under the hood," we wait one frame before (re)initializing playback core (and thus e.g. hls.js and mux-embed data sdk), so everything
+  // should be applied as expected as a result.
+  useObjectPropEffect('playbackId', playbackId, ref);
   useObjectPropEffect('playbackRates', playbackRates, ref);
   useObjectPropEffect('metadata', metadata, ref);
   useObjectPropEffect('extraSourceParams', extraSourceParams, ref);
   useObjectPropEffect('_hlsConfig', _hlsConfig, ref);
   useObjectPropEffect('themeProps', themeProps, ref);
   useObjectPropEffect('tokens', tokens, ref);
-  useObjectPropEffect('playbackId', playbackId, ref);
   useObjectPropEffect('castCustomData', castCustomData, ref);
   useObjectPropEffect(
     'paused',


### PR DESCRIPTION
To validate, use https://elements-demo-nextjs-git-fork-cjpillsbury-fix-mux-da-eeafeb-mux.vercel.app/MuxNewsPlayer and confirm video titles are different and expected for each playlist item in our Mux Data Views.