### PR TITLE
test: add slow proxy to next app for slow storyboard blocking playbac…

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -1,10 +1,11 @@
 import Head from 'next/head';
 import MuxPlayer, { MuxPlayerProps, MaxResolution, MinResolution, RenditionOrder } from '@mux/mux-player-react';
+import type MuxPlayerElement from '@mux/mux-player';
 import '@mux/mux-player/themes/classic';
 import '@mux/mux-player/themes/minimal';
 import '@mux/mux-player/themes/microvideo';
 import '@mux/mux-player/themes/gerwig';
-import { useReducer, useState } from 'react';
+import { useReducer, useRef, useState } from 'react';
 import mediaAssetsJSON from '@mux/assets/media-assets.json';
 import type { NextParsedUrlQuery } from 'next/dist/server/request-meta';
 import {
@@ -252,7 +253,8 @@ export const getServerSideProps = getLocationServerSideProps;
 type Props = LocationProps;
 
 function MuxPlayerPage({ location }: Props) {
-  // const mediaElRef = useRef<MuxPlayerElement>(null);
+  const mediaElRef = useRef<MuxPlayerElement>(null);
+  const [playerSoftwareInfo, setPlayerSoftwareInfo] = useState<{ name?: string; version?: string }>({});
   const [mediaAssets, _setMediaAssets] = useState(mediaAssetsJSON);
   const [selectedAsset, setSelectedAsset] = useState(undefined);
   /** @TODO fix typing complexities here (CJP) */
@@ -272,7 +274,7 @@ function MuxPlayerPage({ location }: Props) {
       <main className="component-page">
         <div id="custom-fullscreen-element">
         <MuxPlayer
-          // ref={mediaElRef}
+          ref={mediaElRef}
           style={stylesState}
           theme={state.theme}
           fullscreenElement={state.fullscreenElement}
@@ -302,7 +304,13 @@ function MuxPlayerPage({ location }: Props) {
           crossOrigin={state.crossOrigin}
           nohotkeys={state.nohotkeys}
           hotkeys={state.hotkeys}
-          // onPlayerReady={() => console.log("ready!")}
+          onPlayerReady={(evt) => {
+            onPlayerReady(evt);
+            setPlayerSoftwareInfo({
+              name: mediaElRef.current?.playerSoftwareName,
+              version: mediaElRef.current?.playerSoftwareVersion,
+            });
+          }}
           preferCmcd={state.preferCmcd}
           preferPlayback={state.preferPlayback}
           debug={state.debug}
@@ -362,6 +370,12 @@ function MuxPlayerPage({ location }: Props) {
         <div className="options">
           <ComponentCodeRenderer state={state} component="MuxPlayer" />
           <URLPathRenderer state={state} location={typeof window !== 'undefined' ? window.location : location} />
+          {(playerSoftwareInfo.name || playerSoftwareInfo.version) && (
+            <div>
+              <strong>playerSoftwareName:</strong> {playerSoftwareInfo.name ?? 'N/A'}<br />
+              <strong>playerSoftwareVersion:</strong> {playerSoftwareInfo.version ?? 'N/A'}
+            </div>
+          )}
           <div>
             <label htmlFor="assets-control">Select from one of our example assets</label>
             <select

--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -266,12 +266,19 @@ function MuxPlayerPage({ location }: Props) {
   const [stylesState, dispatchStyles] = useReducer(reducer, DEFAULT_INITIAL_STYLES_STATE);
   const genericOnStyleChange = (obj) => dispatchStyles(updateProps(obj));
 
+  console.log('playerSoftwareInfo', playerSoftwareInfo);
+
   return (
     <>
       <Head>
         <title>&lt;MuxPlayer/&gt; Demo</title>
       </Head>
       <main className="component-page">
+        {(playerSoftwareInfo.name || playerSoftwareInfo.version) && (
+          <div>
+            <strong>{playerSoftwareInfo.name ?? 'N/A'}@{playerSoftwareInfo.version ?? 'N/A'}</strong>
+          </div>
+        )}
         <div id="custom-fullscreen-element">
         <MuxPlayer
           ref={mediaElRef}
@@ -304,13 +311,6 @@ function MuxPlayerPage({ location }: Props) {
           crossOrigin={state.crossOrigin}
           nohotkeys={state.nohotkeys}
           hotkeys={state.hotkeys}
-          onPlayerReady={(evt) => {
-            onPlayerReady(evt);
-            setPlayerSoftwareInfo({
-              name: mediaElRef.current?.playerSoftwareName,
-              version: mediaElRef.current?.playerSoftwareVersion,
-            });
-          }}
           preferCmcd={state.preferCmcd}
           preferPlayback={state.preferPlayback}
           debug={state.debug}
@@ -350,6 +350,10 @@ function MuxPlayerPage({ location }: Props) {
           proudlyDisplayMuxBadge={state.proudlyDisplayMuxBadge}
           onPlay={(evt: Event) => {
             onPlay(evt);
+            setPlayerSoftwareInfo({
+              name: mediaElRef.current?.playerSoftwareName,
+              version: mediaElRef.current?.playerSoftwareVersion,
+            });
             // dispatch(updateProps({ paused: false }));
           }}
           onPause={(evt: Event) => {
@@ -370,12 +374,6 @@ function MuxPlayerPage({ location }: Props) {
         <div className="options">
           <ComponentCodeRenderer state={state} component="MuxPlayer" />
           <URLPathRenderer state={state} location={typeof window !== 'undefined' ? window.location : location} />
-          {(playerSoftwareInfo.name || playerSoftwareInfo.version) && (
-            <div>
-              <strong>playerSoftwareName:</strong> {playerSoftwareInfo.name ?? 'N/A'}<br />
-              <strong>playerSoftwareVersion:</strong> {playerSoftwareInfo.version ?? 'N/A'}
-            </div>
-          )}
           <div>
             <label htmlFor="assets-control">Select from one of our example assets</label>
             <select

--- a/examples/nextjs-with-typescript/pages/api/storyboard-proxy.ts
+++ b/examples/nextjs-with-typescript/pages/api/storyboard-proxy.ts
@@ -22,5 +22,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const body = await upstream.text();
 
   res.setHeader('Content-Type', upstream.headers.get('content-type') ?? 'text/vtt');
+  res.setHeader('Cache-Control', 'no-store');
   res.status(200).send(body);
 }

--- a/examples/nextjs-with-typescript/pages/api/storyboard-proxy.ts
+++ b/examples/nextjs-with-typescript/pages/api/storyboard-proxy.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { url, delay } = req.query;
+
+  if (!url || typeof url !== 'string') {
+    return res.status(400).json({ error: 'Missing required "url" query parameter' });
+  }
+
+  const delayMs = parseInt(typeof delay === 'string' ? delay : '0', 10) || 0;
+
+  if (delayMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  const upstream = await fetch(url);
+
+  if (!upstream.ok) {
+    return res.status(upstream.status).json({ error: `Upstream error: ${upstream.statusText}` });
+  }
+
+  const body = await upstream.text();
+
+  res.setHeader('Content-Type', upstream.headers.get('content-type') ?? 'text/vtt');
+  res.status(200).send(body);
+}


### PR DESCRIPTION
## Reproduction steps (main/mux-player-react@3.11.5 — issue resolved)

1. Open the Vercel preview for this PR
2. Navigate to:
   `/MuxPlayer?playbackId="vJzD4ayErsL3z5qs0201rKHfffmQOMWSk58J6A7FtECKs"&storyboardSrc="%2Fapi%2Fstoryboard-proxy%3Furl%3Dhttps%3A%2F%2Fimage.mux.com%2FvJzD4ayErsL3z5qs0201rKHfffmQOMWSk58J6A7FtECKs%2Fstoryboard.vtt%26delay%3D60000"&metadata=%7B"video_id"%3A"videoId5"%2C"video_title"%3A"Title%3A+Landscape+VOD+%28From+LL-Live%29"%7D&videoTitle="Landscape+VOD+%28From+LL-Live%29"&placeholder="data%3Aimage%2Fjpeg%3Bbase64%2C%2F9j%2F2wBDABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN%2BgXz%2F2wBDARUXFx4aHjshITt8U0ZTfHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHz%2FwAARCAASACADASIAAhEBAxEB%2F8QAGQAAAgMBAAAAAAAAAAAAAAAAAAMBAgQF%2F8QAGxAAAwADAQEAAAAAAAAAAAAAAAECERIxAxP%2FxAAXAQADAQAAAAAAAAAAAAAAAAAAAgMB%2F8QAGBEBAQEBAQAAAAAAAAAAAAAAAQACETH%2F2gAMAwEAAhEDEQA%2FAOvo0WnI53LITnJqTK0fPKF3LkfukhV2mT2HJsLZ0xkgBfUV3wz%2BnQAlvybN%2F9k%3D"&muted=true&autoPlay=true`
3. Confirm the player name and version shown above the player matches the current main branch version

**Expected (fix):** Playback begins quickly — the slow storyboard fetch does not block playback startup.