### PR TITLE
feat: Support relative urls on multivariant playlists

### DIFF
--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -31,6 +31,7 @@ import {
   addEventListenerWithTeardown,
   i18n,
   parseJwt,
+  isRelativeUrl,
 } from './util';
 import { StreamTypes, PlaybackTypes, ExtensionMimeTypeMap, CmcdTypes, HlsPlaylistTypes, MediaTypes } from './types';
 import { getErrorFromResponse, MuxJWTAud } from './request-errors';
@@ -80,12 +81,41 @@ export const toDRMTypeFromKeySystem = (keySystem: string): DRMTypeValue | undefi
   return undefined;
 };
 
-export const getMediaPlaylistFromMultivariantPlaylist = (multivariantPlaylist: string) => {
+/**
+ * Fetches the first media playlist from a multivariant (master) HLS playlist string.
+ *
+ * The first `#EXT-X-STREAM-INF` entry is selected. If its URL is relative, it is
+ * resolved against `masterPlaylistUrl`; absolute URLs are used as-is.
+ *
+ * @param multivariantPlaylist - The raw text of the multivariant playlist.
+ * @param masterPlaylistUrl - The URL the multivariant playlist was fetched from.
+ *   Required when the media playlist URL in the manifest is relative.
+ * @returns A promise that resolves with the media playlist text.
+ * @rejects {Error} If no `#EXT-X-STREAM-INF` entry is found in the playlist.
+ * @rejects {Error} If the media playlist URL is relative and `masterPlaylistUrl` is not provided.
+ * @rejects {Response} If the fetch response status is not 200.
+ */
+export const getMediaPlaylistFromMultivariantPlaylist = (
+  multivariantPlaylist: string,
+  masterPlaylistUrl?: string | URL
+) => {
   const mediaPlaylistUrl = multivariantPlaylist.split('\n').find((_line, idx, lines) => {
     return idx && lines[idx - 1].startsWith('#EXT-X-STREAM-INF');
-  }) as string;
+  });
 
