### PR TITLE
fix: Address failing tests

### DIFF
--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -138,6 +138,7 @@ export const content = (props: MuxTemplateProps) => html`
       cast-src="${!!props.src ? props.src : props.playbackId ? toMuxVideoURL(props) : false}"
       cast-receiver="${props.castReceiver ?? false}"
       drm-token="${props.tokens?.drm ?? false}"
+      playback-token="${props.tokens?.playback ?? false}"
       exportparts="video"
       disable-pseudo-ended="${props.disablePseudoEnded ?? false}"
       max-auto-resolution="${props.maxAutoResolution ?? false}"

--- a/packages/playback-core/test/tracks.test.js
+++ b/packages/playback-core/test/tracks.test.js
@@ -96,13 +96,18 @@ describe('textTracks', function () {
       });
 
       it('should set the last cuePoint endTime as MAX_SAFE_INTEGER if duration is not a finite number', async () => {
+        if (mediaEl.readyState >= HTMLMediaElement.HAVE_METADATA) {
+          Object.defineProperty(mediaEl, 'duration', { get: () => Infinity, configurable: true });
+        }
         const track = await addCuePoints(mediaEl, cuePoints);
         const lastCue = track.cues[track.cues.length - 1];
         assert.equal(lastCue.endTime, Number.MAX_SAFE_INTEGER);
       });
 
       it('should set the last cuePoint endTime as mediaEl.duration if duration is a finite number', async () => {
-        await oneEvent(mediaEl, 'durationchange');
+        if (mediaEl.readyState < HTMLMediaElement.HAVE_METADATA) {
+          await oneEvent(mediaEl, 'durationchange');
+        }
         const track = await addCuePoints(mediaEl, cuePoints);
         const lastCue = track.cues[track.cues.length - 1];
         assert.equal(lastCue.endTime, mediaEl.duration);


### PR DESCRIPTION
Closes https://github.com/muxinc/elements/issues/1304

Tests seem to have started failing on [this commit](https://github.com/muxinc/elements/commit/76ba494791da018525914600213c208dba10f614), so this PR also addresses this [related issue](https://github.com/muxinc/elements/issues/1304) and some flaky tests.

Added `playback-token` to `<mux-player>` template so src is correctly updated when other related attributes change.
An alternative approach to this fix is to modify `<mux-video>` attribute changes if they would not modify the src url.

Also added some conditional mocking on tracks tests to try to reduce test flakiness 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signed playback URL/token propagation in `mux-player`, which can affect authenticated playback behavior. Test changes are low risk but may mask real regressions if the readyState assumptions are wrong across environments.
> 
> **Overview**
> Fixes `mux-player` URL signing updates by forwarding `tokens.playback` to the inner `<mux-video>` as `playback-token`, ensuring `src` is recomputed when the playback token changes.
> 
> Stabilizes `playback-core` track/cuepoint tests by making duration mocking and `durationchange` waiting conditional on `mediaEl.readyState`, reducing flaky timing-dependent failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df696f7826bb55a6ffa29ee998496749fbfde2a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->