### PR TITLE
Fix: Remove error dialog for audio only

### DIFF
--- a/packages/mux-player/src/themes/classic/classic.html
+++ b/packages/mux-player/src/themes/classic/classic.html
@@ -525,10 +525,8 @@
     <slot name="media" slot="media"></slot>
     <slot name="poster" slot="poster"></slot>
     <media-loading-indicator slot="centered-chrome" noautohide></media-loading-indicator>
-    <media-error-dialog slot="dialog" noautohide></media-error-dialog>
-
+    
     <template if="audio">
-
       <template if="streamtype == 'on-demand'">
         <template if="title">
           <media-control-bar part="control-bar top">{{>TitleDisplay}}</media-control-bar>
@@ -590,7 +588,7 @@
     </template>
 
     <template if="!audio">
-
+      <media-error-dialog slot="dialog" noautohide></media-error-dialog>
       <template if="streamtype == 'on-demand'">
 
         <template if="!breakpointsm">

--- a/packages/mux-player/src/themes/gerwig/gerwig.html
+++ b/packages/mux-player/src/themes/gerwig/gerwig.html
@@ -1027,9 +1027,9 @@
     <slot name="poster" slot="poster"></slot>
 
     <media-loading-indicator slot="centered-chrome" noautohide></media-loading-indicator>
-    <media-error-dialog slot="dialog" noautohide></media-error-dialog>
 
     <template if="!audio">
+      <media-error-dialog slot="dialog" noautohide></media-error-dialog>
       <!-- Pre-playback UI -->
       <!-- same for both on-demand and live -->
       <div slot="centered-chrome" class="center-controls pre-playback">


### PR DESCRIPTION
Fixes #1189 

## Changes
Error dialog is no longer rendered if the media is an audio.