-  return fetch(mediaPlaylistUrl).then((resp) => {
+  if (!mediaPlaylistUrl) {
+    return Promise.reject(new Error('No media playlist URL found in multivariant playlist'));
+  }
+
+  const isRelative = isRelativeUrl(mediaPlaylistUrl);
+
+  if (isRelative && !masterPlaylistUrl) {
+    return Promise.reject(new Error('masterPlaylistUrl is required to resolve relative media playlist URL'));
+  }
+
+  const fetchUrl = isRelative ? new URL(mediaPlaylistUrl, masterPlaylistUrl) : mediaPlaylistUrl;
+
+  return fetch(fetchUrl).then((resp) => {
     if (resp.status !== 200) {
       return Promise.reject(resp);
     }
@@ -177,7 +207,7 @@ export const getStreamInfoFromSrcAndType = async (src: string, type?: MediaTypes
       return Promise.reject(multivariantPlaylistResponse);
     }
     const multivariantPlaylist = await multivariantPlaylistResponse.text();
-    const mediaPlaylist = await getMediaPlaylistFromMultivariantPlaylist(multivariantPlaylist);
+    const mediaPlaylist = await getMediaPlaylistFromMultivariantPlaylist(multivariantPlaylist, src);
     return {
       ...getMultivariantPlaylistSessionData(multivariantPlaylist),
       ...getStreamInfoFromPlaylist(mediaPlaylist),

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -89,7 +89,8 @@ export const toDRMTypeFromKeySystem = (keySystem: string): DRMTypeValue | undefi
  *
  * @param multivariantPlaylist - The raw text of the multivariant playlist.
  * @param masterPlaylistUrl - The URL the multivariant playlist was fetched from.
- *   Required when the media playlist URL in the manifest is relative.
+ *   Required when the media playlist URL in the manifest is relative. If this is
+ *   itself a relative URL it is resolved against `window.location.href` first.
  * @returns A promise that resolves with the media playlist text.
  * @rejects {Error} If no `#EXT-X-STREAM-INF` entry is found in the playlist.
  * @rejects {Error} If the media playlist URL is relative and `masterPlaylistUrl` is not provided.
@@ -115,10 +116,9 @@ export const getMediaPlaylistFromMultivariantPlaylist = (
       return Promise.reject(new Error('masterPlaylistUrl is required to resolve relative media playlist URL'));
     }
 
-    const absoluteMasterUrl =
-      masterPlaylistUrl && isRelativeUrl(masterPlaylistUrl.toString())
-        ? new URL(masterPlaylistUrl, window?.location.href)
-        : masterPlaylistUrl;
+    const absoluteMasterUrl = isRelativeUrl(masterPlaylistUrl.toString())
+      ? new URL(masterPlaylistUrl, window?.location.href)
+      : masterPlaylistUrl;
 
     fetchUrl = new URL(mediaPlaylistUrl, absoluteMasterUrl);
   }
@@ -215,7 +215,10 @@ export const getStreamInfoFromSrcAndType = async (src: string, type?: MediaTypes
       return Promise.reject(multivariantPlaylistResponse);
     }
     const multivariantPlaylist = await multivariantPlaylistResponse.text();
-    const mediaPlaylist = await getMediaPlaylistFromMultivariantPlaylist(multivariantPlaylist, src);
+    const mediaPlaylist = await getMediaPlaylistFromMultivariantPlaylist(
+      multivariantPlaylist,
+      multivariantPlaylistResponse.url
+    );
     return {
       ...getMultivariantPlaylistSessionData(multivariantPlaylist),
       ...getStreamInfoFromPlaylist(mediaPlaylist),

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -32,6 +32,8 @@ import {
   i18n,
   parseJwt,
   isRelativeUrl,
+  getFirstMediaPlaylistUrl,
+  toAbsoluteUrl,
 } from './util';
 import { StreamTypes, PlaybackTypes, ExtensionMimeTypeMap, CmcdTypes, HlsPlaylistTypes, MediaTypes } from './types';
 import { getErrorFromResponse, MuxJWTAud } from './request-errors';
@@ -100,27 +102,21 @@ export const getMediaPlaylistFromMultivariantPlaylist = (
   multivariantPlaylist: string,
   masterPlaylistUrl?: string | URL
 ) => {
-  const mediaPlaylistUrl = multivariantPlaylist.split('\n').find((_line, idx, lines) => {
-    return idx && lines[idx - 1].startsWith('#EXT-X-STREAM-INF');
-  });
+  const mediaPlaylistUrl = getFirstMediaPlaylistUrl(multivariantPlaylist);
 
   if (!mediaPlaylistUrl) {
     return Promise.reject(new Error('No media playlist URL found in multivariant playlist'));
   }
 
-  const isRelative = isRelativeUrl(mediaPlaylistUrl);
+  if (isRelativeUrl(mediaPlaylistUrl) && !masterPlaylistUrl) {
+    return Promise.reject(new Error('masterPlaylistUrl is required to resolve relative media playlist URL'));
+  }
 
-  let fetchUrl: URL | string = mediaPlaylistUrl;
-  if (isRelative) {
-    if (!masterPlaylistUrl) {
-      return Promise.reject(new Error('masterPlaylistUrl is required to resolve relative media playlist URL'));
-    }
-
-    const absoluteMasterUrl = isRelativeUrl(masterPlaylistUrl.toString())
-      ? new URL(masterPlaylistUrl, window?.location.href)
-      : masterPlaylistUrl;
-
-    fetchUrl = new URL(mediaPlaylistUrl, absoluteMasterUrl);
+  let fetchUrl: URL | string;
+  try {
+    fetchUrl = toAbsoluteUrl(mediaPlaylistUrl, masterPlaylistUrl);
+  } catch (e) {
+    return Promise.reject(e);
   }
 
   return fetch(fetchUrl).then((resp) => {
@@ -215,6 +211,7 @@ export const getStreamInfoFromSrcAndType = async (src: string, type?: MediaTypes
       return Promise.reject(multivariantPlaylistResponse);
     }
     const multivariantPlaylist = await multivariantPlaylistResponse.text();
+    // Note: We use response.url instead of src because it considers redirects.
     const mediaPlaylist = await getMediaPlaylistFromMultivariantPlaylist(
       multivariantPlaylist,
       multivariantPlaylistResponse.url

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -109,11 +109,19 @@ export const getMediaPlaylistFromMultivariantPlaylist = (
 
   const isRelative = isRelativeUrl(mediaPlaylistUrl);
 
-  if (isRelative && !masterPlaylistUrl) {
-    return Promise.reject(new Error('masterPlaylistUrl is required to resolve relative media playlist URL'));
-  }
+  let fetchUrl: URL | string = mediaPlaylistUrl;
+  if (isRelative) {
+    if (!masterPlaylistUrl) {
+      return Promise.reject(new Error('masterPlaylistUrl is required to resolve relative media playlist URL'));
+    }
 
-  const fetchUrl = isRelative ? new URL(mediaPlaylistUrl, masterPlaylistUrl) : mediaPlaylistUrl;
+    const absoluteMasterUrl =
+      masterPlaylistUrl && isRelativeUrl(masterPlaylistUrl.toString())
+        ? new URL(masterPlaylistUrl, window?.location.href)
+        : masterPlaylistUrl;
+
+    fetchUrl = new URL(mediaPlaylistUrl, absoluteMasterUrl);
+  }
 
   return fetch(fetchUrl).then((resp) => {
     if (resp.status !== 200) {

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -844,7 +844,7 @@ export const setupHls = (
       cmcd,
       xhrSetup: (xhr, url) => {
         if (preferCmcd && preferCmcd !== CmcdTypes.QUERY) return;
-        const urlObj = new URL(url);
+        const urlObj = toAbsoluteUrl(url);
         if (!urlObj.searchParams.has('CMCD')) return;
         const cmcdVal = (urlObj.searchParams.get('CMCD')?.split(',') ?? [])
           .filter((cmcdKVStr) => cmcdKVStr.startsWith('sid') || cmcdKVStr.startsWith('cid'))

--- a/packages/playback-core/src/util.ts
+++ b/packages/playback-core/src/util.ts
@@ -112,6 +112,34 @@ export const isRelativeUrl = (url: string): boolean => {
   }
 };
 
+/**
+ * Returns the first media playlist URL from a multivariant HLS playlist string,
+ * i.e. the URI line that immediately follows an `#EXT-X-STREAM-INF` tag.
+ *
+ * @returns The URL string, or `undefined` if no `#EXT-X-STREAM-INF` entry is found.
+ */
+export const getFirstMediaPlaylistUrl = (multivariantPlaylist: string): string | undefined => {
+  return multivariantPlaylist.split('\n').find((_line, idx, lines) => {
+    return idx > 0 && lines[idx - 1].startsWith('#EXT-X-STREAM-INF');
+  });
+};
+
+/**
+ * Resolves `url` to an absolute `URL` instance.
+ *
+ * - If `url` is already absolute it is returned as-is.
+ * - If `url` is relative, `base` is used to resolve it. When `base` is itself
+ *   relative it is first resolved against `window?.location.href`.
+ *
+ * @throws {TypeError} If `url` is relative and `base` is not provided, or if
+ *   either value cannot be parsed as a valid URL.
+ */
+export const toAbsoluteUrl = (url: string, base?: string | URL): URL => {
+  if (!isRelativeUrl(url)) return new URL(url);
+  const absoluteBase = base && isRelativeUrl(base.toString()) ? new URL(base, window?.location.href) : base;
+  return new URL(url, absoluteBase);
+};
+
 const MUX_VIDEO_DOMAIN = 'mux.com';
 export const isExtensionLessMuxM3U8URL = ({
   src,

--- a/packages/playback-core/src/util.ts
+++ b/packages/playback-core/src/util.ts
@@ -103,6 +103,15 @@ export const inferMimeTypeFromURL = (props: Partial<Pick<MuxMediaProps, 'src' | 
   return isKeyOf(upperExt, ExtensionMimeTypeMap) ? ExtensionMimeTypeMap[upperExt] : '';
 };
 
+export const isRelativeUrl = (url: string): boolean => {
+  try {
+    new URL(url);
+    return false;
+  } catch {
+    return true;
+  }
+};
+
 const MUX_VIDEO_DOMAIN = 'mux.com';
 export const isExtensionLessMuxM3U8URL = ({
   src,

--- a/packages/playback-core/src/util.ts
+++ b/packages/playback-core/src/util.ts
@@ -130,9 +130,9 @@ export const getFirstMediaPlaylistUrl = (multivariantPlaylist: string): string |
  * - If `url` is already absolute it is returned as-is.
  * - If `url` is relative, `base` is used to resolve it. When `base` is itself
  *   relative it is first resolved against `window?.location?.href`.
- * - `base` defaults to `window?.location?.href`.
+ * - If undefined, `base` defaults to `window?.location?.href`.
  *
- * @throws {TypeError} If `url` is relative and `base` is not provided, or if
+ * @throws {TypeError} If both `url` and `base` are relative, or if
  *   either `url` or `base` value cannot be parsed as a valid URL.
  */
 export const toAbsoluteUrl = (url: string, base?: string | URL): URL => {

--- a/packages/playback-core/src/util.ts
+++ b/packages/playback-core/src/util.ts
@@ -84,9 +84,9 @@ export const inferMimeTypeFromURL = (props: Partial<Pick<MuxMediaProps, 'src' | 
 
   let pathname = '';
   try {
-    pathname = new URL(src).pathname;
+    pathname = toAbsoluteUrl(src).pathname;
   } catch (_e) {
-    console.error('invalid url');
+    console.error('Invalid url when trying to infer mime type', src);
   }
 
   const extDelimIdx = pathname.lastIndexOf('.');
@@ -129,14 +129,19 @@ export const getFirstMediaPlaylistUrl = (multivariantPlaylist: string): string |
  *
  * - If `url` is already absolute it is returned as-is.
  * - If `url` is relative, `base` is used to resolve it. When `base` is itself
- *   relative it is first resolved against `window?.location.href`.
+ *   relative it is first resolved against `window?.location?.href`.
+ * - `base` defaults to `window?.location?.href`.
  *
  * @throws {TypeError} If `url` is relative and `base` is not provided, or if
- *   either value cannot be parsed as a valid URL.
+ *   either `url` or `base` value cannot be parsed as a valid URL.
  */
 export const toAbsoluteUrl = (url: string, base?: string | URL): URL => {
   if (!isRelativeUrl(url)) return new URL(url);
-  const absoluteBase = base && isRelativeUrl(base.toString()) ? new URL(base, window?.location.href) : base;
+  const windowLocation = window?.location?.href;
+  let absoluteBase: string | URL = base ?? windowLocation;
+  if (base && isRelativeUrl(base.toString())) {
+    absoluteBase = new URL(base, windowLocation);
+  }
   return new URL(url, absoluteBase);
 };
 

--- a/packages/playback-core/test/tracks.test.js
+++ b/packages/playback-core/test/tracks.test.js
@@ -96,13 +96,18 @@ describe('textTracks', function () {
       });
 
       it('should set the last cuePoint endTime as MAX_SAFE_INTEGER if duration is not a finite number', async () => {
+        if (mediaEl.readyState >= HTMLMediaElement.HAVE_METADATA) {
+          Object.defineProperty(mediaEl, 'duration', { get: () => Infinity, configurable: true });
+        }
         const track = await addCuePoints(mediaEl, cuePoints);
         const lastCue = track.cues[track.cues.length - 1];
         assert.equal(lastCue.endTime, Number.MAX_SAFE_INTEGER);
       });
 
       it('should set the last cuePoint endTime as mediaEl.duration if duration is a finite number', async () => {
-        await oneEvent(mediaEl, 'durationchange');
+        if (mediaEl.readyState < HTMLMediaElement.HAVE_METADATA) {
+          await oneEvent(mediaEl, 'durationchange');
+        }
         const track = await addCuePoints(mediaEl, cuePoints);
         const lastCue = track.cues[track.cues.length - 1];
         assert.equal(lastCue.endTime, mediaEl.duration);

--- a/packages/playback-core/test/url.test.js
+++ b/packages/playback-core/test/url.test.js
@@ -70,6 +70,23 @@ describe('getMediaPlaylistFromMultivariantPlaylist()', () => {
     assert.equal(result, playlistContent);
   });
 
+  it('should resolve a relative media playlist URL when masterPlaylistUrl is itself relative', async () => {
+    const relativeMediaUrl = 'media/playlist.m3u8';
+    const relativeMasterUrl = '/hls/master.m3u8';
+    // window.location.href in the test browser is something like http://localhost:8004/
+    const expectedUrl = new URL(relativeMediaUrl, new URL(relativeMasterUrl, window.location.href)).toString();
+    const playlistContent = '#EXTM3U\n#EXT-X-ENDLIST';
+    const { getLastFetchedUrl } = mockFetch(200, playlistContent);
+
+    const result = await getMediaPlaylistFromMultivariantPlaylist(
+      makeMultivariantPlaylist(relativeMediaUrl),
+      relativeMasterUrl
+    );
+
+    assert.equal(getLastFetchedUrl(), expectedUrl);
+    assert.equal(result, playlistContent);
+  });
+
   it('should warn when a relative media playlist URL is found but masterPlaylistUrl is not provided', async () => {
     try {
       await getMediaPlaylistFromMultivariantPlaylist(makeMultivariantPlaylist('media/playlist.m3u8'));

--- a/packages/playback-core/test/url.test.js
+++ b/packages/playback-core/test/url.test.js
@@ -1,5 +1,66 @@
 import { assert } from '@open-wc/testing';
 import { getMediaPlaylistFromMultivariantPlaylist } from '../src/index.ts';
+import { getFirstMediaPlaylistUrl, toAbsoluteUrl } from '../src/util.ts';
+
+describe('getFirstMediaPlaylistUrl()', () => {
+  it('should return the URL line following #EXT-X-STREAM-INF', () => {
+    const playlist = '#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1000000\nhttps://cdn.example.com/media.m3u8';
+    assert.equal(getFirstMediaPlaylistUrl(playlist), 'https://cdn.example.com/media.m3u8');
+  });
+
+  it('should return the first variant when multiple are present', () => {
+    const playlist =
+      '#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=500000\nhttps://cdn.example.com/low.m3u8\n#EXT-X-STREAM-INF:BANDWIDTH=2000000\nhttps://cdn.example.com/high.m3u8';
+    assert.equal(getFirstMediaPlaylistUrl(playlist), 'https://cdn.example.com/low.m3u8');
+  });
+
+  it('should return undefined when no #EXT-X-STREAM-INF entry is present', () => {
+    const playlist = '#EXTM3U\n#EXT-X-VERSION:3\n';
+    assert.isUndefined(getFirstMediaPlaylistUrl(playlist));
+  });
+
+  it('should return a relative URL as-is', () => {
+    const playlist = '#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1000000\nmedia/playlist.m3u8';
+    assert.equal(getFirstMediaPlaylistUrl(playlist), 'media/playlist.m3u8');
+  });
+});
+
+describe('toAbsoluteUrl()', () => {
+  it('should return an absolute URL unchanged', () => {
+    const url = 'https://cdn.example.com/media/playlist.m3u8';
+    assert.equal(toAbsoluteUrl(url).toString(), url);
+  });
+
+  it('should resolve a relative URL against an absolute base', () => {
+    assert.equal(
+      toAbsoluteUrl('media/playlist.m3u8', 'https://cdn.example.com/hls/master.m3u8').toString(),
+      'https://cdn.example.com/hls/media/playlist.m3u8'
+    );
+  });
+
+  it('should resolve a root-relative URL against an absolute base', () => {
+    assert.equal(
+      toAbsoluteUrl('/hls/media/playlist.m3u8', 'https://cdn.example.com/other/master.m3u8').toString(),
+      'https://cdn.example.com/hls/media/playlist.m3u8'
+    );
+  });
+
+  it('should resolve a relative URL when base is itself relative (uses window.location.href)', () => {
+    const expected = new URL('media/playlist.m3u8', new URL('/hls/master.m3u8', window.location.href)).toString();
+    assert.equal(toAbsoluteUrl('media/playlist.m3u8', '/hls/master.m3u8').toString(), expected);
+  });
+
+  it('should accept a URL instance as base', () => {
+    assert.equal(
+      toAbsoluteUrl('media/playlist.m3u8', new URL('https://cdn.example.com/hls/master.m3u8')).toString(),
+      'https://cdn.example.com/hls/media/playlist.m3u8'
+    );
+  });
+
+  it('should throw when URL is relative and no base is provided', () => {
+    assert.throws(() => toAbsoluteUrl('media/playlist.m3u8'), TypeError);
+  });
+});
 
 describe('getMediaPlaylistFromMultivariantPlaylist()', () => {
   let originalFetch;

--- a/packages/playback-core/test/url.test.js
+++ b/packages/playback-core/test/url.test.js
@@ -1,0 +1,105 @@
+import { assert } from '@open-wc/testing';
+import { getMediaPlaylistFromMultivariantPlaylist } from '../src/index.ts';
+
+describe('getMediaPlaylistFromMultivariantPlaylist()', () => {
+  let originalFetch;
+
+  const makeMultivariantPlaylist = (mediaUrl) =>
+    `#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-STREAM-INF:BANDWIDTH=1000000\n${mediaUrl}`;
+
+  const mockFetch = (status, body) => {
+    let lastFetchedUrl;
+    globalThis.fetch = (url) => {
+      lastFetchedUrl = url.toString();
+      return Promise.resolve({ status, text: () => Promise.resolve(body) });
+    };
+    return { getLastFetchedUrl: () => lastFetchedUrl };
+  };
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('should fetch an absolute media playlist URL directly, ignoring masterPlaylistUrl', async () => {
+    const absoluteMediaUrl = 'https://cdn.example.com/media/playlist.m3u8';
+    const playlistContent = '#EXTM3U\n#EXT-X-ENDLIST';
+    const { getLastFetchedUrl } = mockFetch(200, playlistContent);
+
+    const result = await getMediaPlaylistFromMultivariantPlaylist(
+      makeMultivariantPlaylist(absoluteMediaUrl),
+      'https://other.example.com/master.m3u8'
+    );
+
+    assert.equal(getLastFetchedUrl(), absoluteMediaUrl);
+    assert.equal(result, playlistContent);
+  });
+
+  it('should resolve a relative media playlist URL against masterPlaylistUrl', async () => {
+    const relativeMediaUrl = 'media/playlist.m3u8';
+    const masterUrl = 'https://cdn.example.com/hls/master.m3u8';
+    const expectedUrl = 'https://cdn.example.com/hls/media/playlist.m3u8';
+    const playlistContent = '#EXTM3U\n#EXT-X-ENDLIST';
+    const { getLastFetchedUrl } = mockFetch(200, playlistContent);
+
+    const result = await getMediaPlaylistFromMultivariantPlaylist(
+      makeMultivariantPlaylist(relativeMediaUrl),
+      masterUrl
+    );
+
+    assert.equal(getLastFetchedUrl(), expectedUrl);
+    assert.equal(result, playlistContent);
+  });
+
+  it('should resolve a root-relative media playlist URL against masterPlaylistUrl origin', async () => {
+    const relativeMediaUrl = '/hls/media/playlist.m3u8';
+    const masterUrl = 'https://cdn.example.com/hls/master.m3u8';
+    const expectedUrl = 'https://cdn.example.com/hls/media/playlist.m3u8';
+    const playlistContent = '#EXTM3U\n#EXT-X-ENDLIST';
+    const { getLastFetchedUrl } = mockFetch(200, playlistContent);
+
+    const result = await getMediaPlaylistFromMultivariantPlaylist(
+      makeMultivariantPlaylist(relativeMediaUrl),
+      masterUrl
+    );
+
+    assert.equal(getLastFetchedUrl(), expectedUrl);
+    assert.equal(result, playlistContent);
+  });
+
+  it('should warn when a relative media playlist URL is found but masterPlaylistUrl is not provided', async () => {
+    try {
+      await getMediaPlaylistFromMultivariantPlaylist(makeMultivariantPlaylist('media/playlist.m3u8'));
+      assert.fail('expected rejection');
+    } catch (err) {
+      assert.instanceOf(err, Error);
+      assert.include(err.message, 'masterPlaylistUrl');
+    }
+  });
+
+  it('should reject when no media playlist URL is found in the multivariant playlist', async () => {
+    const emptyPlaylist = '#EXTM3U\n#EXT-X-VERSION:3\n';
+    try {
+      await getMediaPlaylistFromMultivariantPlaylist(emptyPlaylist, 'https://cdn.example.com/master.m3u8');
+      assert.fail('expected rejection');
+    } catch (err) {
+      assert.instanceOf(err, Error);
+      assert.include(err.message, 'No media playlist URL found');
+    }
+  });
+
+  it('should reject with the response when the fetch returns a non-200 status', async () => {
+    mockFetch(404, '');
+    try {
+      await getMediaPlaylistFromMultivariantPlaylist(
+        makeMultivariantPlaylist('https://cdn.example.com/media/playlist.m3u8')
+      );
+      assert.fail('expected rejection');
+    } catch (resp) {
+      assert.equal(resp.status, 404);
+    }
+  });
+});

--- a/packages/playback-core/test/url.test.js
+++ b/packages/playback-core/test/url.test.js
@@ -57,8 +57,9 @@ describe('toAbsoluteUrl()', () => {
     );
   });
 
-  it('should throw when URL is relative and no base is provided', () => {
-    assert.throws(() => toAbsoluteUrl('media/playlist.m3u8'), TypeError);
+  it('should default to window location URL when URL is relative and no base is provided', () => {
+    const expected = new URL('media/playlist.m3u8', window.location.href).toString();
+    assert.equal(toAbsoluteUrl('media/playlist.m3u8'), expected);
   });
 });
 


### PR DESCRIPTION
Closes https://github.com/muxinc/elements/issues/1262

`getMediaPlaylistFromMultivariantPlaylist` previously assumed all media playlist URLs in a multivariant manifest were absolute, causing broken playback when a CDN or server serves HLS manifests with relative URLs

Added `isRelativeUrl` helper to `util.ts` that detects relative URLs by attempting a bare `new URL()` parse
The function now resolves relative URLs against `masterPlaylistUrl` and passes absolute URLs through unchanged; it also rejects early when no #EXT-X-STREAM-INF entry is found or when a relative URL is present without a base URL to resolve against

Updated the call site in `getStreamInfoFromSrcAndType` to pass src as `masterPlaylistUrl`

Added unit tests covering absolute URLs, path-relative URLs, root-relative URLs, missing base URL, empty playlist, and non-200 responses

## Test plan
- Run npm test in packages/playback-core — all existing and new tests pass
- Verify playback works end-to-end with a multivariant playlist that uses relative media URLs
- Verify playback is unaffected for multivariant playlists with absolute media URLs


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core playlist fetching/URL parsing paths; incorrect resolution or `window.location` assumptions could break playback for some environments, though behavior is covered by new unit tests.
> 
> **Overview**
> Fixes HLS multivariant (master) playlist handling by allowing the first variant media playlist URI to be *relative* and resolving it against the master playlist URL (including redirect-aware `response.url`).
> 
> Introduces `isRelativeUrl`, `getFirstMediaPlaylistUrl`, and `toAbsoluteUrl`, refactors `getMediaPlaylistFromMultivariantPlaylist()` to validate missing variants/base URLs and fetch the resolved URL, and updates other URL parsing call sites to use `toAbsoluteUrl`. Adds comprehensive unit tests covering absolute vs relative (path/root) resolution, missing base, empty playlists, and non-200 fetches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b6758fc8486fe681449013309861fbb68be1002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->