### PR TITLE
fix: replace inline event handlers with addEventListener to comply wi…

### DIFF
--- a/packages/mux-player/src/base.ts
+++ b/packages/mux-player/src/base.ts
@@ -305,22 +305,24 @@ class MuxPlayerElement extends VideoApiElement implements IMuxPlayerElement {
       window.location.reload();
     }
   };
+  // Bound programmatically (see #setUpErrors) instead of via inline on* template
+  // attributes, which are refused by a strict CSP (script-src without 'unsafe-inline').
+  #onCloseErrorDialog = (event: Event) => {
+    const localName = (event.composedPath()[0] as HTMLElement)?.localName;
+    if (localName !== 'media-error-dialog') return;
+
+    this.#setState({ isDialogOpen: false });
+  };
+  #onFocusInErrorDialog = (event: Event) => {
+    const localName = (event.composedPath()[0] as HTMLElement)?.localName;
+    if (localName !== 'media-error-dialog') return;
+
+    const isFocusedElementInPlayer = containsComposedNode(this, document.activeElement);
+    if (!isFocusedElementInPlayer) event.preventDefault();
+  };
   #captionsMovementCleanup?: () => void;
   #state: Partial<MuxTemplateProps> = {
     ...initialState,
-    onCloseErrorDialog: (event) => {
-      const localName = (event.composedPath()[0] as HTMLElement)?.localName;
-      if (localName !== 'media-error-dialog') return;
-
-      this.#setState({ isDialogOpen: false });
-    },
-    onFocusInErrorDialog: (event) => {
-      const localName = (event.composedPath()[0] as HTMLElement)?.localName;
-      if (localName !== 'media-error-dialog') return;
-
-      const isFocusedElementInPlayer = containsComposedNode(this, document.activeElement);
-      if (!isFocusedElementInPlayer) event.preventDefault();
-    },
   };
 
   static get NAME() {
@@ -497,6 +499,8 @@ class MuxPlayerElement extends VideoApiElement implements IMuxPlayerElement {
     this.media?.removeEventListener('loadstart', this.#onLoadStart);
     this.removeEventListener('error', this.#onError);
     this.removeEventListener('click', this.#onReloadClick);
+    this.mediaTheme?.removeEventListener('close', this.#onCloseErrorDialog);
+    this.mediaTheme?.removeEventListener('focusin', this.#onFocusInErrorDialog);
     if (this.media) {
       this.media.errorTranslator = undefined;
     }
@@ -549,6 +553,11 @@ class MuxPlayerElement extends VideoApiElement implements IMuxPlayerElement {
     // from video.onerror. This allows us to simulate errors from the outside.
     this.addEventListener('error', this.#onError);
     this.addEventListener('click', this.#onReloadClick);
+
+    // Bind the error-dialog lifecycle handlers on <media-theme> here rather than
+    // as inline onclose/onfocusin template attributes, which a strict CSP refuses.
+    this.mediaTheme?.addEventListener('close', this.#onCloseErrorDialog);
+    this.mediaTheme?.addEventListener('focusin', this.#onFocusInErrorDialog);
 
     /** @TODO Push errorTranslator logic down to playback-core. Should be able to use MediaError message + context + code (muxCode?) (CJP) */
     if (this.media) {

--- a/packages/mux-player/src/template.ts
+++ b/packages/mux-player/src/template.ts
@@ -108,8 +108,6 @@ export const content = (props: MuxTemplateProps) => html`
     videotitle="${props.videoTitle ?? false}"
     proudlydisplaymuxbadge="${props.proudlyDisplayMuxBadge ?? false}"
     exportparts="${partsListStr}"
-    onclose="${props.onCloseErrorDialog}"
-    onfocusin="${props.onFocusInErrorDialog}"
   >
     <mux-video
       slot="media"

--- a/packages/mux-player/src/types.ts
+++ b/packages/mux-player/src/types.ts
@@ -40,8 +40,6 @@ export type MuxTemplateProps = Partial<MuxPlayerProps> & {
   defaultShowRemainingTime: boolean;
   defaultDuration?: number;
   hideDuration: boolean;
-  onCloseErrorDialog: (evt: CustomEvent) => void;
-  onFocusInErrorDialog: (evt: CustomEvent) => void;
   dialog: DialogOptions;
   inLiveWindow: boolean;
   maxResolution?: MaxResolutionValue;

--- a/packages/mux-player/test/template.test.js
+++ b/packages/mux-player/test/template.test.js
@@ -2,6 +2,9 @@ import { assert } from '@open-wc/testing';
 import { content, partsListStr } from '../src/template.ts';
 import { render } from '../src/html.ts';
 
+// Matches inline event-handler content attributes, e.g. `onclose="..."`, `onclick="..."`.
+const INLINE_HANDLER_ATTR = /\son[a-z]+="/i;
+
 const minify = (html) => html.trim().replace(/>\s+</g, '><');
 
 describe('<mux-player> template render', () => {
@@ -75,6 +78,20 @@ describe('<mux-player> template render', () => {
         `<media-theme defaultsubtitles="" disabled="" exportparts="${partsListStr}" nohotkeys=""><mux-video crossorigin="" exportparts="video" playsinline="" slot="media" stream-type="on-demand"><slot></slot></mux-video><slot name="poster" slot="poster"><media-poster-image exportparts="poster, img" part="poster"></media-poster-image></slot></media-theme>`
       )
     );
+  });
+
+  it('does not emit inline event-handler attributes (CSP script-src-attr)', function () {
+    // Regression: the error-dialog lifecycle handlers must be bound via
+    // addEventListener, never as inline on* attributes. Under a strict CSP
+    // (script-src without 'unsafe-inline') the browser refuses inline handlers
+    // and reports a script-src-attr / blocked-uri: inline violation.
+    //
+    // We assert on the *raw* template HTML (before part-processing), because
+    // that is the string the browser parses/clones into the live DOM and what
+    // CSP evaluates. The `html` processor strips on* attributes while binding
+    // them, so the post-render innerHTML would hide a regression here.
+    const rawHtml = content({ isDialogOpen: true, dialog: { title: 'Errr' } }).template.innerHTML;
+    assert.notMatch(rawHtml, INLINE_HANDLER_ATTR, 'template must not contain inline on* event-handler attributes');
   });
 });
 


### PR DESCRIPTION
Closes #1341

The error dialog's `<media-theme>` element used inline `onclose` and `onfocusin` attributes, which violate a strict `script-src` CSP (no `'unsafe-inline'`, and no `script-src-attr` override). Unlike the retry link (fixed in #1332), these are not gated on user interaction; they fire on the dialog's own focus/lifecycle events, so they trip CSP essentially whenever an error dialog appears.

Although the player's `html` template processor rebinds `on*` values via `addEventListener` and strips the attribute at runtime, the literal `on*=` text still lives in the template HTML string that is parsed/cloned into the live DOM. The browser therefore attempts to compile the inline handler (and CSP refuses it, reporting `violated-directive: script-src-attr`, `blocked-uri: inline`) *before* the processor removes the attribute.

### Changes
- **`mux-player`**: Removes the `onclose`/`onfocusin` attributes from the `<media-theme>` template. The two handlers are now bound programmatically on the `media-theme` element via `addEventListener` in `#setUpErrors`, with matching cleanup in `disconnectedCallback`. The handlers keep their existing `composedPath()` / `media-error-dialog` guards, so behavior is unchanged.
- Removes the now-unused `onCloseErrorDialog` / `onFocusInErrorDialog` template props from `MuxTemplateProps`.
- **test**: Adds a `template.test.js` regression test asserting the rendered template contains no inline `on*` event-handler attributes. It checks the raw template string (pre part-processing), since that is what the browser parses into the DOM and what CSP evaluates (the post-render DOM would hide the regression because the processor strips the attributes).

### Testing
- `npm test` in `packages/mux-player` — 134 passing, 0 failed.
- Existing error-dialog open/close tests (`player.test.js`) continue to pass, confirming the rebound `close`/`focusin` handlers behave identically.
- Static check: `grep -oE '\bon[a-z]+="[^"]*"' dist/mux-player.mjs` returns no error-dialog handlers after build.

### Notes
- This is a follow-up to #1332, which removed the inline `onclick` from the retry link. Together they clear all inline event-handler attributes from the error-dialog path so consumers (e.g. the `player.mux.com` iframe embed) can enforce a strict `script-src` without `'unsafe-inline'`.
- No reliance on `'unsafe-inline'` is introduced; the fix is purely `addEventListener`-based.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized wiring change with existing tests and a CSP regression guard; no auth or data-path changes.
> 
> **Overview**
> **Removes inline `onclose` / `onfocusin` from the `<media-theme>` template** so strict `script-src` (no `'unsafe-inline'`) no longer trips `script-src-attr` when the error dialog appears. The browser evaluates inline handlers in the parsed template string before the `html` processor can strip them.
> 
> **Error-dialog close and focus behavior is unchanged:** `#onCloseErrorDialog` and `#onFocusInErrorDialog` are class fields with the same `composedPath()` / `media-error-dialog` guards, wired in `#setUpErrors` with `addEventListener('close'|'focusin')` on `mediaTheme` and removed in `disconnectedCallback`. The corresponding props are dropped from `MuxTemplateProps`.
> 
> **Adds a regression test** that the raw template HTML (pre part-processing) contains no `on*` event-handler attributes, since post-render DOM would hide a reintroduction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dbffa3f476de4e35816b92e44c19f20cce18a7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->