### PR TITLE
fix(mux-player-react): Stop-gap solution to some architectural layer + src-related prop setting causing early and incorrect playback-core initialization.

### DIFF
--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -69,6 +69,11 @@ const usePlayer = (
     _hlsConfig,
     ...remainingProps
   } = props;
+  /**
+   * @TODO We need to have some better modeling/architecture around order effects. We should also revisit our mapping of media-request-related props
+   * all to `src` in our template code. For now, moving tokens before playbackId, as there are timing issues that happen if we set it after playbackId (CJP)
+   **/
+  useObjectPropEffect('tokens', tokens, ref);
   // NOTE: We should set playbackId before all other props to ensure that any playback/view session-specific props are applied to the approrpiate
   // session. "Under the hood," we wait one frame before (re)initializing playback core (and thus e.g. hls.js and mux-embed data sdk), so everything
   // should be applied as expected as a result.
@@ -78,7 +83,6 @@ const usePlayer = (
   useObjectPropEffect('extraSourceParams', extraSourceParams, ref);
   useObjectPropEffect('_hlsConfig', _hlsConfig, ref);
   useObjectPropEffect('themeProps', themeProps, ref);
-  useObjectPropEffect('tokens', tokens, ref);
   useObjectPropEffect('castCustomData', castCustomData, ref);
   useObjectPropEffect(
     'paused',


### PR DESCRIPTION
To smoke test, load [this page](https://elements-demo-nextjs-git-fork-cjpillsbury-fix-order-852a9b-mux.vercel.app/MuxPlayer?playbackId=%22qIJBqaJPkhNXiHbed8j2jyx02tQQWBI5fL6WkIQYL63w%22&tokens=%7B%22playback%22%3A%22eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImFkamYzb2JpYURUcEF0QVlpS3NCMkpvRlkwMXBpbEJMTHdYcUQzaHpJYURJIn0.eyJleHAiOjE5NjE2NDY0MDMsImF1ZCI6InYiLCJzdWIiOiJxSUpCcWFKUGtoTlhpSGJlZDhqMmp5eDAydFFRV0JJNWZMNldrSVFZTDYzdyJ9.mukZou10_iwaqPeHVFbXwTZShMK1D8kWpFAFOl6bwuIMB7hx0bAqscZxj5FwrIB8dzB6s_9YtJEEVXcR6ezxOhOc_y2ij1XM4YQYCuGH-elJc3rapHbahv2K7L_asz9Bdu1Ld6i6Ux7keNpEuGSYCDmsPmvdII7_XAPmzU01ZTvaXqCgzCY2PO7xz6z3hu1HOww2eL41TSif_Zu0okNZlhfHE9U-nyr4OVpuS9Q-rTtVvfE2ILSd9Ezt02AuOK-JkBCeR3Xf-UrbXB33ZFHLJrYVA-B516Iym0CGRfVssZsAn80_PNaxS_3M_OmVzyaDJ4zudb-YjGcaNl0yf96h6w%22%2C%22storyboard%22%3A%22eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImFkamYzb2JpYURUcEF0QVlpS3NCMkpvRlkwMXBpbEJMTHdYcUQzaHpJYURJIn0.eyJleHAiOjE5NjE2NTkzMTQsImF1ZCI6InMiLCJzdWIiOiJxSUpCcWFKUGtoTlhpSGJlZDhqMmp5eDAydFFRV0JJNWZMNldrSVFZTDYzdyJ9.QxvtM-FBakS8IPl_mZloBKLKyHRU8md7IbSifAYbAVHrLwUre3-CXlOcsd6sKi0hVen_DnSqQeuuFTYF6o2TeS31gnBsf5U4W7JDpOjxAepj4ODM6bpPJBu6XDpZmMTduuwVrIXP9pQWSwiHSQ93hk6RR17YrPgGz6sCXIL5gt0re_WqkSEazwYEscu9eByMN3F_sM7W830C7Wzeatb1TMeEf6wQhbpKABLB33VM0FOuM5ojjI9DWmDhJksfFVrOxaZtoju4hjiWQtNPVBCFP28J9LHNLA7brRXvDGaIUxHG5-vrcVuImlghdWgPyrAOb0lWYSiklYx2ObHhNWJK1g%22%2C%22thumbnail%22%3A%22eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImFkamYzb2JpYURUcEF0QVlpS3NCMkpvRlkwMXBpbEJMTHdYcUQzaHpJYURJIn0.eyJleHAiOjE5NjE2NTkzMzAsImF1ZCI6InQiLCJzdWIiOiJxSUpCcWFKUGtoTlhpSGJlZDhqMmp5eDAydFFRV0JJNWZMNldrSVFZTDYzdyJ9.zQ0tDimpgu7nsT9Tb7GBgitMpYSbLBodwS-fSc7U0K0WT-giCUgxXXSqXquwpHMjEEfSuCsCU3Y1gq2P7WaJUBGTOTLKT5GOwyhjeoJzTPXEQqW7T-tpKXhjEDVwy_H2UPNVdA9ZALos5R9rrWyiTQA53sxT56FWy-IhvaISpiB16nzankRKCAo98kh6lloexE8p3lXnUhLwIK8Hqco4hRmHSmWqUndnJrbq0_kag0o8R0drffSMj6CvKas8_f6v3MtHXDhW0JkJ1TZKwICt7W-jrSyMfhgAb9wltBCUXdNHYvQTXkFfFnsI1R-BuZodQL2zN3pVBqzuhQA0UPADMw%22%7D&metadata=%7B%22video_id%22%3A%22videoId13%22%2C%22video_title%22%3A%22Title%3A+Landscape+VOD+%28with+Tokens%29%22%7D&videoTitle=%22Landscape+VOD+%28with+Tokens%29%22&placeholder=%22data%3Aimage%2Fjpeg%3Bbase64%2C%2F9j%2F2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN%2BgXz%2F2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz%2FwAARCAASACADASIAAhEBAxEB%2F8QAGQAAAwEBAQAAAAAAAAAAAAAAAAQFAwEC%2F8QAHRAAAgICAwEAAAAAAAAAAAAAAAECAwQhERIxIv%2FEABUBAQEAAAAAAAAAAAAAAAAAAAME%2F8QAGhEAAgMBAQAAAAAAAAAAAAAAAAEDETEyUf%2FaAAwDAQACEQMRAD8Ak9UjnHYXqtlJ%2FQ1FrgvT8Imq0xsxFNbJ%2BTSqXop22tLRMyZuctgy4NHY7E1XgAKAzxZ4I3gAc3Isen%2F%2F2Q%3D%3D%22) in safari (pre-configured via URL next.js MuxPlayer test page)