### PR TITLE
fix: Add display names to React Components

### DIFF
--- a/packages/mux-video/src/ads/react.ts
+++ b/packages/mux-video/src/ads/react.ts
@@ -8,6 +8,7 @@ import { createComponent } from 'ce-la-react';
 export default createComponent({
   react: React,
   tagName: 'mux-video',
+  displayName: 'MuxVideoAds',
   elementClass: MuxVideoElement,
   toAttributeName,
 });

--- a/packages/mux-video/src/react.ts
+++ b/packages/mux-video/src/react.ts
@@ -8,6 +8,7 @@ import { createComponent } from 'ce-la-react';
 export default createComponent({
   react: React,
   tagName: 'mux-video',
+  displayName: 'MuxVideo',
   elementClass: MuxVideoElement,
   toAttributeName,
 });


### PR DESCRIPTION
This PR relates to an issue that happens commonly on next-video. This does not fix the issue, but makes the warning message more clear.

Relates to:
- https://github.com/muxinc/next-video/issues/397
- https://github.com/muxinc/ce-la-react/issues/6

When rendering a MuxVideo element from `@mux/mux-video/react` we see this message:
```
Check the render method of `i`. See https://react.dev/link/warning-keys for more information.
Each child in a list should have a unique "key" prop.
```

This PR changes the message to be:
```
Check the render method of `MuxVideo`. See https://react.dev/link/warning-keys for more information.
Each child in a list should have a unique "key" prop.
```

This also happens with `hls-video-element/react` and `dash-video-element/react` (which already have the displayName).
You can test this by running the example in `next-video` (while [this issue](https://github.com/muxinc/next-video/issues/397) is open) and seeing the Next console logs.