### PR TITLE
fix: default to MSE except safari

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -329,7 +329,6 @@ declare global {
 
 const userAgentStr = globalThis?.navigator?.userAgent ?? '';
 const userAgentPlatform = globalThis?.navigator?.userAgentData?.platform ?? '';
-const browserBrands = globalThis?.navigator?.userAgentData?.brands ?? [];
 
 // NOTE: Our primary *goal* with this is to detect "non-Apple-OS" platforms which may also support
 // native HLS playback. Our primary concern with any check for this is "false negatives" where we


### PR DESCRIPTION
This change updates the video player logic to use MSE by default if its not Safari since. Chromium-based browsers with native HLS support were experiencing issues with captions not available. By defaulting to MSE except on Safari, we ensure captions work consistently across browsers.  

**Changes:**  
- Replaced Chrome detection with Safari detection.
- Updated logic to fallback to MSE for non-Safari browsers.
- Maintains native HLS for Safari for optimal compatibility.