### PR TITLE
fix: move canary publish to CD for npm trusted publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -90,8 +90,6 @@ jobs:
           SLACK_ICON: https://avatars.githubusercontent.com/muxinc?size=48
           SLACK_FOOTER: ''
 
-  # Canary prereleases run from this (the trusted-publisher) workflow rather than
-  # CI, because npm trusted publishing only trusts a single workflow per package.
   canary:
     # Only publish canaries from main, and never on the Release Please commit
     # (that path publishes the real release via `release` above).
@@ -117,7 +115,4 @@ jobs:
       - run: npm ci
       - run: npm run clean
       - run: npm run build:packages
-      # Auth is handled by npm trusted publishing (OIDC) via `id-token: write`.
-      # Do not add NODE_AUTH_TOKEN here — the long-lived NPM token is unused and
-      # flagged by security scanning.
       - run: npx --yes -w packages wet-run@1.2.5 release prerelease --prerelease canary --provenance --log-level verbose

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,8 +73,6 @@ jobs:
       - name: Publish
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: npm exec -c publish-packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: 'Get message'
         if: ${{ steps.release.outputs.releases_created == 'true' }}
@@ -91,3 +89,35 @@ jobs:
           SLACK_USERNAME: Mux Elements
           SLACK_ICON: https://avatars.githubusercontent.com/muxinc?size=48
           SLACK_FOOTER: ''
+
+  # Canary prereleases run from this (the trusted-publisher) workflow rather than
+  # CI, because npm trusted publishing only trusts a single workflow per package.
+  canary:
+    # Only publish canaries from main, and never on the Release Please commit
+    # (that path publishes the real release via `release` above).
+    if: ${{ github.ref == 'refs/heads/main' && github.event.commits[0].author.name != 'github-actions[bot]' }}
+
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: read node version from the .nvmrc file
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        shell: bash
+        id: nvmrc
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{steps.nvmrc.outputs.NODE_VERSION}}
+          # required so npm can publish below
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+      - run: npm ci
+      - run: npm run clean
+      - run: npm run build:packages
+      # Auth is handled by npm trusted publishing (OIDC) via `id-token: write`.
+      # Do not add NODE_AUTH_TOKEN here — the long-lived NPM token is unused and
+      # flagged by security scanning.
+      - run: npx --yes -w packages wet-run@1.2.5 release prerelease --prerelease canary --provenance --log-level verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -32,10 +30,6 @@ jobs:
       - run: npm ci
       - run: npm run clean
       - run: npm run build:packages
-      - run: npx --yes -w packages wet-run@1.2.5 release prerelease --prerelease canary --provenance --log-level verbose
-        if: ${{ github.ref == 'refs/heads/main' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   lint:
     # Don't run if the CI is triggered by Release Please


### PR DESCRIPTION
## Summary

Canary publishes have been failing on every push to `main` ([Example](https://github.com/muxinc/elements/actions/runs/25879146137/job/76054190551)). Doing a similar approach to what we did for media chrome. Moved (created) canary step to cd.yml. Also removed unused token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production deployment workflows and npm publish paths; misconfigured gates could skip canaries or publish on the wrong commits, but application/runtime code is unchanged.
> 
> **Overview**
> **Canary npm publishes** are moved out of `ci.yml` into a dedicated **`canary` job** in `cd.yml`, matching the media-chrome approach so publishes can use **npm trusted publishing** (OIDC via `id-token: write` and the `production` environment) instead of failing with token-based auth.
> 
> The CI **`build` job** no longer runs `wet-run` prerelease or requests `id-token` permissions—it only installs, cleans, and builds packages. The new CD job runs on **`main`** for non–Release Please commits (`github-actions[bot]` excluded), then ci → clean → build → **`wet-run` canary prerelease with provenance**.
> 
> The release **`Publish`** step in CD also drops the unused **`NODE_AUTH_TOKEN`** env var, aligning stable releases with the same trusted-publishing setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c07b5506b338c18af1fd0448c4789cfe4e49949d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->