### PR TITLE
fix: suppressing non fatal errors

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -1574,14 +1574,11 @@ const getErrorFromHlsErrorData = (
   props: Partial<Pick<MuxMediaPropsInternal, 'playbackId' | 'drmToken' | 'playbackToken' | 'tokens' | 'debug'>>
 ) => {
   // Non-fatal errors: only log when debug is enabled (using console.warn to reduce user concern)
-  // Fatal errors: always log (using console.error)
-  // Consider non-fatal if fatal is explicitly false, undefined, or any other falsy value
   const isNonFatal = !data.fatal;
   if (isNonFatal) {
     if (props.debug) {
       console.warn('getErrorFromHlsErrorData() (non-fatal)', data);
     }
-    // Don't log non-fatal errors when debug is off
   } else {
     console.error('getErrorFromHlsErrorData()', data);
   }


### PR DESCRIPTION
This PR closes #1208

Non-fatal getErrorFromHlsErrorData errors are only logged when the debug prop is enabled, using console.warn instead of console.error to indicate they are recoverable. When debug is disabled, non-fatal errors are silent. 