### PR TITLE
fix: add missing types for new maxReconnectAttempts

### DIFF
--- a/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
+++ b/examples/nextjs-with-typescript/pages/MuxPlayer.tsx
@@ -129,6 +129,7 @@ const DEFAULT_INITIAL_STATE: Partial<MuxPlayerProps> = Object.freeze({
   proudlyDisplayMuxBadge: undefined,
   disablePseudoEnded: undefined,
   capRenditionToPlayerSize: undefined,
+  maxReconnectRetries: undefined,
 });
 
 const SMALL_BREAKPOINT = 700;
@@ -285,6 +286,7 @@ function MuxPlayerPage({ location }: Props) {
           // }}
           maxAutoResolution="720p"
           capRenditionToPlayerSize={state.capRenditionToPlayerSize}
+          maxReconnectRetries={state.maxReconnectRetries}
           title={state.title}
           videoTitle={state.videoTitle}
           startTime={state.startTime}
@@ -661,6 +663,14 @@ function MuxPlayerPage({ location }: Props) {
             value={state.capRenditionToPlayerSize}
             name="capRenditionToPlayerSize"
             onChange={genericOnChange}
+          />
+          <NumberRenderer
+            value={state.maxReconnectRetries}
+            name="maxReconnectRetries"
+            label="maxReconnectRetries (0/unset = off; e.g. 6 to enable network recovery)"
+            onChange={genericOnChange}
+            min={0}
+            step={1}
           />
         </div>
       </main>

--- a/packages/mux-player-astro/src/types.ts
+++ b/packages/mux-player-astro/src/types.ts
@@ -89,6 +89,7 @@ export type MuxPlayerProps = {
   initialBandwidthEstimateKbps?: number;
   initialEstimateSegments?: number;
   minPreloadSegments?: number;
+  maxReconnectRetries?: number;
   storyboardSrc?: string;
   preferCmcd?: ValueOf<CmcdTypes> | undefined;
 } & astroHTML.JSX.HTMLAttributes;

--- a/packages/mux-player-react/src/types.ts
+++ b/packages/mux-player-react/src/types.ts
@@ -122,6 +122,7 @@ export type MuxPlayerProps = {
   themeProps?: { [k: string]: any };
   fullscreenElement?: string;
   capRenditionToPlayerSize?: boolean;
+  maxReconnectRetries?: number;
   onAbort?: GenericEventListener<MuxPlayerElementEventMap['abort']>;
   onCanPlay?: GenericEventListener<MuxPlayerElementEventMap['canplay']>;
   onCanPlayThrough?: GenericEventListener<MuxPlayerElementEventMap['canplaythrough']>;

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -124,6 +124,7 @@ MuxVideo.propTypes = {
   initialBandwidthEstimateKbps: PropTypes.number,
   initialEstimateSegments: PropTypes.number,
   minPreloadSegments: PropTypes.number,
+  maxReconnectRetries: PropTypes.number,
   streamType: PropTypes.oneOf(Object.values(StreamTypes)),
   targetLiveWindow: PropTypes.number,
   tokens: PropTypes.object,


### PR DESCRIPTION
Follow up for the work done in https://github.com/muxinc/elements/pull/1344

It was missing adding the new prop type to different React/Astro packages. While this is not released, using the property should still work, so it's safe to ignore the error temporarily.

**Edit: accidentally overwrote Cursor summary while editing the description so adding from edit history**


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type and demo-only surface changes with no runtime logic; behavior was already supported at runtime without these declarations.
> 
> **Overview**
> Adds the missing **`maxReconnectRetries`** optional number prop to the public TypeScript surfaces for **`@mux/mux-player-react`** and **`@mux/mux-player-astro`**, and registers it in **`mux-video-react`** `PropTypes`, so consumers get type-checking for the network recovery option introduced in the earlier playback work.
> 
> The Next.js **`MuxPlayer`** demo is updated to wire the prop through player state and a numeric control (documented as off when unset/0, e.g. 6 to enable recovery).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d9a6e0ad9b065ca9b3968103ef675dabc4baf8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->