### PR TITLE
fix(mux-video): remove duplicate word in prefer-playback docs

### DIFF
--- a/packages/mux-video/README.md
+++ b/packages/mux-video/README.md
@@ -165,7 +165,7 @@ Take a look at the [metadata guide](https://docs.mux.com/guides/data/make-your-d
 ### Advanced: prefer-playback
 
 By default `<mux-video>` will try to use native playback via the underlying `<video>` tag whenever possible.
-However, it can also instead use an in-code player when the browser browser supports [Media Source Extension](https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extensions_API).
+However, it can also instead use an in-code player when the browser supports [Media Source Extension](https://developer.mozilla.org/en-US/docs/Web/API/Media_Source_Extensions_API).
 This includes MSE in Mac OS Safari.
 
 If you prefer to use the in-code MSE-based engine (currently hls.js) whenever possible, then set the `prefer-playback` attribute to `mse`.


### PR DESCRIPTION
Fixes a typo in docs.

Labeled as fix to trigger release. https://github.com/muxinc/elements/pull/1268 and https://github.com/muxinc/elements/pull/1271 and https://github.com/muxinc/elements/pull/1273 failed to release due to a misconfiguration in our npm tokens.