### PR TITLE
fix: Added a warning when tracks are being added before player init

### DIFF
--- a/packages/mux-video/src/base.ts
+++ b/packages/mux-video/src/base.ts
@@ -696,6 +696,12 @@ export class MuxVideoBaseElement extends CustomVideoElement implements IMuxVideo
   }
 
   async addCuePoints<T = any>(cuePoints: CuePoint<T>[]) {
+    if (!this.nativeEl.currentSrc) {
+      console.warn(
+        'addCuePoints() was called before the media element has loaded. ' +
+          'Wait for the loadstart event before calling addCuePoints().'
+      );
+    }
     return addCuePoints(this.nativeEl, cuePoints);
   }
 
@@ -708,6 +714,12 @@ export class MuxVideoBaseElement extends CustomVideoElement implements IMuxVideo
   }
 
   async addChapters(chapters: Chapter[]) {
+    if (!this.nativeEl.currentSrc) {
+      console.warn(
+        'addChapters() was called before the media element has loaded. ' +
+          'Wait for the loadstart event before calling addChapters().'
+      );
+    }
     return addChapters(this.nativeEl, chapters);
   }
 


### PR DESCRIPTION
Closes https://github.com/muxinc/devextravaganza/issues/215

Relates to a behavior we often see (mainly on Safari) that adding a track to the player element before it initializes, causes playback to buffer indefinitely. For example https://github.com/muxinc/devextravaganza/issues/215.

While this PR does not fix the issue, it adds a warning so this behavior is easier to identify. 


An example where this could happen is if on React a user were to write this it would log a warning:
```jsx
const Player = (props) => {
    return (<MuxPlayer
        {...props}
        ref={(instance) => {
            instance?.addChapters(props.chapters);
            props.ref.current = instance;
        }
    />)
}
```
To address this they should do something like this:
```jsx
const Player = (props) => {
    return (<MuxPlayer
        {...props}
        ref={(instance) => {
            if (instance) {
                const handler = () => instance.addChapters(muxChapters ?? []);
                instance.addEventListener(
                    "loadedmetadata", 
                    () => instance.addChapters(props.chapters), 
                    { once: true }
                );
            }
            
            props.ref.current = instance;
        }
    />)
}
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds console warnings only; behavior and data flow for chapters/cue points remain unchanged aside from extra logging that could be noisy in some apps.
> 
> **Overview**
> Adds a guard in `MuxVideoBaseElement.addCuePoints()` and `addChapters()` to `console.warn` when these are called before the media element has a `currentSrc`, nudging callers to wait for initial load (e.g., `loadstart`). No functional change to how cue points/chapters are added beyond emitting the warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3c216d2fcfcdeca057ee65405a50727018d69f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->