### PR TITLE
fix: add Mux Data SDK packages to Dependabot allow-list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,5 @@ updates:
       - dependency-name: 'castable-video'
       - dependency-name: 'custom-media-element'
       - dependency-name: 'media-tracks'
+      - dependency-name: 'mux-embed'
+      - dependency-name: '@mux/mux-data-google-ima'

--- a/package-lock.json
+++ b/package-lock.json
@@ -4168,15 +4168,6 @@
       "resolved": "packages/mux-audio-react",
       "link": true
     },
-    "node_modules/@mux/mux-data-google-ima": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.2.8.tgz",
-      "integrity": "sha512-0ZEkHdcZ6bS8QtcjFcoJeZxJTpX7qRIledf4q1trMWPznugvtajCjCM2kieK/pzkZj1JM6liDRFs1PJSfVUs2A==",
-      "license": "MIT",
-      "dependencies": {
-        "mux-embed": "5.9.0"
-      }
-    },
     "node_modules/@mux/mux-elements-codemod": {
       "resolved": "packages/mux-elements-codemod",
       "link": true
@@ -25586,7 +25577,7 @@
         "@mux/mux-video": "0.30.0",
         "@mux/playback-core": "0.33.0",
         "media-chrome": "~4.17.2",
-        "player.style": "^0.3.1"
+        "player.style": "^0.3.0"
       },
       "devDependencies": {
         "@mux/esbuilder": "0.1.0",
@@ -26359,7 +26350,7 @@
       "version": "0.30.0",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-data-google-ima": "0.2.8",
+        "@mux/mux-data-google-ima": "^0.3.4",
         "@mux/playback-core": "0.33.0",
         "castable-video": "~1.1.11",
         "custom-media-element": "~1.4.5",
@@ -26444,12 +26435,27 @@
         "@types/react": "^18.0.0"
       }
     },
+    "packages/mux-video/node_modules/@mux/mux-data-google-ima": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.3.4.tgz",
+      "integrity": "sha512-j8IOD5kw1qIOkbpipEQRGQ7vXB6+CArrhIAvtvj8YFqy0PHi7JcHk4WR3ZBVy5+5yaRCH+nzHkmJmGsg8g6O5g==",
+      "license": "MIT",
+      "dependencies": {
+        "mux-embed": "5.16.1"
+      }
+    },
     "packages/mux-video/node_modules/hls.js": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.15.tgz",
       "integrity": "sha512-E3a5VwgXimGHwpRGV+WxRTKeSp2DW5DI5MWv34ulL3t5UNmyJWCQ1KmLEHbYzcfThfXG8amBL+fCYPneGHC4VA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "packages/mux-video/node_modules/mux-embed": {
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.16.1.tgz",
+      "integrity": "sha512-XWeOG/nzrfRjdyDajW9VNiP0FuKZhEIHMh8Ybpo8uudQByRSOKH8qOaL+MEGdm7KAHzJunwoyYNodD059Spw/A==",
+      "license": "MIT"
     },
     "packages/playback-core": {
       "name": "@mux/playback-core",

--- a/packages/mux-video/package.json
+++ b/packages/mux-video/package.json
@@ -124,7 +124,7 @@
     "build": "npm-run-all 'build:esm:base -- --minify' 'build:cjs:base -- --minify' 'build:esm:ads:mixin -- --minify' 'build:cjs:ads:mixin -- --minify' --parallel 'build:esm:** -- --minify' 'build:cjs:** -- --minify' 'build:iife:** -- --minify' 'build:esm-module:** -- --minify'"
   },
   "dependencies": {
-    "@mux/mux-data-google-ima": "0.2.8",
+    "@mux/mux-data-google-ima": "^0.3.4",
     "@mux/playback-core": "0.33.0",
     "castable-video": "~1.1.11",
     "custom-media-element": "~1.4.5",


### PR DESCRIPTION
## Summary

- Adds `mux-embed` and `@mux/mux-data-google-ima` to the Dependabot allow-list in `.github/dependabot.yml` so new releases automatically generate PRs.
- Changes `@mux/mux-data-google-ima` from a pinned version (`0.2.8`) to a caret range (`^0.3.4`) so compatible updates are resolved by `npm install`. This immediately bumps it to `0.3.4` (and transitively bumps `mux-embed` from `5.9.0` to `5.16.1`).

After this, when a new `mux-embed` or `@mux/mux-data-google-ima` release is published, Dependabot will automatically open a PR on its daily schedule.