### PR TITLE
fix: remove inline onclick CSP violation in retry link

### DIFF
--- a/packages/mux-player/src/base.ts
+++ b/packages/mux-player/src/base.ts
@@ -298,6 +298,13 @@ class MuxPlayerElement extends VideoApiElement implements IMuxPlayerElement {
   #onStreamTypeChange = () => this.#render();
   #onLoadStart = () => this.#render();
   #onTrackCountChange = () => this.#render();
+  #onReloadClick = (event: MouseEvent) => {
+    const target = event.composedPath().find((el) => (el as Element)?.hasAttribute?.('data-mux-reload'));
+    if (target) {
+      event.preventDefault();
+      window.location.reload();
+    }
+  };
   #captionsMovementCleanup?: () => void;
   #state: Partial<MuxTemplateProps> = {
     ...initialState,
@@ -465,6 +472,7 @@ class MuxPlayerElement extends VideoApiElement implements IMuxPlayerElement {
     this.media?.removeEventListener('streamtypechange', this.#onStreamTypeChange);
     this.media?.removeEventListener('loadstart', this.#onLoadStart);
     this.removeEventListener('error', this.#onError);
+    this.removeEventListener('click', this.#onReloadClick);
     if (this.media) {
       this.media.errorTranslator = undefined;
     }
@@ -516,6 +524,7 @@ class MuxPlayerElement extends VideoApiElement implements IMuxPlayerElement {
     // Keep this event listener on mux-player instead of calling onError directly
     // from video.onerror. This allows us to simulate errors from the outside.
     this.addEventListener('error', this.#onError);
+    this.addEventListener('click', this.#onReloadClick);
 
     /** @TODO Push errorTranslator logic down to playback-core. Should be able to use MediaError message + context + code (muxCode?) (CJP) */
     if (this.media) {

--- a/packages/mux-player/src/errors.ts
+++ b/packages/mux-player/src/errors.ts
@@ -50,6 +50,9 @@ const muxMediaErrorToDialogTitle = (mediaError: MediaError, translate = false) =
 };
 
 const muxMediaErrorToDialogMessage = (mediaError: MediaError, translate = false) => {
+  if (mediaError.reload) {
+    return `Try again later or <a href="#" data-mux-reload style="color: #4a90e2;">click here to retry</a>`;
+  }
   if (mediaError.muxCode) {
     const category = capitalizeFirstLetter(mediaError.errorCategory ?? 'video');
     const tokenNamePrefix = errorCategoryToTokenNameOrPrefix(mediaError.errorCategory ?? MuxErrorCategory.VIDEO);

--- a/packages/playback-core/src/errors.ts
+++ b/packages/playback-core/src/errors.ts
@@ -81,6 +81,7 @@ export class MediaError extends Error {
   fatal: boolean;
   data?: any;
   streamType?: 'live' | 'on-demand' | 'unknown';
+  reload?: boolean;
 
   constructor(message?: Stringable, code: number = MediaError.MEDIA_ERR_CUSTOM, fatal?: boolean, context?: string) {
     super(message);

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -1464,12 +1464,9 @@ export const loadMedia = (
         } else {
           state.retryCount = 0;
           // New error with the retry link
-          const retryLinkError = new MediaError(
-            'Try again later or <a href="#" onclick="window.location.reload(); return false;" style="color: #4a90e2;">click here to retry</a>',
-            error.code,
-            error.fatal
-          );
+          const retryLinkError = new MediaError('Network error, try reloading.', error.code, error.fatal);
           Object.assign(retryLinkError, error);
+          retryLinkError.reload = true;
           saveAndDispatchError(mediaEl, retryLinkError);
           return;
         }


### PR DESCRIPTION
Closes #1331

The "click here to retry" link shown after HLS manifest load retries are exhausted used an inline `onclick` attribute, which violates `script-src-attr 'none'` CSP policies.

### Changes
- **`playback-core`**: Replaces the inline `onclick` with a typed `reload` flag on `MediaError`. The message is now plain text, so direct consumers of `playback-core`/`mux-video` are no longer exposed to raw HTML in the error message.
- **`mux-player`**: Builds the retry link HTML (using `data-mux-reload`) in `muxMediaErrorToDialogMessage`, and handles clicks via event delegation on the player element using `composedPath()` to reach through shadow DOM boundaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized to error messaging and retry-click handling; main risk is regressions where the reload link no longer appears or reloads in some shadow DOM/event-path edge cases.
> 
> **Overview**
> Removes the CSP-violating inline `onclick` reload handler from the HLS manifest retry exhaustion error.
> 
> `playback-core` now marks these errors with a `MediaError.reload` flag and emits a plain-text message, while `mux-player` conditionally renders the retry anchor (`data-mux-reload`) and handles retry clicks via delegated `click` handling using `composedPath()` (with proper listener cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cebafedac7669f1798d341db621310e9a57d4d76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->