### PR TITLE
fix: make disableCookies reactive

### DIFF
--- a/packages/mux-audio-react/src/index.tsx
+++ b/packages/mux-audio-react/src/index.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   allMediaTypes,
+  applyDisableCookies,
   initialize,
   teardown,
   MuxMediaProps,
@@ -44,22 +45,22 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
     setSrc(toMuxVideoURL(props) ?? outerSrc);
   }, [outerSrc, playbackId]);
 
-  useEffect(() => {
-    const propsWithState = {
-      // NOTE: Applying playerInitTime first as a simple way of overriding it if/when folks update
-      // the value via props after initial load (e.g. when swapping src)
-      playerInitTime,
-      ...props,
-      src,
-      playerSoftwareName,
-      playerSoftwareVersion,
-      autoplay: autoPlay,
-    };
+  const getPropsWithState = () => ({
+    // NOTE: Applying playerInitTime first as a simple way of overriding it if/when folks update
+    // the value via props after initial load (e.g. when swapping src)
+    playerInitTime,
+    ...props,
+    src,
+    playerSoftwareName,
+    playerSoftwareVersion,
+    autoplay: autoPlay,
+  });
 
+  useEffect(() => {
     // mediaEl required caching here so the ref was not null in the unmount callback.
     let mediaEl = mediaElRef.current;
     if (mediaEl) {
-      playbackCoreRef.current = initialize(propsWithState, mediaEl, playbackCoreRef.current);
+      playbackCoreRef.current = initialize(getPropsWithState(), mediaEl, playbackCoreRef.current);
     }
 
     return () => {
@@ -68,6 +69,12 @@ const MuxAudio = React.forwardRef<HTMLAudioElement | undefined, Partial<Props>>(
       playbackCoreRef.current = undefined;
     };
   }, [src]);
+
+  // mux-embed latches `disableCookies` when the monitor is created and offers no setter, so Mux Data
+  // has to be re-attached to pick up a change. Unlike a src change, that leaves the media alone.
+  useEffect(() => {
+    applyDisableCookies(getPropsWithState(), mediaElRef.current, playbackCoreRef.current);
+  }, [props.disableCookies]);
 
   useEffect(() => {
     playbackCoreRef.current?.setAutoplay(autoPlay);

--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -1,5 +1,6 @@
 import { globalThis } from './polyfills';
 import {
+  applyDisableCookies,
   initialize,
   teardown,
   generatePlayerInitTime,
@@ -580,6 +581,14 @@ class MuxAudioElement extends CustomAudioElement implements Partial<MuxMediaProp
         }
         if (!!this._hls) {
           this._hls.config.debug = debug;
+        }
+        break;
+      }
+      case Attributes.DISABLE_COOKIES: {
+        if (newValue == null || newValue !== oldValue) {
+          // mux-embed latches the value when the monitor is created and has no setter for it, so
+          // Mux Data has to be re-attached to pick up a change. That doesn't reload the media.
+          applyDisableCookies(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
         }
         break;
       }

--- a/packages/mux-audio/test/player.test.js
+++ b/packages/mux-audio/test/player.test.js
@@ -1,4 +1,4 @@
-import { fixture, assert, aTimeout } from '@open-wc/testing';
+import { fixture, assert, aTimeout, waitUntil } from '@open-wc/testing';
 import MuxAudioElement, { AudioEvents } from '../src/index.ts';
 
 describe('<mux-audio>', () => {
@@ -165,7 +165,11 @@ describe('<mux-audio>', () => {
   });
 });
 
-describe('<mux-audio> disable-cookies', () => {
+describe('<mux-audio> disable-cookies', function () {
+  // These load real media, and every wait below is on a condition rather than a delay, so give the
+  // slowest CI browser room instead of racing mocha's 2s default.
+  this.timeout(15000);
+
   const PLAYBACK_ID = 'vDpm5ygrRJgfIEPNIc02IJR4Trf3z00AiP';
   const VIEWER_ID = 'test-viewer-id';
 
@@ -204,14 +208,34 @@ describe('<mux-audio> disable-cookies', () => {
     };
   };
 
+  // waitUntil() defaults to a 1s timeout, which a loaded CI browser can blow through.
+  const WAIT = { timeout: 5000 };
+
+  const waitForMonitors = (muxDataSDK, count, message) =>
+    waitUntil(() => muxDataSDK.monitors.length >= count, message, WAIT);
+
+  const waitForNoMuxDataCookie = (message) => waitUntil(() => readMuxDataCookie() === null, message, WAIT);
+
+  /** Gives whatever a change kicked off time to surface, before asserting that nothing else did. */
+  const settle = () => aTimeout(50);
+
   /** Loads a player with the Mux Data SDK spied on from the very first monitor. */
   const fixtureWithSpy = async (attrs = '') => {
     const player = await fixture(`<mux-audio muted ${attrs}></mux-audio>`);
     const muxDataSDK = createMuxDataSDKSpy();
     player.muxDataSDK = muxDataSDK;
+
+    // The first load fires its own emptied/loadstart, and on a slow browser those can land well
+    // after the monitor does, so wait for them rather than for a fixed delay: a test watching for a
+    // reload would otherwise pick up the initial load.
+    let loadStarted = false;
+    player.addEventListener('loadstart', () => (loadStarted = true), { once: true });
+
     // Setting the playback id is what triggers the first load, and with it the first monitor.
     player.playbackId = PLAYBACK_ID;
-    await aTimeout(50);
+
+    await waitForMonitors(muxDataSDK, 1, 'Mux Data should monitor the first load');
+    await waitUntil(() => loadStarted, 'the first load should have started', WAIT);
     return { player, muxDataSDK };
   };
 
@@ -225,9 +249,8 @@ describe('<mux-audio> disable-cookies', () => {
     assert.notOk(muxDataSDK.monitors[0].options.disableCookies, 'cookies enabled to begin with');
 
     player.disableCookies = true;
-    await aTimeout(0);
+    await waitForMonitors(muxDataSDK, 2, 'monitor should be re-created');
 
-    assert.equal(muxDataSDK.monitors.length, 2, 'monitor was re-created');
     assert.isTrue(muxDataSDK.monitors[0].destroyed, 'the previous monitor was destroyed');
     assert.isTrue(muxDataSDK.monitors[1].options.disableCookies, 'the new monitor has cookies disabled');
   });
@@ -237,9 +260,8 @@ describe('<mux-audio> disable-cookies', () => {
     assert.isTrue(muxDataSDK.monitors[0].options.disableCookies, 'cookies disabled to begin with');
 
     player.disableCookies = false;
-    await aTimeout(0);
+    await waitForMonitors(muxDataSDK, 2, 'monitor should be re-created');
 
-    assert.equal(muxDataSDK.monitors.length, 2, 'monitor was re-created');
     assert.notOk(muxDataSDK.monitors[1].options.disableCookies, 'the new monitor has cookies enabled');
   });
 
@@ -247,17 +269,16 @@ describe('<mux-audio> disable-cookies', () => {
     const { player, muxDataSDK } = await fixtureWithSpy();
 
     player.setAttribute('disable-cookies', '');
-    await aTimeout(0);
-    assert.equal(muxDataSDK.monitors.length, 2, 'the change was applied');
+    await waitForMonitors(muxDataSDK, 2, 'the change should be applied');
 
     // attributeChangedCallback fires even when the value is identical.
     player.setAttribute('disable-cookies', '');
-    await aTimeout(0);
+    await settle();
     assert.equal(muxDataSDK.monitors.length, 2, 'no monitor for a redundant re-apply');
   });
 
   it('does not reload the media when disable-cookies changes', async () => {
-    const { player } = await fixtureWithSpy();
+    const { player, muxDataSDK } = await fixtureWithSpy();
 
     const mediaEvents = [];
     ['emptied', 'loadstart', 'abort'].forEach((type) => {
@@ -265,7 +286,9 @@ describe('<mux-audio> disable-cookies', () => {
     });
 
     player.disableCookies = true;
-    await aTimeout(50);
+    // Anchored on the re-attach, so this can't pass just because the change hasn't landed yet.
+    await waitForMonitors(muxDataSDK, 2, 'Mux Data should be re-attached');
+    await settle();
 
     assert.deepEqual(mediaEvents, [], 'the media element was left alone');
   });
@@ -275,9 +298,8 @@ describe('<mux-audio> disable-cookies', () => {
     plantMuxDataCookie();
 
     player.disableCookies = true;
-    await aTimeout(0);
 
-    assert.equal(readMuxDataCookie(), null, 'the cookie was cleared');
+    await waitForNoMuxDataCookie('the cookie should be cleared');
   });
 
   it('keeps an existing muxData cookie when it initializes with disable-cookies', async () => {
@@ -286,6 +308,7 @@ describe('<mux-audio> disable-cookies', () => {
     plantMuxDataCookie();
 
     const { muxDataSDK } = await fixtureWithSpy('disable-cookies');
+    await settle();
 
     assert.include(readMuxDataCookie(), VIEWER_ID, 'the cookie was left alone');
     assert.equal(muxDataSDK.monitors.length, 1, 'no re-attach was needed');

--- a/packages/mux-audio/test/player.test.js
+++ b/packages/mux-audio/test/player.test.js
@@ -132,3 +132,131 @@ describe('<mux-audio>', () => {
     );
   });
 });
+
+describe('<mux-audio> disable-cookies', () => {
+  const PLAYBACK_ID = 'vDpm5ygrRJgfIEPNIc02IJR4Trf3z00AiP';
+  const VIEWER_ID = 'test-viewer-id';
+
+  const readMuxDataCookie = () => document.cookie.split('; ').find((c) => c.startsWith('muxData')) ?? null;
+
+  const plantMuxDataCookie = () => {
+    document.cookie = `muxData==undefined&mux_viewer_id=${VIEWER_ID}&msn=0.5&sid=s&sst=1&sex=9999999999999;path=/;max-age=3600`;
+  };
+
+  const forgetMuxDataCookie = () => {
+    document.cookie = `muxData=;expires=${new Date(0).toUTCString()};path=/`;
+  };
+
+  /**
+   * Stand-in for mux-embed that records the options each monitor was created with, so a re-attached
+   * monitor can be told from a re-used one without sending beacons.
+   */
+  const createMuxDataSDKSpy = () => {
+    const monitors = [];
+    return {
+      monitors,
+      monitor(mediaEl, options) {
+        const record = { options, destroyed: false };
+        monitors.push(record);
+        mediaEl.mux = {
+          deleted: false,
+          emit() {},
+          addHLSJS() {},
+          removeHLSJS() {},
+          destroy() {
+            record.destroyed = true;
+            this.deleted = true;
+          },
+        };
+      },
+    };
+  };
+
+  /** Loads a player with the Mux Data SDK spied on from the very first monitor. */
+  const fixtureWithSpy = async (attrs = '') => {
+    const player = await fixture(`<mux-audio muted ${attrs}></mux-audio>`);
+    const muxDataSDK = createMuxDataSDKSpy();
+    player.muxDataSDK = muxDataSDK;
+    // Setting the playback id is what triggers the first load, and with it the first monitor.
+    player.playbackId = PLAYBACK_ID;
+    await aTimeout(50);
+    return { player, muxDataSDK };
+  };
+
+  afterEach(() => {
+    forgetMuxDataCookie();
+  });
+
+  it('re-attaches Mux Data when disable-cookies is turned on', async () => {
+    const { player, muxDataSDK } = await fixtureWithSpy();
+    assert.equal(muxDataSDK.monitors.length, 1, 'monitored once on load');
+    assert.notOk(muxDataSDK.monitors[0].options.disableCookies, 'cookies enabled to begin with');
+
+    player.disableCookies = true;
+    await aTimeout(0);
+
+    assert.equal(muxDataSDK.monitors.length, 2, 'monitor was re-created');
+    assert.isTrue(muxDataSDK.monitors[0].destroyed, 'the previous monitor was destroyed');
+    assert.isTrue(muxDataSDK.monitors[1].options.disableCookies, 'the new monitor has cookies disabled');
+  });
+
+  it('re-attaches Mux Data when disable-cookies is turned off', async () => {
+    const { player, muxDataSDK } = await fixtureWithSpy('disable-cookies');
+    assert.isTrue(muxDataSDK.monitors[0].options.disableCookies, 'cookies disabled to begin with');
+
+    player.disableCookies = false;
+    await aTimeout(0);
+
+    assert.equal(muxDataSDK.monitors.length, 2, 'monitor was re-created');
+    assert.notOk(muxDataSDK.monitors[1].options.disableCookies, 'the new monitor has cookies enabled');
+  });
+
+  it('does not re-attach Mux Data when the same value is re-applied', async () => {
+    const { player, muxDataSDK } = await fixtureWithSpy();
+
+    player.setAttribute('disable-cookies', '');
+    await aTimeout(0);
+    assert.equal(muxDataSDK.monitors.length, 2, 'the change was applied');
+
+    // attributeChangedCallback fires even when the value is identical.
+    player.setAttribute('disable-cookies', '');
+    await aTimeout(0);
+    assert.equal(muxDataSDK.monitors.length, 2, 'no monitor for a redundant re-apply');
+  });
+
+  it('does not reload the media when disable-cookies changes', async () => {
+    const { player } = await fixtureWithSpy();
+
+    const mediaEvents = [];
+    ['emptied', 'loadstart', 'abort'].forEach((type) => {
+      player.addEventListener(type, () => mediaEvents.push(type));
+    });
+
+    player.disableCookies = true;
+    await aTimeout(50);
+
+    assert.deepEqual(mediaEvents, [], 'the media element was left alone');
+  });
+
+  it('clears the muxData cookie when cookies are disabled at runtime', async () => {
+    const { player } = await fixtureWithSpy();
+    plantMuxDataCookie();
+
+    player.disableCookies = true;
+    await aTimeout(0);
+
+    assert.equal(readMuxDataCookie(), null, 'the cookie was cleared');
+  });
+
+  it('keeps an existing muxData cookie when it initializes with disable-cookies', async () => {
+    // A server-rendered page can't read consent, so it always emits the cookie-less state. Clearing
+    // there would drop a returning viewer's mux_viewer_id before consent can be granted.
+    plantMuxDataCookie();
+
+    const { muxDataSDK } = await fixtureWithSpy('disable-cookies');
+
+    assert.include(readMuxDataCookie(), VIEWER_ID, 'the cookie was left alone');
+    assert.equal(muxDataSDK.monitors.length, 1, 'no re-attach was needed');
+    assert.isTrue(muxDataSDK.monitors[0].options.disableCookies, 'and cookies are disabled');
+  });
+});

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -80,6 +80,11 @@ const usePlayer = (
   useObjectPropEffect('playbackId', playbackId, ref);
   useObjectPropEffect('playbackRates', playbackRates, ref);
   useObjectPropEffect('metadata', metadata, ref);
+  // Also applied as a property, on top of the `disable-cookies` attribute below, because React
+  // never reconciles attributes during hydration — it warns that the mismatch "won't be patched
+  // up" and leaves the server's value in the DOM. A server-rendered page can't read consent, so it
+  // has to emit the cookie-less state; without this the player would stay stuck in it for good.
+  useObjectPropEffect('disableCookies', props.disableCookies ?? false, ref);
   useObjectPropEffect('extraSourceParams', extraSourceParams, ref);
   useObjectPropEffect('_hlsConfig', _hlsConfig, ref);
   useObjectPropEffect('themeProps', themeProps, ref);

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -80,9 +80,6 @@ const usePlayer = (
   useObjectPropEffect('playbackId', playbackId, ref);
   useObjectPropEffect('playbackRates', playbackRates, ref);
   useObjectPropEffect('metadata', metadata, ref);
-  // Applied as a property on top of the `disable-cookies` attribute, because React never reconciles
-  // attributes during hydration. A server-rendered page can't read consent so it has to emit the
-  // cookie-less state, and without this the player would stay stuck in it.
   useObjectPropEffect('disableCookies', props.disableCookies ?? false, ref);
   useObjectPropEffect('extraSourceParams', extraSourceParams, ref);
   useObjectPropEffect('_hlsConfig', _hlsConfig, ref);

--- a/packages/mux-player-react/src/index.tsx
+++ b/packages/mux-player-react/src/index.tsx
@@ -80,10 +80,9 @@ const usePlayer = (
   useObjectPropEffect('playbackId', playbackId, ref);
   useObjectPropEffect('playbackRates', playbackRates, ref);
   useObjectPropEffect('metadata', metadata, ref);
-  // Also applied as a property, on top of the `disable-cookies` attribute below, because React
-  // never reconciles attributes during hydration — it warns that the mismatch "won't be patched
-  // up" and leaves the server's value in the DOM. A server-rendered page can't read consent, so it
-  // has to emit the cookie-less state; without this the player would stay stuck in it for good.
+  // Applied as a property on top of the `disable-cookies` attribute, because React never reconciles
+  // attributes during hydration. A server-rendered page can't read consent so it has to emit the
+  // cookie-less state, and without this the player would stay stuck in it.
   useObjectPropEffect('disableCookies', props.disableCookies ?? false, ref);
   useObjectPropEffect('extraSourceParams', extraSourceParams, ref);
   useObjectPropEffect('_hlsConfig', _hlsConfig, ref);

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -82,13 +82,16 @@ describe('<mux-player>', () => {
   });
 
   it('playbackId is forwarded to the media element', async function () {
+    // Setting up a real player can take a while on a loaded CI browser.
+    this.timeout(10000);
+
     const player = await fixture(`<mux-player
       playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
       stream-type="on-demand"
       muted
     ></mux-player>`);
 
-    await aTimeout(100);
+    await waitUntil(() => player.media, 'media element should be available', { timeout: 5000 });
 
     assert.equal(player.playbackId, 'DS00Spx1CV902MCtPj5WknGlR102V5HFkDe');
   });
@@ -532,6 +535,11 @@ describe('<mux-player>', () => {
   });
 
   it("signing tokens generate correct asset URL's", async function () {
+    // The storyboard <track> only appears once the media reports a currentSrc, so this waits on a
+    // real load. waitUntil()'s 1s default is not enough for that on a loaded CI browser.
+    this.timeout(15000);
+    const wait = { timeout: 10000 };
+
     // tokens expire in 10 years
     const player = await fixture(`<mux-player
       stream-type="on-demand"
@@ -544,23 +552,27 @@ describe('<mux-player>', () => {
     const muxVideo = player.media;
     const mediaPosterImage = player.mediaTheme.querySelector('media-poster-image');
 
-    await waitUntil(() => !!muxVideo.getAttribute('src'), '<mux-video> src never set');
+    await waitUntil(() => !!muxVideo.getAttribute('src'), '<mux-video> src never set', wait);
     assert.equal(
       muxVideo.getAttribute('src'),
       'https://stream.mux.com/bos2bPV3qbFgpVPaQ900Xd5UcdM6WXTmz02WZSz01nJ00tY.m3u8?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE5NjE2MDE2MjgsImF1ZCI6InYiLCJzdWIiOiJib3MyYlBWM3FiRmdwVlBhUTkwMFhkNVVjZE02V1hUbXowMldaU3owMW5KMDB0WSJ9.OUegJAmrlvD9BhzUhogrup_mYRBYNG2ocqmJZK2lKPLFmP1jLKi99Lj_9ZQqIXgmoYeXo2jKr3WFMO8nbGwtZFKU2_szq1EWlj4mBgdWXfAP5amC92qkm87nIuNFM2WVANGlBksmj8uOmYNIuPh1Ctti1qiJEYkf-JthWFFpaR_2TlQJ7g0bmRPzk3nOPDtqZnJBfTVm3n4Kp7Cr27a_VBA6zpoW6DwjJ6_uPkm6TAxXjw7VWNd3YVLs7S_jgs8q3t9DPpAN57q94syVQtEUkRh4tlDX-gdIrJDi9nFB1fIBh45pD01PvrAWzZXKKE9YSW7dnktqSUy81kcu2F_gXA'
     );
 
-    await waitUntil(() => !!mediaPosterImage.getAttribute('src'), '<media-poster-image> src never set');
+    await waitUntil(() => !!mediaPosterImage.getAttribute('src'), '<media-poster-image> src never set', wait);
     assert.equal(
       mediaPosterImage.getAttribute('src'),
       'https://image.mux.com/bos2bPV3qbFgpVPaQ900Xd5UcdM6WXTmz02WZSz01nJ00tY/thumbnail.webp?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE5NjE2MDE3MzYsImF1ZCI6InQiLCJzdWIiOiJib3MyYlBWM3FiRmdwVlBhUTkwMFhkNVVjZE02V1hUbXowMldaU3owMW5KMDB0WSJ9.gDe_efqmRB5E3e4ag6in8MfMK-Vn3c_3B4M-BiWw6lg2aaf2BOTv7ltxhn2cvg4G0iFi-esRjhDlHbMRTxwTGavsx8TRLFtJ8vyBzToaFQbQMrn9OZztq_XrCEwqkD8bUAVtdOT1YB606OZyy6XO-CxdMRrKMUsM-cGrfv0TxvzJjThJBY4SzFv_whtYRxqAypZojROU7IiTbqcsk_cSrRMjB7WyAOAvyPNKnr6RkVEuMJtlCtaf_e4DIJHebZUZb3JmVTG4jIWrD1QkN7uLUwCPPRvGhXwhet9JaJPyC5lmkcb9YmH-15V6GOpwSg7sDMGC3YS4aIb_RtVkan0t-w'
     );
 
     let storyboardTrack;
-    await waitUntil(() => {
-      storyboardTrack = muxVideo.shadowRoot.querySelector("track[label='thumbnails']");
-      return storyboardTrack && !!storyboardTrack.getAttribute('src');
-    }, 'storyboard <track> src never set');
+    await waitUntil(
+      () => {
+        storyboardTrack = muxVideo.shadowRoot.querySelector("track[label='thumbnails']");
+        return storyboardTrack && !!storyboardTrack.getAttribute('src');
+      },
+      'storyboard <track> src never set',
+      wait
+    );
     assert.equal(
       storyboardTrack.getAttribute('src'),
       'https://image.mux.com/bos2bPV3qbFgpVPaQ900Xd5UcdM6WXTmz02WZSz01nJ00tY/storyboard.vtt?token=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik96VU90ek1nUWhPbkk2MDJ6SlFQbU52THR4MDBnSjJqTlBxN0tTTzAxQlozelEifQ.eyJleHAiOjE5NjE2MDE3NzcsImF1ZCI6InMiLCJzdWIiOiJib3MyYlBWM3FiRmdwVlBhUTkwMFhkNVVjZE02V1hUbXowMldaU3owMW5KMDB0WSJ9.aVd0dsOJUVeQko3BWd9YEhL41Eytf_ZfaBeNzHSSUqU_gREa_jJEVTlRfuiE4g71cKJLSiVTKP7f-F7Txh6DlL8E2SkonfIPB2H0f_3DQxYLso2E8qI4zuJkyxKORbQFLAEB_vSE-2lMbrHXfdpQhv6SrVyu6di9ku0LpFpoyz-_7fVJICr8nhlsqOGt66AYcaa99TXoZ582FWzBaePmWw-WWKYsLvtNjLS9UoxbdVaBRwNylohvhh-i1Y9dNilyNooJ7O8Cj4GuMjeh1pCj0BOrGagxrWrswm3HjUVNUqFq5JCWnJCxgjjwiV4RLZg_4z7gkBXyX7H2-i1dKA3Cpw&format=webp'
@@ -1239,7 +1251,11 @@ describe('<mux-player> seek to live behaviors', function () {
   });
 });
 
-describe('<mux-player> disable-cookies', () => {
+describe('<mux-player> disable-cookies', function () {
+  // These load real media, and every wait below is on a condition rather than a delay, so give the
+  // slowest CI browser room instead of racing mocha's 2s default.
+  this.timeout(15000);
+
   const PLAYBACK_ID = 'DS00Spx1CV902MCtPj5WknGlR102V5HFkDe';
   const VIEWER_ID = 'test-viewer-id';
 
@@ -1278,15 +1294,35 @@ describe('<mux-player> disable-cookies', () => {
     };
   };
 
+  // waitUntil() defaults to a 1s timeout, which a loaded CI browser can blow through.
+  const WAIT = { timeout: 5000 };
+
+  const waitForMonitors = (muxDataSDK, count, message) =>
+    waitUntil(() => muxDataSDK.monitors.length >= count, message, WAIT);
+
+  const waitForNoMuxDataCookie = (message) => waitUntil(() => readMuxDataCookie() === null, message, WAIT);
+
+  /** Gives whatever a change kicked off time to surface, before asserting that nothing else did. */
+  const settle = () => aTimeout(50);
+
   /** Loads a player with the Mux Data SDK spied on from the very first monitor. */
   const fixtureWithSpy = async (attrs = '') => {
     const player = await fixture(`<mux-player muted prefer-playback="mse" ${attrs}></mux-player>`);
-    await waitUntil(() => player.media, 'media element should be available');
+    await waitUntil(() => player.media, 'media element should be available', WAIT);
     const muxDataSDK = createMuxDataSDKSpy();
     player.media.muxDataSDK = muxDataSDK;
+
+    // The first load fires its own emptied/loadstart, and on a slow browser those can land well
+    // after the monitor does, so wait for them rather than for a fixed delay: a test watching for a
+    // reload would otherwise pick up the initial load.
+    let loadStarted = false;
+    player.media.addEventListener('loadstart', () => (loadStarted = true), { once: true });
+
     // Setting the playback id is what triggers the first load, and with it the first monitor.
     player.playbackId = PLAYBACK_ID;
-    await aTimeout(50);
+
+    await waitForMonitors(muxDataSDK, 1, 'Mux Data should monitor the first load');
+    await waitUntil(() => loadStarted, 'the first load should have started', WAIT);
     return { player, muxDataSDK };
   };
 
@@ -1294,37 +1330,29 @@ describe('<mux-player> disable-cookies', () => {
     forgetMuxDataCookie();
   });
 
-  it('re-attaches Mux Data when disableCookies is turned on', async function () {
-    this.timeout(5000);
-
+  it('re-attaches Mux Data when disableCookies is turned on', async () => {
     const { player, muxDataSDK } = await fixtureWithSpy();
     assert.equal(muxDataSDK.monitors.length, 1, 'monitored once on load');
     assert.notOk(muxDataSDK.monitors[0].options.disableCookies, 'cookies enabled to begin with');
 
     player.disableCookies = true;
-    await aTimeout(50);
+    await waitForMonitors(muxDataSDK, 2, 'monitor should be re-created');
 
-    assert.equal(muxDataSDK.monitors.length, 2, 'monitor was re-created');
     assert.isTrue(muxDataSDK.monitors[1].options.disableCookies, 'the new monitor has cookies disabled');
   });
 
-  it('re-attaches Mux Data when disableCookies is turned off', async function () {
-    this.timeout(5000);
-
+  it('re-attaches Mux Data when disableCookies is turned off', async () => {
     const { player, muxDataSDK } = await fixtureWithSpy('disable-cookies');
     assert.isTrue(muxDataSDK.monitors[0].options.disableCookies, 'cookies disabled to begin with');
 
     player.disableCookies = false;
-    await aTimeout(50);
+    await waitForMonitors(muxDataSDK, 2, 'monitor should be re-created');
 
-    assert.equal(muxDataSDK.monitors.length, 2, 'monitor was re-created');
     assert.notOk(muxDataSDK.monitors[1].options.disableCookies, 'the new monitor has cookies enabled');
   });
 
-  it('does not reload the media when disableCookies changes', async function () {
-    this.timeout(5000);
-
-    const { player } = await fixtureWithSpy();
+  it('does not reload the media when disableCookies changes', async () => {
+    const { player, muxDataSDK } = await fixtureWithSpy();
 
     const mediaEvents = [];
     ['emptied', 'loadstart', 'abort'].forEach((type) => {
@@ -1332,31 +1360,29 @@ describe('<mux-player> disable-cookies', () => {
     });
 
     player.disableCookies = true;
-    await aTimeout(100);
+    // Anchored on the re-attach, so this can't pass just because the change hasn't landed yet.
+    await waitForMonitors(muxDataSDK, 2, 'Mux Data should be re-attached');
+    await settle();
 
     assert.deepEqual(mediaEvents, [], 'the media element was left alone');
   });
 
-  it('clears the muxData cookie when cookies are disabled at runtime', async function () {
-    this.timeout(5000);
-
+  it('clears the muxData cookie when cookies are disabled at runtime', async () => {
     const { player } = await fixtureWithSpy();
     plantMuxDataCookie();
 
     player.disableCookies = true;
-    await aTimeout(50);
 
-    assert.equal(readMuxDataCookie(), null, 'the cookie was cleared');
+    await waitForNoMuxDataCookie('the cookie should be cleared');
   });
 
-  it('keeps an existing muxData cookie when it initializes with disable-cookies', async function () {
-    this.timeout(5000);
-
+  it('keeps an existing muxData cookie when it initializes with disable-cookies', async () => {
     // A server-rendered page can't read consent, so it always emits the cookie-less state. Clearing
     // there would drop a returning viewer's mux_viewer_id before consent can be granted.
     plantMuxDataCookie();
 
     const { muxDataSDK } = await fixtureWithSpy('disable-cookies');
+    await settle();
 
     assert.include(readMuxDataCookie(), VIEWER_ID, 'the cookie was left alone');
     assert.equal(muxDataSDK.monitors.length, 1, 'no re-attach was needed');

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -1145,3 +1145,128 @@ describe('<mux-player> seek to live behaviors', function () {
     });
   });
 });
+
+describe('<mux-player> disable-cookies', () => {
+  const PLAYBACK_ID = 'DS00Spx1CV902MCtPj5WknGlR102V5HFkDe';
+  const VIEWER_ID = 'test-viewer-id';
+
+  const readMuxDataCookie = () => document.cookie.split('; ').find((c) => c.startsWith('muxData')) ?? null;
+
+  const plantMuxDataCookie = () => {
+    document.cookie = `muxData==undefined&mux_viewer_id=${VIEWER_ID}&msn=0.5&sid=s&sst=1&sex=9999999999999;path=/;max-age=3600`;
+  };
+
+  const forgetMuxDataCookie = () => {
+    document.cookie = `muxData=;expires=${new Date(0).toUTCString()};path=/`;
+  };
+
+  /**
+   * Stand-in for mux-embed that records the options each monitor was created with, so a re-attached
+   * monitor can be told from a re-used one without sending beacons.
+   */
+  const createMuxDataSDKSpy = () => {
+    const monitors = [];
+    return {
+      monitors,
+      monitor(mediaEl, options) {
+        const record = { options, destroyed: false };
+        monitors.push(record);
+        mediaEl.mux = {
+          deleted: false,
+          emit() {},
+          addHLSJS() {},
+          removeHLSJS() {},
+          destroy() {
+            record.destroyed = true;
+            this.deleted = true;
+          },
+        };
+      },
+    };
+  };
+
+  /** Loads a player with the Mux Data SDK spied on from the very first monitor. */
+  const fixtureWithSpy = async (attrs = '') => {
+    const player = await fixture(`<mux-player muted prefer-playback="mse" ${attrs}></mux-player>`);
+    await waitUntil(() => player.media, 'media element should be available');
+    const muxDataSDK = createMuxDataSDKSpy();
+    player.media.muxDataSDK = muxDataSDK;
+    // Setting the playback id is what triggers the first load, and with it the first monitor.
+    player.playbackId = PLAYBACK_ID;
+    await aTimeout(50);
+    return { player, muxDataSDK };
+  };
+
+  afterEach(() => {
+    forgetMuxDataCookie();
+  });
+
+  it('re-attaches Mux Data when disableCookies is turned on', async function () {
+    this.timeout(5000);
+
+    const { player, muxDataSDK } = await fixtureWithSpy();
+    assert.equal(muxDataSDK.monitors.length, 1, 'monitored once on load');
+    assert.notOk(muxDataSDK.monitors[0].options.disableCookies, 'cookies enabled to begin with');
+
+    player.disableCookies = true;
+    await aTimeout(50);
+
+    assert.equal(muxDataSDK.monitors.length, 2, 'monitor was re-created');
+    assert.isTrue(muxDataSDK.monitors[1].options.disableCookies, 'the new monitor has cookies disabled');
+  });
+
+  it('re-attaches Mux Data when disableCookies is turned off', async function () {
+    this.timeout(5000);
+
+    const { player, muxDataSDK } = await fixtureWithSpy('disable-cookies');
+    assert.isTrue(muxDataSDK.monitors[0].options.disableCookies, 'cookies disabled to begin with');
+
+    player.disableCookies = false;
+    await aTimeout(50);
+
+    assert.equal(muxDataSDK.monitors.length, 2, 'monitor was re-created');
+    assert.notOk(muxDataSDK.monitors[1].options.disableCookies, 'the new monitor has cookies enabled');
+  });
+
+  it('does not reload the media when disableCookies changes', async function () {
+    this.timeout(5000);
+
+    const { player } = await fixtureWithSpy();
+
+    const mediaEvents = [];
+    ['emptied', 'loadstart', 'abort'].forEach((type) => {
+      player.media.addEventListener(type, () => mediaEvents.push(type));
+    });
+
+    player.disableCookies = true;
+    await aTimeout(100);
+
+    assert.deepEqual(mediaEvents, [], 'the media element was left alone');
+  });
+
+  it('clears the muxData cookie when cookies are disabled at runtime', async function () {
+    this.timeout(5000);
+
+    const { player } = await fixtureWithSpy();
+    plantMuxDataCookie();
+
+    player.disableCookies = true;
+    await aTimeout(50);
+
+    assert.equal(readMuxDataCookie(), null, 'the cookie was cleared');
+  });
+
+  it('keeps an existing muxData cookie when it initializes with disable-cookies', async function () {
+    this.timeout(5000);
+
+    // A server-rendered page can't read consent, so it always emits the cookie-less state. Clearing
+    // there would drop a returning viewer's mux_viewer_id before consent can be granted.
+    plantMuxDataCookie();
+
+    const { muxDataSDK } = await fixtureWithSpy('disable-cookies');
+
+    assert.include(readMuxDataCookie(), VIEWER_ID, 'the cookie was left alone');
+    assert.equal(muxDataSDK.monitors.length, 1, 'no re-attach was needed');
+    assert.isTrue(muxDataSDK.monitors[0].options.disableCookies, 'and cookies are disabled');
+  });
+});

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -56,7 +56,7 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
     setSrc(toMuxVideoURL(props) ?? outerSrc);
   }, [outerSrc, playbackId]);
 
-  const propsWithState = {
+  const getPropsWithState = () => ({
     // NOTE: Applying playerInitTime first as a simple way of overriding it if/when folks update
     // the value via props after initial load (e.g. when swapping src)
     playerInitTime,
@@ -65,17 +65,16 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
     playerSoftwareName,
     playerSoftwareVersion,
     autoplay: autoPlay,
-  };
+  });
 
-  // The value `disableCookies` was last applied with, so a src change and a `disableCookies`
-  // change in the same commit don't re-create the monitor twice.
+  // The value `disableCookies` was last applied with.
   const appliedDisableCookiesRef = useRef(props.disableCookies);
 
   useEffect(() => {
     // mediaEl required caching here so the ref was not null in the unmount callback.
     let mediaEl = mediaElRef.current;
     if (mediaEl) {
-      playbackCoreRef.current = initialize(propsWithState, mediaEl, playbackCoreRef.current);
+      playbackCoreRef.current = initialize(getPropsWithState(), mediaEl, playbackCoreRef.current);
       appliedDisableCookiesRef.current = props.disableCookies;
     }
 
@@ -86,12 +85,10 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
     };
   }, [src]);
 
-  // mux-embed latches `disableCookies` when the monitor is created and offers no setter, so the
-  // only way to apply a change is to re-create the monitor. Unlike a src change this leaves the
-  // media alone, so playback isn't interrupted.
-  // Only a change is handled, never the mounted value: on a server-rendered page the first client
-  // render can carry `disableCookies` simply because consent isn't known yet, and clearing the
-  // cookie there would drop a returning viewer's mux_viewer_id. Same reasoning as <mux-video>.
+  // Re-create the monitor, since mux-embed latches `disableCookies` and offers no setter. Only on a
+  // change, never on the mounted value: the first client render of a server-rendered page can carry
+  // `disableCookies` just because consent isn't known yet, and clearing the cookie there would drop
+  // a returning viewer's mux_viewer_id. Same reasoning as <mux-video>.
   useEffect(() => {
     if (appliedDisableCookiesRef.current === props.disableCookies) return;
     appliedDisableCookiesRef.current = props.disableCookies;
@@ -99,9 +96,8 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
     const mediaEl = mediaElRef.current;
     if (!mediaEl || !playbackCoreRef.current) return;
 
-    // Re-attach before clearing: tearing down the old monitor flushes a final beacon, which
-    // would re-write the cookie under the old value.
-    reinitMuxData(propsWithState, mediaEl, playbackCoreRef.current);
+    // Clear after re-attaching: tearing down the old monitor flushes a beacon that rewrites the cookie.
+    reinitMuxData(getPropsWithState(), mediaEl, playbackCoreRef.current);
     if (props.disableCookies) {
       clearMuxDataCookies();
     }

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -5,7 +5,9 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   allMediaTypes,
+  clearMuxDataCookies,
   initialize,
+  reinitMuxData,
   teardown,
   MuxMediaProps,
   StreamTypes,
@@ -54,22 +56,31 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
     setSrc(toMuxVideoURL(props) ?? outerSrc);
   }, [outerSrc, playbackId]);
 
-  useEffect(() => {
-    const propsWithState = {
-      // NOTE: Applying playerInitTime first as a simple way of overriding it if/when folks update
-      // the value via props after initial load (e.g. when swapping src)
-      playerInitTime,
-      ...props,
-      src,
-      playerSoftwareName,
-      playerSoftwareVersion,
-      autoplay: autoPlay,
-    };
+  const propsWithState = {
+    // NOTE: Applying playerInitTime first as a simple way of overriding it if/when folks update
+    // the value via props after initial load (e.g. when swapping src)
+    playerInitTime,
+    ...props,
+    src,
+    playerSoftwareName,
+    playerSoftwareVersion,
+    autoplay: autoPlay,
+  };
 
+  // The value `disableCookies` was last applied with, so a src change and a `disableCookies`
+  // change in the same commit don't re-create the monitor twice.
+  const appliedDisableCookiesRef = useRef(props.disableCookies);
+
+  useEffect(() => {
     // mediaEl required caching here so the ref was not null in the unmount callback.
     let mediaEl = mediaElRef.current;
     if (mediaEl) {
       playbackCoreRef.current = initialize(propsWithState, mediaEl, playbackCoreRef.current);
+      appliedDisableCookiesRef.current = props.disableCookies;
+      // Match <mux-video>, which clears the cookie when it initializes with cookies disabled.
+      if (props.disableCookies) {
+        clearMuxDataCookies();
+      }
     }
 
     return () => {
@@ -78,6 +89,24 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
       playbackCoreRef.current = undefined;
     };
   }, [src]);
+
+  // mux-embed latches `disableCookies` when the monitor is created and offers no setter, so the
+  // only way to apply a change is to re-create the monitor. Unlike a src change this leaves the
+  // media alone, so playback isn't interrupted.
+  useEffect(() => {
+    if (appliedDisableCookiesRef.current === props.disableCookies) return;
+    appliedDisableCookiesRef.current = props.disableCookies;
+
+    const mediaEl = mediaElRef.current;
+    if (!mediaEl || !playbackCoreRef.current) return;
+
+    // Re-attach before clearing: tearing down the old monitor flushes a final beacon, which
+    // would re-write the cookie under the old value.
+    reinitMuxData(propsWithState, mediaEl, playbackCoreRef.current);
+    if (props.disableCookies) {
+      clearMuxDataCookies();
+    }
+  }, [props.disableCookies]);
 
   useEffect(() => {
     playbackCoreRef.current?.setAutoplay(autoPlay);

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -77,10 +77,6 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
     if (mediaEl) {
       playbackCoreRef.current = initialize(propsWithState, mediaEl, playbackCoreRef.current);
       appliedDisableCookiesRef.current = props.disableCookies;
-      // Match <mux-video>, which clears the cookie when it initializes with cookies disabled.
-      if (props.disableCookies) {
-        clearMuxDataCookies();
-      }
     }
 
     return () => {
@@ -93,6 +89,9 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
   // mux-embed latches `disableCookies` when the monitor is created and offers no setter, so the
   // only way to apply a change is to re-create the monitor. Unlike a src change this leaves the
   // media alone, so playback isn't interrupted.
+  // Only a change is handled, never the mounted value: on a server-rendered page the first client
+  // render can carry `disableCookies` simply because consent isn't known yet, and clearing the
+  // cookie there would drop a returning viewer's mux_viewer_id. Same reasoning as <mux-video>.
   useEffect(() => {
     if (appliedDisableCookiesRef.current === props.disableCookies) return;
     appliedDisableCookiesRef.current = props.disableCookies;

--- a/packages/mux-video-react/src/index.tsx
+++ b/packages/mux-video-react/src/index.tsx
@@ -5,9 +5,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   allMediaTypes,
-  clearMuxDataCookies,
+  applyDisableCookies,
   initialize,
-  reinitMuxData,
   teardown,
   MuxMediaProps,
   StreamTypes,
@@ -67,15 +66,11 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
     autoplay: autoPlay,
   });
 
-  // The value `disableCookies` was last applied with.
-  const appliedDisableCookiesRef = useRef(props.disableCookies);
-
   useEffect(() => {
     // mediaEl required caching here so the ref was not null in the unmount callback.
     let mediaEl = mediaElRef.current;
     if (mediaEl) {
       playbackCoreRef.current = initialize(getPropsWithState(), mediaEl, playbackCoreRef.current);
-      appliedDisableCookiesRef.current = props.disableCookies;
     }
 
     return () => {
@@ -85,22 +80,10 @@ const MuxVideo = React.forwardRef<HTMLVideoElement | undefined, Partial<Props>>(
     };
   }, [src]);
 
-  // Re-create the monitor, since mux-embed latches `disableCookies` and offers no setter. Only on a
-  // change, never on the mounted value: the first client render of a server-rendered page can carry
-  // `disableCookies` just because consent isn't known yet, and clearing the cookie there would drop
-  // a returning viewer's mux_viewer_id. Same reasoning as <mux-video>.
+  // mux-embed latches `disableCookies` when the monitor is created and offers no setter, so Mux Data
+  // has to be re-attached to pick up a change. Unlike a src change, that leaves the media alone.
   useEffect(() => {
-    if (appliedDisableCookiesRef.current === props.disableCookies) return;
-    appliedDisableCookiesRef.current = props.disableCookies;
-
-    const mediaEl = mediaElRef.current;
-    if (!mediaEl || !playbackCoreRef.current) return;
-
-    // Clear after re-attaching: tearing down the old monitor flushes a beacon that rewrites the cookie.
-    reinitMuxData(getPropsWithState(), mediaEl, playbackCoreRef.current);
-    if (props.disableCookies) {
-      clearMuxDataCookies();
-    }
+    applyDisableCookies(getPropsWithState(), mediaElRef.current, playbackCoreRef.current);
   }, [props.disableCookies]);
 
   useEffect(() => {

--- a/packages/mux-video/src/base.ts
+++ b/packages/mux-video/src/base.ts
@@ -886,7 +886,7 @@ export class MuxVideoBaseElement extends CustomVideoElement implements IMuxVideo
 
   load() {
     initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
-    // The value Mux Data was just set up with. See the `disable-cookies` attribute handler.
+    // What Mux Data was just set up with. See the `disable-cookies` handler.
     this.#appliedDisableCookies = this.disableCookies;
   }
 
@@ -1002,21 +1002,17 @@ export class MuxVideoBaseElement extends CustomVideoElement implements IMuxVideo
       case Attributes.DISABLE_COOKIES: {
         if (newValue == null || newValue !== oldValue) {
           const disabled = this.disableCookies;
-          // Compare against the value Mux Data is actually running with, not against the
-          // attribute's previous string. Upgrading a server-rendered `<mux-video disable-cookies>`
-          // looks exactly like a revoke — both arrive with oldValue == null — and the monitor has
-          // already been created, from that same attribute, with the same value. Re-applying it
-          // would be a no-op, but clearing the cookie would drop a returning viewer's
-          // mux_viewer_id right before the client resolves consent and grants it, leaving Mux Data
-          // to mint a new one on every page load.
+          // Compare against what Mux Data is running with, not against oldValue: upgrading a
+          // server-rendered `<mux-video disable-cookies>` is indistinguishable from a revoke, and
+          // clearing there would drop a returning viewer's mux_viewer_id moments before the client
+          // resolves consent and grants it.
           if (!this.#core || this.#appliedDisableCookies === disabled) break;
           this.#appliedDisableCookies = disabled;
-          // Clearing the cookie isn't enough: mux-embed latched the old value when the monitor
-          // was created, so it would keep writing (or keep not writing) regardless. Re-attach
-          // Mux Data to pick up the new value. Unlike disable-tracking, this doesn't reload the media.
+          // Clearing the cookie isn't enough on its own: mux-embed latched the old value, so it
+          // would keep writing (or keep not writing) regardless.
           reinitMuxData(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
-          // Clear after re-attaching: tearing down the old monitor flushes a final beacon, which
-          // would re-write the cookie under the old value.
+          // Clear after re-attaching: tearing down the old monitor flushes a beacon that would
+          // rewrite the cookie under the old value.
           if (disabled) {
             clearMuxDataCookies();
           }

--- a/packages/mux-video/src/base.ts
+++ b/packages/mux-video/src/base.ts
@@ -1,5 +1,7 @@
 import {
+  clearMuxDataCookies,
   initialize,
+  reinitMuxData,
   teardown,
   generatePlayerInitTime,
   MuxMediaProps,
@@ -997,14 +999,16 @@ export class MuxVideoBaseElement extends CustomVideoElement implements IMuxVideo
       case Attributes.DISABLE_COOKIES: {
         if (newValue == null || newValue !== oldValue) {
           const disabled = this.disableCookies;
+          // Clearing the cookie isn't enough: mux-embed latched the old value when the monitor
+          // was created, so it would keep writing (or keep not writing) regardless. Re-attach
+          // Mux Data to pick up the new value. Unlike disable-tracking, this doesn't reload the media.
+          // Do this before clearing the cookie: tearing down the old monitor flushes a final
+          // beacon, which would re-write the cookie under the old value.
+          if (this.#core) {
+            reinitMuxData(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
+          }
           if (disabled) {
-            document.cookie.split(';').forEach((c) => {
-              if (c.trim().startsWith('muxData')) {
-                document.cookie = c
-                  .replace(/^ +/, '')
-                  .replace(/=.*/, '=;expires=' + new Date().toUTCString() + ';path=/');
-              }
-            });
+            clearMuxDataCookies();
           }
         }
         break;

--- a/packages/mux-video/src/base.ts
+++ b/packages/mux-video/src/base.ts
@@ -1,7 +1,6 @@
 import {
-  clearMuxDataCookies,
+  applyDisableCookies,
   initialize,
-  reinitMuxData,
   teardown,
   generatePlayerInitTime,
   MuxMediaProps,
@@ -111,7 +110,6 @@ export class MuxVideoBaseElement extends CustomVideoElement implements IMuxVideo
   }
 
   #loadRequested?: Promise<void> | null;
-  #appliedDisableCookies?: boolean;
   #defaultPlayerInitTime: number | undefined;
   #metadata: Metadata = {};
   #tokens: Tokens = {};
@@ -886,8 +884,6 @@ export class MuxVideoBaseElement extends CustomVideoElement implements IMuxVideo
 
   load() {
     initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
-    // What Mux Data was just set up with. See the `disable-cookies` handler.
-    this.#appliedDisableCookies = this.disableCookies;
   }
 
   unload() {
@@ -1001,21 +997,10 @@ export class MuxVideoBaseElement extends CustomVideoElement implements IMuxVideo
       }
       case Attributes.DISABLE_COOKIES: {
         if (newValue == null || newValue !== oldValue) {
-          const disabled = this.disableCookies;
-          // Compare against what Mux Data is running with, not against oldValue: upgrading a
-          // server-rendered `<mux-video disable-cookies>` is indistinguishable from a revoke, and
-          // clearing there would drop a returning viewer's mux_viewer_id moments before the client
-          // resolves consent and grants it.
-          if (!this.#core || this.#appliedDisableCookies === disabled) break;
-          this.#appliedDisableCookies = disabled;
-          // Clearing the cookie isn't enough on its own: mux-embed latched the old value, so it
-          // would keep writing (or keep not writing) regardless.
-          reinitMuxData(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
-          // Clear after re-attaching: tearing down the old monitor flushes a beacon that would
-          // rewrite the cookie under the old value.
-          if (disabled) {
-            clearMuxDataCookies();
-          }
+          // mux-embed latches the value when the monitor is created and has no setter for it, so
+          // Mux Data has to be re-attached to pick up a change. Unlike disable-tracking, that
+          // doesn't reload the media.
+          applyDisableCookies(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
         }
         break;
       }

--- a/packages/mux-video/src/base.ts
+++ b/packages/mux-video/src/base.ts
@@ -111,6 +111,7 @@ export class MuxVideoBaseElement extends CustomVideoElement implements IMuxVideo
   }
 
   #loadRequested?: Promise<void> | null;
+  #appliedDisableCookies?: boolean;
   #defaultPlayerInitTime: number | undefined;
   #metadata: Metadata = {};
   #tokens: Tokens = {};
@@ -885,6 +886,8 @@ export class MuxVideoBaseElement extends CustomVideoElement implements IMuxVideo
 
   load() {
     initialize(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
+    // The value Mux Data was just set up with. See the `disable-cookies` attribute handler.
+    this.#appliedDisableCookies = this.disableCookies;
   }
 
   unload() {
@@ -999,14 +1002,21 @@ export class MuxVideoBaseElement extends CustomVideoElement implements IMuxVideo
       case Attributes.DISABLE_COOKIES: {
         if (newValue == null || newValue !== oldValue) {
           const disabled = this.disableCookies;
+          // Compare against the value Mux Data is actually running with, not against the
+          // attribute's previous string. Upgrading a server-rendered `<mux-video disable-cookies>`
+          // looks exactly like a revoke — both arrive with oldValue == null — and the monitor has
+          // already been created, from that same attribute, with the same value. Re-applying it
+          // would be a no-op, but clearing the cookie would drop a returning viewer's
+          // mux_viewer_id right before the client resolves consent and grants it, leaving Mux Data
+          // to mint a new one on every page load.
+          if (!this.#core || this.#appliedDisableCookies === disabled) break;
+          this.#appliedDisableCookies = disabled;
           // Clearing the cookie isn't enough: mux-embed latched the old value when the monitor
           // was created, so it would keep writing (or keep not writing) regardless. Re-attach
           // Mux Data to pick up the new value. Unlike disable-tracking, this doesn't reload the media.
-          // Do this before clearing the cookie: tearing down the old monitor flushes a final
-          // beacon, which would re-write the cookie under the old value.
-          if (this.#core) {
-            reinitMuxData(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
-          }
+          reinitMuxData(this as Partial<MuxMediaProps>, this.nativeEl, this.#core);
+          // Clear after re-attaching: tearing down the old monitor flushes a final beacon, which
+          // would re-write the cookie under the old value.
           if (disabled) {
             clearMuxDataCookies();
           }

--- a/packages/mux-video/src/react.ts
+++ b/packages/mux-video/src/react.ts
@@ -5,13 +5,43 @@ import React from 'react';
 // keep as last import, ce-la-react is bundled.
 import { createComponent } from 'ce-la-react';
 
-export default createComponent({
+const MuxVideo = createComponent({
   react: React,
   tagName: 'mux-video',
   displayName: 'MuxVideo',
   elementClass: MuxVideoElement,
   toAttributeName,
 });
+
+type MuxVideoProps = React.ComponentProps<typeof MuxVideo>;
+
+/**
+ * `disable-cookies` is an observed attribute, so ce-la-react renders it as an attribute — and React
+ * never reconciles attributes during hydration, it only warns that the mismatch "won't be patched
+ * up". A server-rendered page can't read consent, so it has to emit the cookie-less state, and the
+ * player would stay stuck in it. Re-apply the value as a property after mount to get out of it.
+ */
+const MuxVideoWithConsent = React.forwardRef<MuxVideoElement, MuxVideoProps>((props, ref) => {
+  const innerRef = React.useRef<MuxVideoElement | null>(null);
+  const composedRef = React.useCallback(
+    (element: MuxVideoElement | null) => {
+      innerRef.current = element;
+      if (typeof ref === 'function') ref(element);
+      else if (ref) ref.current = element;
+    },
+    [ref]
+  );
+
+  React.useEffect(() => {
+    if (innerRef.current) innerRef.current.disableCookies = !!props.disableCookies;
+  }, [props.disableCookies]);
+
+  return React.createElement(MuxVideo, { ...props, ref: composedRef });
+});
+
+MuxVideoWithConsent.displayName = 'MuxVideo';
+
+export default MuxVideoWithConsent;
 
 const ReactPropToAttrNameMap: Record<string, string> = {
   autoPlay: 'autoplay',

--- a/packages/mux-video/test/index.test.js
+++ b/packages/mux-video/test/index.test.js
@@ -511,3 +511,256 @@ describe('<mux-video>', () => {
     });
   });
 });
+
+describe('<mux-video> disable-cookies', () => {
+  const PLAYBACK_ID = 'DS00Spx1CV902MCtPj5WknGlR102V5HFkDe';
+  const VIEWER_ID = 'test-viewer-id';
+
+  const readMuxDataCookie = () => document.cookie.split('; ').find((c) => c.startsWith('muxData')) ?? null;
+
+  const plantMuxDataCookie = () => {
+    document.cookie = `muxData==undefined&mux_viewer_id=${VIEWER_ID}&msn=0.5&sid=s&sst=1&sex=9999999999999;path=/;max-age=3600`;
+  };
+
+  const forgetMuxDataCookie = () => {
+    document.cookie = `muxData=;expires=${new Date(0).toUTCString()};path=/`;
+  };
+
+  /**
+   * Stand-in for mux-embed that records the options each monitor was created with, so a re-attached
+   * monitor can be told from a re-used one without sending beacons.
+   */
+  const createMuxDataSDKSpy = ({ flushOnDestroy = false, deferFlush = false } = {}) => {
+    const monitors = [];
+    // Stands in for the final beacon mux-embed sends from destroy(), which refreshes the cookie
+    // using the options the monitor was created with.
+    const flush = (options) => {
+      if (!flushOnDestroy || options.disableCookies) return;
+      const write = () => {
+        document.cookie = `muxData==undefined&sid=s&sst=1&sex=9999999999999;path=/;max-age=3600`;
+      };
+      if (deferFlush) Promise.resolve().then(write);
+      else write();
+    };
+    return {
+      monitors,
+      monitor(mediaEl, options) {
+        const record = { options, destroyed: false };
+        monitors.push(record);
+        mediaEl.mux = {
+          deleted: false,
+          emit() {},
+          addHLSJS() {},
+          removeHLSJS() {},
+          destroy() {
+            record.destroyed = true;
+            this.deleted = true;
+            flush(options);
+          },
+        };
+      },
+    };
+  };
+
+  /** Loads a player with the Mux Data SDK spied on from the very first monitor. */
+  const fixtureWithSpy = async (attrs = '', spyOptions) => {
+    const player = await fixture(`<mux-video muted ${attrs}></mux-video>`);
+    const muxDataSDK = createMuxDataSDKSpy(spyOptions);
+    player.muxDataSDK = muxDataSDK;
+    // Setting the playback id is what triggers the first load, and with it the first monitor.
+    player.playbackId = PLAYBACK_ID;
+    await aTimeout(50);
+    return { player, muxDataSDK };
+  };
+
+  afterEach(() => {
+    forgetMuxDataCookie();
+  });
+
+  it('re-attaches Mux Data when disable-cookies is turned on', async () => {
+    const { player, muxDataSDK } = await fixtureWithSpy();
+    assert.equal(muxDataSDK.monitors.length, 1, 'monitored once on load');
+    assert.notOk(muxDataSDK.monitors[0].options.disableCookies, 'cookies enabled to begin with');
+
+    player.disableCookies = true;
+    await aTimeout(0);
+
+    assert.equal(muxDataSDK.monitors.length, 2, 'monitor was re-created');
+    assert.isTrue(muxDataSDK.monitors[0].destroyed, 'the previous monitor was destroyed');
+    assert.isTrue(muxDataSDK.monitors[1].options.disableCookies, 'the new monitor has cookies disabled');
+  });
+
+  it('re-attaches Mux Data when disable-cookies is turned off', async () => {
+    const { player, muxDataSDK } = await fixtureWithSpy('disable-cookies');
+    assert.isTrue(muxDataSDK.monitors[0].options.disableCookies, 'cookies disabled to begin with');
+
+    player.disableCookies = false;
+    await aTimeout(0);
+
+    assert.equal(muxDataSDK.monitors.length, 2, 'monitor was re-created');
+    assert.notOk(muxDataSDK.monitors[1].options.disableCookies, 'the new monitor has cookies enabled');
+  });
+
+  it('does not re-attach Mux Data when the same value is re-applied', async () => {
+    const { player, muxDataSDK } = await fixtureWithSpy();
+
+    player.setAttribute('disable-cookies', '');
+    await aTimeout(0);
+    assert.equal(muxDataSDK.monitors.length, 2, 'the change was applied');
+
+    // attributeChangedCallback fires even when the value is identical.
+    player.setAttribute('disable-cookies', '');
+    await aTimeout(0);
+    assert.equal(muxDataSDK.monitors.length, 2, 'no monitor for a redundant re-apply');
+  });
+
+  it('coalesces several changes in the same tick into a single monitor', async () => {
+    const { player, muxDataSDK } = await fixtureWithSpy();
+
+    player.disableCookies = true;
+    player.disableCookies = false;
+    player.disableCookies = true;
+    await aTimeout(0);
+
+    assert.equal(muxDataSDK.monitors.length, 2, 'one monitor for the whole burst');
+    assert.isTrue(muxDataSDK.monitors[1].options.disableCookies, 'created with the settled value');
+  });
+
+  it('leaves Mux Data on the settled value when a change is reverted', async () => {
+    const { player, muxDataSDK } = await fixtureWithSpy();
+
+    // Same tick: the value the monitor is created with is read when it is created, not when the
+    // change came in, so a reverted change can't leave Mux Data out of sync with the attribute.
+    player.disableCookies = true;
+    player.disableCookies = false;
+    await aTimeout(0);
+
+    assert.notOk(muxDataSDK.monitors[muxDataSDK.monitors.length - 1].options.disableCookies);
+
+    // ...and the next real change is still picked up.
+    player.disableCookies = true;
+    await aTimeout(0);
+
+    assert.isTrue(muxDataSDK.monitors[muxDataSDK.monitors.length - 1].options.disableCookies);
+  });
+
+  it('applies a change and its revert in separate ticks', async () => {
+    const { player, muxDataSDK } = await fixtureWithSpy();
+
+    player.disableCookies = true;
+    await aTimeout(0);
+    player.disableCookies = false;
+    await aTimeout(0);
+
+    assert.equal(muxDataSDK.monitors.length, 3, 'monitored again for each change');
+    assert.isTrue(muxDataSDK.monitors[1].options.disableCookies);
+    assert.notOk(muxDataSDK.monitors[2].options.disableCookies);
+  });
+
+  it('does not reload the media when disable-cookies changes', async () => {
+    const { player } = await fixtureWithSpy();
+
+    const mediaEvents = [];
+    ['emptied', 'loadstart', 'abort'].forEach((type) => {
+      player.addEventListener(type, () => mediaEvents.push(type));
+    });
+
+    player.disableCookies = true;
+    await aTimeout(50);
+
+    assert.deepEqual(mediaEvents, [], 'the media element was left alone');
+  });
+
+  it('clears the muxData cookie when cookies are disabled at runtime', async () => {
+    const { player } = await fixtureWithSpy();
+    plantMuxDataCookie();
+
+    player.disableCookies = true;
+    await aTimeout(0);
+
+    assert.equal(readMuxDataCookie(), null, 'the cookie was cleared');
+  });
+
+  it('keeps an existing muxData cookie when it initializes with disable-cookies', async () => {
+    // A server-rendered page can't read consent, so it always emits the cookie-less state. Clearing
+    // there would drop a returning viewer's mux_viewer_id before consent can be granted.
+    plantMuxDataCookie();
+
+    const { muxDataSDK } = await fixtureWithSpy('disable-cookies');
+
+    assert.include(readMuxDataCookie(), VIEWER_ID, 'the cookie was left alone');
+    assert.equal(muxDataSDK.monitors.length, 1, 'no re-attach was needed');
+    assert.isTrue(muxDataSDK.monitors[0].options.disableCookies, 'and cookies are disabled');
+  });
+
+  it('clears the cookie even when a monitor flushes its final beacon asynchronously', async () => {
+    const { player } = await fixtureWithSpy('', { flushOnDestroy: true, deferFlush: true });
+    plantMuxDataCookie();
+
+    player.disableCookies = true;
+    await aTimeout(0);
+
+    assert.equal(readMuxDataCookie(), null, 'the flush cannot outlive the clear');
+  });
+
+  it('clears the shared cookie when several players are disabled at once', async () => {
+    // There is one cookie for every player on the page, and each teardown flush rewrites it, so the
+    // clears have to expire the cookie unconditionally instead of only what they just read.
+    const players = [];
+    for (let i = 0; i < 3; i += 1) {
+      players.push(await fixtureWithSpy('', { flushOnDestroy: true }));
+    }
+    plantMuxDataCookie();
+
+    players.forEach(({ player }) => {
+      player.disableCookies = true;
+    });
+    await aTimeout(0);
+
+    assert.equal(readMuxDataCookie(), null, 'no player is left holding the cookie');
+    players.forEach(({ muxDataSDK }, i) => {
+      assert.isTrue(muxDataSDK.monitors[1]?.options.disableCookies, `player ${i} re-attached with cookies off`);
+    });
+  });
+
+  it('clears the cookie with several players disabled in the same tick', async () => {
+    // Every player flushes a final beacon that rewrites the shared cookie, so the flushes and the
+    // clears must not interleave: one player writing after another has cleared would leave the
+    // cookie behind (session fields only, no mux_viewer_id).
+    const players = [];
+    for (let i = 0; i < 3; i++) {
+      players.push(await fixtureWithSpy('', { flushOnDestroy: true }));
+    }
+    plantMuxDataCookie();
+
+    players.forEach(({ player }) => {
+      player.disableCookies = true;
+    });
+    await aTimeout(0);
+
+    assert.equal(readMuxDataCookie(), null, 'no player wrote the cookie back after the clears');
+  });
+
+  it('keeps chapters and their text track across the change', async function () {
+    this.timeout(10000);
+
+    const player = await fixture(`<mux-video
+      playback-id="${PLAYBACK_ID}"
+      preload="metadata"
+      prefer-playback="mse"
+      muted
+    ></mux-video>`);
+    await oneEvent(player, 'loadstart');
+    await player.addChapters([
+      { startTime: 0, endTime: 5, value: 'One' },
+      { startTime: 5, endTime: 10, value: 'Two' },
+    ]);
+    const chaptersTrack = Array.from(player.textTracks).find((track) => track.kind === 'chapters');
+
+    player.disableCookies = true;
+    await aTimeout(50);
+
+    assert.equal(player.chapters.length, 2, 'chapters survived');
+    assert.isTrue(Array.from(player.textTracks).includes(chaptersTrack), 'and so did their text track');
+  });
+});

--- a/packages/mux-video/test/index.test.js
+++ b/packages/mux-video/test/index.test.js
@@ -642,7 +642,11 @@ describe('<mux-video>', () => {
   });
 });
 
-describe('<mux-video> disable-cookies', () => {
+describe('<mux-video> disable-cookies', function () {
+  // These load real media, and every wait below is on a condition rather than a delay, so give the
+  // slowest CI browser room instead of racing mocha's 2s default.
+  this.timeout(15000);
+
   const PLAYBACK_ID = 'DS00Spx1CV902MCtPj5WknGlR102V5HFkDe';
   const VIEWER_ID = 'test-viewer-id';
 
@@ -692,14 +696,34 @@ describe('<mux-video> disable-cookies', () => {
     };
   };
 
+  // waitUntil() defaults to a 1s timeout, which a loaded CI browser can blow through.
+  const WAIT = { timeout: 5000 };
+
+  const waitForMonitors = (muxDataSDK, count, message) =>
+    waitUntil(() => muxDataSDK.monitors.length >= count, message, WAIT);
+
+  const waitForNoMuxDataCookie = (message) => waitUntil(() => readMuxDataCookie() === null, message, WAIT);
+
+  /** Gives whatever a change kicked off time to surface, before asserting that nothing else did. */
+  const settle = () => aTimeout(50);
+
   /** Loads a player with the Mux Data SDK spied on from the very first monitor. */
   const fixtureWithSpy = async (attrs = '', spyOptions) => {
     const player = await fixture(`<mux-video muted ${attrs}></mux-video>`);
     const muxDataSDK = createMuxDataSDKSpy(spyOptions);
     player.muxDataSDK = muxDataSDK;
+
+    // The first load fires its own emptied/loadstart, and on a slow browser those can land well
+    // after the monitor does, so wait for them rather than for a fixed delay: a test watching for a
+    // reload would otherwise pick up the initial load.
+    let loadStarted = false;
+    player.addEventListener('loadstart', () => (loadStarted = true), { once: true });
+
     // Setting the playback id is what triggers the first load, and with it the first monitor.
     player.playbackId = PLAYBACK_ID;
-    await aTimeout(50);
+
+    await waitForMonitors(muxDataSDK, 1, 'Mux Data should monitor the first load');
+    await waitUntil(() => loadStarted, 'the first load should have started', WAIT);
     return { player, muxDataSDK };
   };
 
@@ -713,9 +737,8 @@ describe('<mux-video> disable-cookies', () => {
     assert.notOk(muxDataSDK.monitors[0].options.disableCookies, 'cookies enabled to begin with');
 
     player.disableCookies = true;
-    await aTimeout(0);
+    await waitForMonitors(muxDataSDK, 2, 'monitor should be re-created');
 
-    assert.equal(muxDataSDK.monitors.length, 2, 'monitor was re-created');
     assert.isTrue(muxDataSDK.monitors[0].destroyed, 'the previous monitor was destroyed');
     assert.isTrue(muxDataSDK.monitors[1].options.disableCookies, 'the new monitor has cookies disabled');
   });
@@ -725,9 +748,8 @@ describe('<mux-video> disable-cookies', () => {
     assert.isTrue(muxDataSDK.monitors[0].options.disableCookies, 'cookies disabled to begin with');
 
     player.disableCookies = false;
-    await aTimeout(0);
+    await waitForMonitors(muxDataSDK, 2, 'monitor should be re-created');
 
-    assert.equal(muxDataSDK.monitors.length, 2, 'monitor was re-created');
     assert.notOk(muxDataSDK.monitors[1].options.disableCookies, 'the new monitor has cookies enabled');
   });
 
@@ -735,12 +757,11 @@ describe('<mux-video> disable-cookies', () => {
     const { player, muxDataSDK } = await fixtureWithSpy();
 
     player.setAttribute('disable-cookies', '');
-    await aTimeout(0);
-    assert.equal(muxDataSDK.monitors.length, 2, 'the change was applied');
+    await waitForMonitors(muxDataSDK, 2, 'the change should be applied');
 
     // attributeChangedCallback fires even when the value is identical.
     player.setAttribute('disable-cookies', '');
-    await aTimeout(0);
+    await settle();
     assert.equal(muxDataSDK.monitors.length, 2, 'no monitor for a redundant re-apply');
   });
 
@@ -750,7 +771,8 @@ describe('<mux-video> disable-cookies', () => {
     player.disableCookies = true;
     player.disableCookies = false;
     player.disableCookies = true;
-    await aTimeout(0);
+    await waitForMonitors(muxDataSDK, 2, 'the burst should be applied');
+    await settle();
 
     assert.equal(muxDataSDK.monitors.length, 2, 'one monitor for the whole burst');
     assert.isTrue(muxDataSDK.monitors[1].options.disableCookies, 'created with the settled value');
@@ -763,13 +785,13 @@ describe('<mux-video> disable-cookies', () => {
     // change came in, so a reverted change can't leave Mux Data out of sync with the attribute.
     player.disableCookies = true;
     player.disableCookies = false;
-    await aTimeout(0);
+    await waitForMonitors(muxDataSDK, 2, 'the burst should be applied');
 
     assert.notOk(muxDataSDK.monitors[muxDataSDK.monitors.length - 1].options.disableCookies);
 
     // ...and the next real change is still picked up.
     player.disableCookies = true;
-    await aTimeout(0);
+    await waitForMonitors(muxDataSDK, 3, 'the next change should be applied');
 
     assert.isTrue(muxDataSDK.monitors[muxDataSDK.monitors.length - 1].options.disableCookies);
   });
@@ -778,17 +800,18 @@ describe('<mux-video> disable-cookies', () => {
     const { player, muxDataSDK } = await fixtureWithSpy();
 
     player.disableCookies = true;
-    await aTimeout(0);
+    await waitForMonitors(muxDataSDK, 2, 'the change should be applied');
     player.disableCookies = false;
-    await aTimeout(0);
+    await waitForMonitors(muxDataSDK, 3, 'the revert should be applied');
+    await settle();
 
-    assert.equal(muxDataSDK.monitors.length, 3, 'monitored again for each change');
+    assert.equal(muxDataSDK.monitors.length, 3, 'monitored again for each change, and no more');
     assert.isTrue(muxDataSDK.monitors[1].options.disableCookies);
     assert.notOk(muxDataSDK.monitors[2].options.disableCookies);
   });
 
   it('does not reload the media when disable-cookies changes', async () => {
-    const { player } = await fixtureWithSpy();
+    const { player, muxDataSDK } = await fixtureWithSpy();
 
     const mediaEvents = [];
     ['emptied', 'loadstart', 'abort'].forEach((type) => {
@@ -796,7 +819,9 @@ describe('<mux-video> disable-cookies', () => {
     });
 
     player.disableCookies = true;
-    await aTimeout(50);
+    // Anchored on the re-attach, so this can't pass just because the change hasn't landed yet.
+    await waitForMonitors(muxDataSDK, 2, 'Mux Data should be re-attached');
+    await settle();
 
     assert.deepEqual(mediaEvents, [], 'the media element was left alone');
   });
@@ -806,9 +831,8 @@ describe('<mux-video> disable-cookies', () => {
     plantMuxDataCookie();
 
     player.disableCookies = true;
-    await aTimeout(0);
 
-    assert.equal(readMuxDataCookie(), null, 'the cookie was cleared');
+    await waitForNoMuxDataCookie('the cookie should be cleared');
   });
 
   it('keeps an existing muxData cookie when it initializes with disable-cookies', async () => {
@@ -817,6 +841,7 @@ describe('<mux-video> disable-cookies', () => {
     plantMuxDataCookie();
 
     const { muxDataSDK } = await fixtureWithSpy('disable-cookies');
+    await settle();
 
     assert.include(readMuxDataCookie(), VIEWER_ID, 'the cookie was left alone');
     assert.equal(muxDataSDK.monitors.length, 1, 'no re-attach was needed');
@@ -828,14 +853,18 @@ describe('<mux-video> disable-cookies', () => {
     plantMuxDataCookie();
 
     player.disableCookies = true;
-    await aTimeout(0);
+    await waitForNoMuxDataCookie('the flush cannot outlive the clear');
 
-    assert.equal(readMuxDataCookie(), null, 'the flush cannot outlive the clear');
+    // The flush is what would write it back, so make sure it has run before calling this a pass.
+    await settle();
+    assert.equal(readMuxDataCookie(), null, 'and the flush did not resurrect it');
   });
 
-  it('clears the shared cookie when several players are disabled at once', async () => {
-    // There is one cookie for every player on the page, and each teardown flush rewrites it, so the
-    // clears have to expire the cookie unconditionally instead of only what they just read.
+  it('clears the shared cookie when several players are disabled in the same tick', async () => {
+    // There is one cookie for every player on the page, and each teardown flush rewrites it under
+    // the old value, so the clears have to expire the cookie unconditionally instead of only what
+    // they just read. One player writing after another has cleared would leave the cookie behind
+    // (session fields only, no mux_viewer_id).
     const players = [];
     for (let i = 0; i < 3; i += 1) {
       players.push(await fixtureWithSpy('', { flushOnDestroy: true }));
@@ -845,35 +874,19 @@ describe('<mux-video> disable-cookies', () => {
     players.forEach(({ player }) => {
       player.disableCookies = true;
     });
-    await aTimeout(0);
 
-    assert.equal(readMuxDataCookie(), null, 'no player is left holding the cookie');
-    players.forEach(({ muxDataSDK }, i) => {
-      assert.isTrue(muxDataSDK.monitors[1]?.options.disableCookies, `player ${i} re-attached with cookies off`);
-    });
-  });
-
-  it('clears the cookie with several players disabled in the same tick', async () => {
-    // Every player flushes a final beacon that rewrites the shared cookie, so the flushes and the
-    // clears must not interleave: one player writing after another has cleared would leave the
-    // cookie behind (session fields only, no mux_viewer_id).
-    const players = [];
-    for (let i = 0; i < 3; i++) {
-      players.push(await fixtureWithSpy('', { flushOnDestroy: true }));
+    await waitForNoMuxDataCookie('no player should be left holding the cookie');
+    for (const [i, { muxDataSDK }] of players.entries()) {
+      await waitForMonitors(muxDataSDK, 2, `player ${i} should have re-attached`);
+      assert.isTrue(muxDataSDK.monitors[1].options.disableCookies, `player ${i} re-attached with cookies off`);
     }
-    plantMuxDataCookie();
 
-    players.forEach(({ player }) => {
-      player.disableCookies = true;
-    });
-    await aTimeout(0);
-
+    // Every flush has to have run by now, and none of them may have written the cookie back.
+    await settle();
     assert.equal(readMuxDataCookie(), null, 'no player wrote the cookie back after the clears');
   });
 
-  it('keeps chapters and their text track across the change', async function () {
-    this.timeout(10000);
-
+  it('keeps chapters and their text track across the change', async () => {
     const player = await fixture(`<mux-video
       playback-id="${PLAYBACK_ID}"
       preload="metadata"
@@ -884,7 +897,8 @@ describe('<mux-video> disable-cookies', () => {
     // the event, which can fire before the fixture is even handed back.
     await waitUntil(
       () => Array.from(player.textTracks).some((track) => track.kind === 'chapters'),
-      'the chapters text track should be created'
+      'the chapters text track should be created',
+      WAIT
     );
     await player.addChapters([
       { startTime: 0, endTime: 5, value: 'One' },
@@ -892,8 +906,14 @@ describe('<mux-video> disable-cookies', () => {
     ]);
     const chaptersTrack = Array.from(player.textTracks).find((track) => track.kind === 'chapters');
 
+    // Real Mux Data here, so the re-attach is observed through the monitor it hangs off the media
+    // element rather than through a spy.
+    const monitorBefore = player.nativeEl.mux;
     player.disableCookies = true;
-    await aTimeout(50);
+    if (monitorBefore) {
+      await waitUntil(() => player.nativeEl.mux !== monitorBefore, 'Mux Data should be re-attached', WAIT);
+    }
+    await settle();
 
     assert.equal(player.chapters.length, 2, 'chapters survived');
     assert.isTrue(Array.from(player.textTracks).includes(chaptersTrack), 'and so did their text track');

--- a/packages/mux-video/test/index.test.js
+++ b/packages/mux-video/test/index.test.js
@@ -750,7 +750,12 @@ describe('<mux-video> disable-cookies', () => {
       prefer-playback="mse"
       muted
     ></mux-video>`);
-    await oneEvent(player, 'loadstart');
+    // playback-core creates the chapters track on loadstart, so waiting for the track avoids racing
+    // the event, which can fire before the fixture is even handed back.
+    await waitUntil(
+      () => Array.from(player.textTracks).some((track) => track.kind === 'chapters'),
+      'the chapters text track should be created'
+    );
     await player.addChapters([
       { startTime: 0, endTime: 5, value: 'One' },
       { startTime: 5, endTime: 10, value: 'Two' },

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -726,12 +726,24 @@ export const initialize = (props: Partial<MuxMediaPropsInternal>, mediaEl: HTMLM
   return newCore;
 };
 
-/** Expires any `muxData` cookie mux-embed has written for this origin. */
+/**
+ * Expires any `muxData` cookie mux-embed has written for this origin.
+ *
+ * `muxData` is expired unconditionally, not only when it is currently there: with several players on
+ * the page every monitor teardown flushes a final beacon that rewrites the cookie, so a write can
+ * land between reading `document.cookie` and expiring what was read.
+ */
 export const clearMuxDataCookies = () => {
+  const expires = new Date(0).toUTCString();
+  const names = new Set(['muxData']);
+
   document.cookie.split(';').forEach((c) => {
-    if (c.trim().startsWith('muxData')) {
-      document.cookie = c.replace(/^ +/, '').replace(/=.*/, '=;expires=' + new Date().toUTCString() + ';path=/');
-    }
+    const name = c.split('=')[0].trim();
+    if (name.startsWith('muxData')) names.add(name);
+  });
+
+  names.forEach((name) => {
+    document.cookie = `${name}=;expires=${expires};path=/`;
   });
 };
 
@@ -774,6 +786,38 @@ export const reinitMuxData = (
       setupMux(props, mediaEl, hls as HlsInterface | undefined);
     })
   );
+};
+
+/**
+ * Applies the current `disableCookies` value to Mux Data, if it differs from the one the running
+ * monitor was created with, and clears the cookie when turning it on.
+ *
+ * Only an actual change is acted on. At initialization "disabled" can just mean "consent isn't known
+ * yet" — a server-rendered page can't read consent, so it always emits the cookie-less state — and
+ * clearing there would drop a returning viewer's mux_viewer_id right before consent is granted.
+ */
+export const applyDisableCookies = (
+  props: Partial<MuxMediaPropsInternal>,
+  mediaEl?: HTMLMediaElement | null,
+  core?: PlaybackCore
+) => {
+  if (!mediaEl) return;
+
+  const disabled = !!props.disableCookies;
+  const state = muxMediaState.get(mediaEl);
+  // Nothing set up yet (so the value will be read when it is), or Mux Data already has this value.
+  if (!state || state.muxDataDisableCookies === disabled) return;
+
+  reinitMuxData(props, mediaEl, core);
+
+  if (disabled) {
+    // Clear on a microtask, so that with several players on the page every monitor has flushed its
+    // final beacon (which rewrites the cookie under the old value, synchronously) before any of the
+    // clears run. Re-read the value too: a change reverted within the same tick shouldn't clear.
+    Promise.resolve().then(() => {
+      if (props.disableCookies) clearMuxDataCookies();
+    });
+  }
 };
 
 export const teardown = (
@@ -1182,6 +1226,11 @@ export const setupMux = (
 ) => {
   const { envKey: env_key, disableTracking, muxDataSDK = mux, muxDataSDKOptions = {} } = props;
   const inferredEnv = isMuxVideoSrc(props);
+
+  // Remember what Mux Data is being set up with, so a later change can be told apart from the same
+  // value being re-applied. See applyDisableCookies().
+  const mediaState = muxMediaState.get(mediaEl);
+  if (mediaState) mediaState.muxDataDisableCookies = !!props.disableCookies;
 
   if (!disableTracking && (env_key || inferredEnv)) {
     const {

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -726,6 +726,66 @@ export const initialize = (props: Partial<MuxMediaPropsInternal>, mediaEl: HTMLM
   return newCore;
 };
 
+/**
+ * Expires any `muxData` cookie mux-embed has written for this origin.
+ */
+export const clearMuxDataCookies = () => {
+  document.cookie.split(';').forEach((c) => {
+    if (c.trim().startsWith('muxData')) {
+      document.cookie = c.replace(/^ +/, '').replace(/=.*/, '=;expires=' + new Date().toUTCString() + ';path=/');
+    }
+  });
+};
+
+const pendingMuxDataInit = new WeakMap<HTMLMediaElement, Promise<void>>();
+
+/**
+ * Re-attaches the Mux Data monitor to an already loaded media element, leaving the media
+ * (and the hls.js instance, if any) alone.
+ *
+ * mux-embed latches options like `disableCookies` when the monitor is created and provides
+ * no setter for them, so the only way to apply a change is to re-create the monitor. Note
+ * that this ends the in-flight view and starts a new one.
+ */
+export const reinitMuxData = (
+  props: Partial<MuxMediaPropsInternal>,
+  mediaEl?: HTMLMediaElement | null,
+  core?: PlaybackCore
+) => {
+  if (!mediaEl) return;
+
+  // Tear down synchronously, so nothing keeps being tracked (or written to the cookie) under the
+  // old options. destroy() flushes a final `viewend` and detaches its own hls.js listeners, so
+  // don't call removeHLSJS() first.
+  if (mediaEl.mux) {
+    if (!mediaEl.mux.deleted) mediaEl.mux.destroy();
+    // mux-embed leaves a `deleted: true` tombstone in place of the monitor. Drop it, otherwise
+    // the next monitor() warns about replacing existing listeners.
+    delete mediaEl.mux;
+  }
+
+  // Monitor on a microtask instead: a burst of changes in the same tick (a consent library firing
+  // several callbacks, an element sprouting attributes) then yields a single monitor, created once
+  // every prop has settled.
+  if (pendingMuxDataInit.has(mediaEl)) return;
+
+  pendingMuxDataInit.set(
+    mediaEl,
+    Promise.resolve().then(() => {
+      pendingMuxDataInit.delete(mediaEl);
+
+      const state = muxMediaState.get(mediaEl);
+      // Bail if the media was torn down, or something else re-monitored it, while we waited.
+      if (!state || (mediaEl.mux && !mediaEl.mux.deleted)) return;
+
+      // The hls.js instance outlives the monitor, so hand the current one to the new monitor:
+      // it's where mux-embed gets rendition, request and bandwidth data from.
+      const hls = (state.coreReference ?? core)?.engine;
+      setupMux(props, mediaEl, hls as HlsInterface | undefined);
+    })
+  );
+};
+
 export const teardown = (
   mediaEl?: HTMLMediaElement | null,
   core?: PlaybackCore,

--- a/packages/playback-core/src/index.ts
+++ b/packages/playback-core/src/index.ts
@@ -726,9 +726,7 @@ export const initialize = (props: Partial<MuxMediaPropsInternal>, mediaEl: HTMLM
   return newCore;
 };
 
-/**
- * Expires any `muxData` cookie mux-embed has written for this origin.
- */
+/** Expires any `muxData` cookie mux-embed has written for this origin. */
 export const clearMuxDataCookies = () => {
   document.cookie.split(';').forEach((c) => {
     if (c.trim().startsWith('muxData')) {
@@ -740,12 +738,10 @@ export const clearMuxDataCookies = () => {
 const pendingMuxDataInit = new WeakMap<HTMLMediaElement, Promise<void>>();
 
 /**
- * Re-attaches the Mux Data monitor to an already loaded media element, leaving the media
- * (and the hls.js instance, if any) alone.
- *
- * mux-embed latches options like `disableCookies` when the monitor is created and provides
- * no setter for them, so the only way to apply a change is to re-create the monitor. Note
- * that this ends the in-flight view and starts a new one.
+ * Re-attaches the Mux Data monitor to an already loaded media element, leaving the media (and the
+ * hls.js instance, if any) alone. mux-embed latches options like `disableCookies` when the monitor
+ * is created and provides no setter for them, so re-creating it is the only way to apply a change.
+ * Ends the in-flight view and starts a new one.
  */
 export const reinitMuxData = (
   props: Partial<MuxMediaPropsInternal>,
@@ -754,19 +750,14 @@ export const reinitMuxData = (
 ) => {
   if (!mediaEl) return;
 
-  // Tear down synchronously, so nothing keeps being tracked (or written to the cookie) under the
-  // old options. destroy() flushes a final `viewend` and detaches its own hls.js listeners, so
-  // don't call removeHLSJS() first.
   if (mediaEl.mux) {
+    // destroy() flushes a final `viewend` and then detaches its own hls.js listeners.
     if (!mediaEl.mux.deleted) mediaEl.mux.destroy();
-    // mux-embed leaves a `deleted: true` tombstone in place of the monitor. Drop it, otherwise
-    // the next monitor() warns about replacing existing listeners.
+    // Drop mux-embed's `deleted: true` tombstone, otherwise the next monitor() warns.
     delete mediaEl.mux;
   }
 
-  // Monitor on a microtask instead: a burst of changes in the same tick (a consent library firing
-  // several callbacks, an element sprouting attributes) then yields a single monitor, created once
-  // every prop has settled.
+  // Monitor on a microtask, so a burst of changes in the same tick yields a single monitor.
   if (pendingMuxDataInit.has(mediaEl)) return;
 
   pendingMuxDataInit.set(
@@ -778,8 +769,7 @@ export const reinitMuxData = (
       // Bail if the media was torn down, or something else re-monitored it, while we waited.
       if (!state || (mediaEl.mux && !mediaEl.mux.deleted)) return;
 
-      // The hls.js instance outlives the monitor, so hand the current one to the new monitor:
-      // it's where mux-embed gets rendition, request and bandwidth data from.
+      // hls.js outlives the monitor and is where rendition, request and bandwidth data come from.
       const hls = (state.coreReference ?? core)?.engine;
       setupMux(props, mediaEl, hls as HlsInterface | undefined);
     })

--- a/packages/playback-core/src/types.ts
+++ b/packages/playback-core/src/types.ts
@@ -245,6 +245,8 @@ export type MuxMediaState = WeakMap<
     retryCount?: number;
     networkError?: boolean;
     coreReference?: PlaybackCore;
+    /** The `disableCookies` value the current Mux Data monitor was created with. */
+    muxDataDisableCookies?: boolean;
   }
 >;
 


### PR DESCRIPTION
Related to https://github.com/muxinc/elements/issues/1193 — that one made `disableTracking` reactive, `disableCookies` was left behind.

### Description

`disableCookies` gates the persistent `muxData` cookie that players write through their built-in Mux Data. Today it only takes effect when a player initialises. Changing it afterwards doesn't work in either direction:

- **Turning it on** deletes the cookie, but the running Mux Data monitor writes it straight back on its next beacon, about 10 seconds later.
- **Turning it off** does nothing at all. The visitor's `mux_viewer_id` never comes back for the rest of the page.

That's a problem for consent flows. A consent manager answers after the page has rendered, so the value is almost always set *after* the player exists. The only way around it today is to not render the player until consent is known, which means it can't be server-rendered.

This PR makes the prop reactive, so a player can be rendered up front and told about consent later.

### Why it wasn't reactive

Mux Data reads `disableCookies` once, when its monitor is created, and there's no setter for it afterwards. So the only way to apply a change is to create a new monitor. `videojs/v10` reaches the same conclusion in its `MuxData` component, and this follows its shape — including its guards, so the two implementations stay comparable.

### How it works

When `disableCookies` changes, Mux Data is re-attached: the old monitor is torn down and a new one is created with the new value. The `<video>` element and the hls.js instance are left alone, so **playback isn't interrupted and anything attached to the element imperatively survives** — chapters, caption tracks, listeners. That's the difference from the `disable-tracking` branch right above it, which reloads the media and loses all of that.

`<mux-video>` and `<mux-audio>` both handle the attribute this way, and `<mux-player>` picks it up through the `<mux-video>` it renders. (`disable-tracking` is still init-only on `<mux-audio>`, same as before — that one reloads the media, so it's a separate conversation.)

Turning cookies back on reuses the existing `muxData` cookie if it's still there, so a returning visitor keeps their identity.

Two behaviours worth being explicit about:

**A change while a video is playing splits the Mux Data view in two** — one `viewend`, one new `viewstart`. It's inherent to re-creating the monitor, and it's the same behaviour as `videojs/v10`. Applying the change *before* playback starts costs nothing, because Mux Data only closes a view that had already started, and that's the common case for a consent banner.

**A player that initialises with cookies disabled no longer deletes an existing cookie.** It used to, and that turned out to be harmful: a server-rendered page can't read consent, so it always renders the cookie-less state, and deleting there wiped a returning visitor's `mux_viewer_id` moments before the client granted consent. Mux Data then minted a new identity on every page load. The element can't tell "the visitor declined" from "consent isn't known yet" — same markup, opposite meaning — so it now leaves the cookie alone and never writes to it. Apps that need a stale cookie cleared should do it themselves, where the real consent state is known.

### The React side

Making the element reactive isn't enough for server-rendered pages, because **React never reconciles attributes during hydration** — it warns that the mismatch "won't be patched up" and leaves the server's value in the DOM. So a server-rendered `disable-cookies` would stay there forever and the player would be stuck in the denied state.

`mux-player-react` and the `@mux/mux-video/react` wrapper now also apply `disableCookies` as a property after mount, which is what `mux-player-react` already does for `playbackId`, `metadata` and friends. That's the piece that makes a server-rendered, consent-gated player actually work.

`@mux/mux-video-react` and `@mux/mux-audio-react` are separate implementations with no custom element, so they got their own equivalent: an effect that watches the prop.

### Testing

13 unit tests in `packages/mux-video/test/index.test.js` (46 in the file now), covering both directions, no media reload, the cookie left alone at init, several changes in one tick collapsing into a single monitor, a change reverted in the same tick, and the cookie being cleared even when a monitor flushes its final beacon late or when several players are disabled at once.

`<mux-audio>` and `<mux-player>` get the same shape at a smaller scale, 6 and 5 tests, since everything they share lives in `playback-core`: both directions, no re-attach when the same value is re-applied, no media reload, the cookie cleared at runtime and left alone at init.

One existing test in the `<mux-video>` suite changed: the chapters one now waits for the chapters track instead of the `loadstart` event, which can fire before the listener is attached and made the test hang.

Verified manually with real playback on every flavour — `<mux-video>`, `<mux-audio>`, `<mux-player>`, `@mux/mux-video-react`, `@mux/mux-video/react`, `@mux/mux-audio-react` and `@mux/mux-player-react` — one at a time and then all seven on one page sharing a cookie, plus a server-render-and-hydrate harness on React 18 and 19:

- Revoking mid-playback deletes the cookie and it stays deleted well past the 10s heartbeat.
- Granting mid-playback brings `mux_viewer_id` back within a second, reusing the existing one.
- Zero `emptied` / `loadstart` / `waiting` events on any change, and the playhead never stops.
- Chapters and the caption `TextTrack` object identity survive every change.
- On a server-rendered page, a returning visitor keeps the same `mux_viewer_id` across reloads.
- One `viewstart` and zero `viewend` per player when consent resolves before playback starts.
- With seven players on one page, revoking clears the shared cookie once and none of them writes it back.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Mux Data monitoring, cookie handling, and viewer identity timing; mid-playback toggles split analytics views, but behavior is scoped and heavily tested for consent scenarios.
> 
> **Overview**
> Makes **`disableCookies`** take effect after the player loads, so consent managers can flip cookie behavior without remounting or delaying SSR.
> 
> **playback-core** adds `applyDisableCookies`, `reinitMuxData`, and `clearMuxDataCookies`. When the prop changes, Mux Data is torn down and re-monitored with the new option (mux-embed latches `disableCookies` at creation). Playback and hls.js stay untouched. Runtime disable clears the `muxData` cookie on a microtask (after teardown flushes); init with cookies off no longer deletes an existing cookie, so SSR “unknown consent” does not wipe `mux_viewer_id`. Bursts of changes in one tick coalesce to a single re-attach.
> 
> **Custom elements** (`mux-video`, `mux-audio`) route `disable-cookies` attribute changes through `applyDisableCookies` instead of only clearing cookies inline.
> 
> **React**: `mux-video-react` / `mux-audio-react` watch `props.disableCookies`; `mux-player-react` forwards it via `useObjectPropEffect`; `@mux/mux-video/react` re-applies `disableCookies` as a property after mount to fix hydration attribute mismatches.
> 
> Adds broad **unit tests** for re-attach, no media reload, cookie clearing, and multi-player edge cases; some existing tests get longer `waitUntil` timeouts for CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac5faa12748c27fa1b87e818469587cce7d8ee08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

