### PR TITLE
fix: moved filter drop shadow to parent class

### DIFF
--- a/packages/mux-player/src/themes/gerwig/gerwig.html
+++ b/packages/mux-player/src/themes/gerwig/gerwig.html
@@ -298,6 +298,7 @@
       text-shadow:
         0 0 2px rgb(0 0 0 / 0.25),
         0 0 6px rgb(0 0 0 / 0.25);
+      filter: drop-shadow(0 0 2px rgb(0 0 0 / 0.25)) drop-shadow(0 0 6px rgb(0 0 0 / 0.25));
     }
 
     .center-controls media-play-button {
@@ -305,7 +306,6 @@
       --media-control-hover-background: transparent;
       --media-control-padding: 0;
       width: 40px;
-      filter: drop-shadow(0 0 2px rgb(0 0 0 / 0.25)) drop-shadow(0 0 6px rgb(0 0 0 / 0.25));
     }
 
     [breakpointsm] .center-controls media-play-button {


### PR DESCRIPTION
Closes https://github.com/muxinc/devextravaganza/issues/227

## Problem
Clicking play for the first time on Safari for Mux Player will result in a lingering shadow where the button used to be after it fades. This seems to be a Safari only issue that presents when there's also a transition present, [example here](https://gsap.com/community/forums/topic/44727-svg-drop-shadow-getting-clipped-in-safari-when-animation-is-added/).

Looks something like this: 
<img width="123" height="115" alt="image" src="https://github.com/user-attachments/assets/fc154acd-eacb-4ffe-b0f1-590ccaf43111" />

## Solution
Moving the filter to the containing class fixed the problem (by separating it from the `transition` in `[breakpointsm] .center-controls media-play-button`. 
Note this would also apply the shadow to other elements inside `.center-controls`, but this was assumed to not be much of a problem since there was already a text-shadow doing a similar shadow.

Another approach considered was adding a `will-change: filter, transition`, but I read that's generally not recommended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gerwig theme CSS-only change with no logic or data impact; minor visual scope change for sibling center controls.
> 
> **Overview**
> Fixes a **Safari-only visual bug** where a drop-shadow could linger at the old position after the center play control fades on first playback.
> 
> The `filter: drop-shadow(...)` rule is **moved from** `.center-controls media-play-button` **to** the `.center-controls` wrapper so it is no longer on the same element that uses `transition: background` at the `breakpointsm` breakpoint and the `pre-play-hide` animation. That separation avoids Safari compositing the filter with the transition/animation incorrectly.
> 
> The shadow may now apply to other children inside `.center-controls` (e.g. seek buttons), which is considered acceptable because similar shadow styling already exists via `text-shadow` on those controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c3bfa3197d146af132e1ee9599525edcc806904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->