### PR TITLE
chore: Moved @mux/mux-player-astro and @mux/mux-uploader-astro to point to l…

### DIFF
--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@astrojs/react": "^5.0.3",
     "@astrojs/vercel": "^10.0.4",
-    "@mux/mux-player-astro": ">=3.5.3",
-    "@mux/mux-uploader-astro": ">=1.2.0",
+    "@mux/mux-player-astro": "file:../../packages/mux-player-astro",
+    "@mux/mux-uploader-astro": "file:../../packages/mux-uploader-astro",
     "astro": "^6.1.8",
     "cta-modal": "^1.1.1",
     "water.css": "^2.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,8 @@
       "dependencies": {
         "@astrojs/react": "^5.0.3",
         "@astrojs/vercel": "^10.0.4",
-        "@mux/mux-player-astro": ">=3.5.3",
-        "@mux/mux-uploader-astro": ">=1.2.0",
+        "@mux/mux-player-astro": "file:../../packages/mux-player-astro",
+        "@mux/mux-uploader-astro": "file:../../packages/mux-uploader-astro",
         "astro": "^6.1.8",
         "cta-modal": "^1.1.1",
         "water.css": "^2.1.1"


### PR DESCRIPTION
Moved @mux/mux-player-astro and @mux/mux-uploader-astro to point to local builds to address failing build https://github.com/muxinc/elements/actions/runs/24786447671/job/72531671128#step:13:1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes dependency resolution for the Astro example app, not runtime/library code. Main risk is CI/environment differences if local `file:` paths behave differently than published semver installs.
> 
> **Overview**
> The Astro example app now depends on local workspace copies of `@mux/mux-player-astro` and `@mux/mux-uploader-astro` (via `file:../../packages/...`) instead of semver ranges from npm.
> 
> `package-lock.json` is updated accordingly so installs resolve these two packages from the repo rather than the registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 225bd33a94e0044991e9dca78c559449ef0ff6cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->