### PR TITLE
fix(mux-video, mux-audio): don't re-derive src when the element doesn't own the playback id

### DIFF
--- a/packages/mux-audio/src/index.ts
+++ b/packages/mux-audio/src/index.ts
@@ -568,7 +568,11 @@ class MuxAudioElement extends CustomAudioElement implements Partial<MuxMediaProp
       case Attributes.ASSET_START_TIME:
       case Attributes.ASSET_END_TIME:
       case Attributes.PLAYBACK_TOKEN:
-        this.src = toMuxVideoURL(this) as string;
+        // If the element does not own playback id, we treat it the src as externally-provided
+        // and we should not modify it.
+        if (this.hasAttribute(Attributes.PLAYBACK_ID)) {
+          this.src = toMuxVideoURL(this) as string;
+        }
         break;
       case Attributes.DEBUG: {
         const debug = this.debug;

--- a/packages/mux-audio/test/player.test.js
+++ b/packages/mux-audio/test/player.test.js
@@ -131,4 +131,36 @@ describe('<mux-audio>', () => {
       'currentPdt should be ~60 seconds greater than getStartDate'
     );
   });
+
+  describe('src derivation', () => {
+    it('re-derives src from attributes when it owns the playback id', async function () {
+      const player = await fixture(
+        `<mux-audio playback-id="UgKrPYAnjMjP6oMF4Kcs1gWVhtgYDR02EHQGnj022X1Xo" muted></mux-audio>`
+      );
+
+      player.setAttribute('custom-domain', 'example.com');
+      assert.equal(new URL(player.src).hostname, 'stream.example.com', 'src follows custom-domain');
+    });
+
+    it('leaves an externally set src alone', async function () {
+      // Same guard as mux-video, but it bites harder here: mux-audio's `playbackId` getter does
+      // not fall back to `toPlaybackIdFromSrc()`, so an externally supplied src yielded no URL at
+      // all and the recompute removed the src outright rather than merely dropping its params.
+      const src = 'https://stream.mux.com/UgKrPYAnjMjP6oMF4Kcs1gWVhtgYDR02EHQGnj022X1Xo.m3u8?redundant_streams=true';
+      const player = await fixture(`<mux-audio custom-domain="mux.com" src="${src}" muted></mux-audio>`);
+
+      assert.equal(player.src, src, 'src survives initial upgrade');
+
+      player.setAttribute('custom-domain', 'example.com');
+      assert.equal(player.src, src, 'src survives a custom-domain change');
+    });
+
+    it('leaves a non-Mux src alone', async function () {
+      const src = 'https://my-cdn.example.com/some/playlist.m3u8?sig=abc123';
+      const player = await fixture(`<mux-audio src="${src}" muted></mux-audio>`);
+
+      player.setAttribute('custom-domain', 'example.com');
+      assert.equal(player.src, src, 'src survives a custom-domain change');
+    });
+  });
 });

--- a/packages/mux-player/test/player.test.js
+++ b/packages/mux-player/test/player.test.js
@@ -635,6 +635,99 @@ describe('<mux-player>', () => {
     );
   });
 
+  it('should keep src-derived search params when custom-domain is set', async function () {
+    const player = await fixture(`<mux-player
+      stream-type="on-demand"
+      custom-domain="mux.com"
+      extra-source-params="foo=str&bar=true&baz=1"
+      asset-start-time="10"
+      asset-end-time="20"
+      playback-id="r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA"
+    ></mux-player>`);
+    const muxVideo = player.media;
+
+    // `custom-domain` is the only src input mux-player forwards to <mux-video>, so it used to
+    // trigger a src recompute on an element that has none of the other inputs, silently dropping
+    // every search param. `cast-src` is written from the same expression but never recomputed,
+    // so it doubles as an oracle for what `src` should be.
+    assert.equal(muxVideo.src, muxVideo.getAttribute('cast-src'), 'src should match cast-src');
+
+    const actualSrcUrl = new URL(muxVideo.src);
+    const expectedSrcUrl = new URL(
+      'https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8?foo=str&bar=true&baz=1&asset_start_time=10&asset_end_time=20'
+    );
+    assert.equal(actualSrcUrl.searchParams.size, expectedSrcUrl.searchParams.size);
+    expectedSrcUrl.searchParams.forEach((value, key) => {
+      assert.equal(actualSrcUrl.searchParams.get(key), value, `should preserve ${key}`);
+    });
+  });
+
+  it('should keep the default redundant_streams param when custom-domain is set', async function () {
+    const player = await fixture(`<mux-player
+      stream-type="on-demand"
+      custom-domain="mux.com"
+      playback-id="r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA"
+    ></mux-player>`);
+
+    assert.equal(
+      new URL(player.media.src).searchParams.get('redundant_streams'),
+      'true',
+      'should preserve mux-players default extraSourceParams'
+    );
+  });
+
+  it('should keep search params when custom-domain changes at runtime', async function () {
+    const player = await fixture(`<mux-player
+      stream-type="on-demand"
+      extra-source-params="foo=str"
+      playback-id="r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA"
+    ></mux-player>`);
+
+    player.setAttribute('custom-domain', 'example.com');
+    await aTimeout(50);
+
+    const url = new URL(player.media.src);
+    assert.equal(url.hostname, 'stream.example.com', 'domain is applied');
+    assert.equal(url.searchParams.get('foo'), 'str', 'extra-source-params survive');
+    assert.equal(player.media.src, player.media.getAttribute('cast-src'), 'src stays in sync with cast-src');
+  });
+
+  it('should update src when extra-source-params changes at runtime', async function () {
+    const player = await fixture(`<mux-player
+      stream-type="on-demand"
+      custom-domain="mux.com"
+      playback-id="r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA"
+      ></mux-player>`);
+
+    assert.equal(
+      new URL(player.media.src).searchParams.get('redundant_streams'),
+      'true',
+      'starts with the default params'
+    );
+
+    player.setAttribute('extra-source-params', 'foo=str&bar=1');
+    await aTimeout(50);
+
+    const params = new URL(player.media.src).searchParams;
+    assert.equal(params.get('foo'), 'str');
+    assert.equal(params.get('bar'), '1');
+    assert.isNull(params.get('redundant_streams'), 'explicit params replace the default');
+  });
+
+  it('should drop extra-source-params when a playback-token is present', async function () {
+    // By design: these params only apply to public playback ids, so with a signed URL they have
+    // to be signed into the token instead.
+    const player = await fixture(`<mux-player
+      stream-type="on-demand"
+      custom-domain="mux.com"
+      extra-source-params="foo=str"
+      playback-token="TOKEN"
+      playback-id="r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA"
+    ></mux-player>`);
+
+    assert.deepEqual([...new URL(player.media.src).searchParams.keys()], ['token'], 'only the token remains');
+  });
+
   describe('buffered behaviors', function () {
     it('should have an empty TimeRanges value by default', async function () {
       const playerEl = await fixture('<mux-player stream-type="on-demand"></mux-player>');

--- a/packages/mux-video/src/base.ts
+++ b/packages/mux-video/src/base.ts
@@ -939,7 +939,11 @@ export class MuxVideoBaseElement extends CustomVideoElement implements IMuxVideo
       case Attributes.ASSET_START_TIME:
       case Attributes.ASSET_END_TIME:
       case Attributes.PLAYBACK_TOKEN:
-        this.src = toMuxVideoURL(this) as string;
+        // If the element does not own playback id, we treat it the src as externally-provided
+        // and we should not modify it.
+        if (this.hasAttribute(Attributes.PLAYBACK_ID)) {
+          this.src = toMuxVideoURL(this) as string;
+        }
         break;
       case Attributes.DEBUG: {
         const debug = this.debug;

--- a/packages/mux-video/test/index.test.js
+++ b/packages/mux-video/test/index.test.js
@@ -20,6 +20,136 @@ describe('<mux-video>', () => {
     assert.equal(player.debug, false, 'debug is off');
   });
 
+  describe('src derivation', () => {
+    it('re-derives src from attributes when it owns the playback id', async function () {
+      const player = await fixture(`<mux-video
+        playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
+        stream-type="on-demand"
+        muted
+      ></mux-video>`);
+
+      player.setAttribute('custom-domain', 'example.com');
+      assert.equal(new URL(player.src).hostname, 'stream.example.com', 'src follows custom-domain');
+
+      player.setAttribute('asset-start-time', '10');
+      assert.equal(new URL(player.src).searchParams.get('asset_start_time'), '10', 'src follows asset-start-time');
+    });
+
+    it('leaves an externally set src alone, preserving its search params', async function () {
+      // Without a `playback-id`, `src` is the source of truth. Re-deriving it would round-trip
+      // through `toPlaybackIdFromSrc()`, which drops the query string — the params below only
+      // exist on the src, so a recompute would silently discard them. This is how mux-player
+      // uses <mux-video>: it computes the full src itself and forwards `custom-domain` too.
+      const src =
+        'https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8?redundant_streams=true&asset_start_time=10';
+      const player = await fixture(`<mux-video
+        custom-domain="mux.com"
+        src="${src}"
+        stream-type="on-demand"
+        muted
+      ></mux-video>`);
+
+      assert.equal(player.src, src, 'src survives initial upgrade');
+
+      player.setAttribute('custom-domain', 'example.com');
+      assert.equal(player.src, src, 'src survives a custom-domain change');
+    });
+
+    it('leaves a non-Mux src alone', async function () {
+      // `toPlaybackIdFromSrc()` yields undefined for any src outside `https://stream.`, so
+      // `toMuxVideoURL()` returns undefined and the recompute used to blow the src away entirely.
+      const src = 'https://my-cdn.example.com/some/playlist.m3u8?sig=abc123';
+      const player = await fixture(`<mux-video src="${src}" stream-type="on-demand" muted></mux-video>`);
+
+      player.setAttribute('custom-domain', 'example.com');
+      assert.equal(player.src, src, 'src survives a custom-domain change');
+    });
+
+    it('keeps params carried on a parameterized playback-id', async function () {
+      // A playback id may carry its own query (`toPlaybackIdParts` splits it back off), so those
+      // params have to survive a recompute even though no attribute holds them.
+      const player = await fixture(`<mux-video
+        playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe?foo=bar"
+        muted
+      ></mux-video>`);
+
+      assert.equal(new URL(player.src).searchParams.get('foo'), 'bar', 'param present initially');
+
+      player.setAttribute('custom-domain', 'example.com');
+      const url = new URL(player.src);
+      assert.equal(url.hostname, 'stream.example.com', 'domain updated');
+      assert.equal(url.searchParams.get('foo'), 'bar', 'param survives the recompute');
+    });
+
+    it('drops non-token params when a playback-token is present', async function () {
+      // Intentional: these params only work on public playback ids, so with a signed URL they
+      // have to be baked into the token instead. Pinned so the guard above isn't mistaken for a
+      // promise that every param always survives.
+      const player = await fixture(`<mux-video
+        playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
+        asset-start-time="10"
+        playback-token="TOKEN"
+        muted
+      ></mux-video>`);
+
+      player.setAttribute('custom-domain', 'example.com');
+      const url = new URL(player.src);
+      assert.equal(url.hostname, 'stream.example.com', 'domain still updates');
+      assert.deepEqual([...url.searchParams.keys()], ['token'], 'only the token remains');
+    });
+
+    it('takes over src derivation once a playback-id is added', async function () {
+      const player = await fixture(`<mux-video
+        src="https://stream.mux.com/OTHERID.m3u8?redundant_streams=true"
+        custom-domain="mux.com"
+        muted
+      ></mux-video>`);
+
+      player.setAttribute('playback-id', 'DS00Spx1CV902MCtPj5WknGlR102V5HFkDe');
+      assert.equal(
+        player.src,
+        'https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8',
+        'an explicit playback-id wins over the previous src'
+      );
+    });
+
+    it('leaves src alone when playback-id is removed', async function () {
+      const player = await fixture(`<mux-video
+        playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
+        custom-domain="example.com"
+        muted
+      ></mux-video>`);
+      const derived = player.src;
+
+      player.removeAttribute('playback-id');
+      assert.equal(player.src, derived, 'removing playback-id is a no-op on src');
+    });
+
+    it('falls back to the default domain when custom-domain is removed', async function () {
+      const player = await fixture(`<mux-video
+        playback-id="DS00Spx1CV902MCtPj5WknGlR102V5HFkDe"
+        custom-domain="example.com"
+        muted
+      ></mux-video>`);
+
+      player.removeAttribute('custom-domain');
+      assert.equal(new URL(player.src).hostname, 'stream.mux.com', 'src falls back to stream.mux.com');
+    });
+
+    it('clears src for a present-but-empty playback-id', async function () {
+      // Long-standing behavior, not introduced by the guard: the guard keys on the attribute
+      // being *present*, and an empty playback id yields no URL at all. `removeAttribute` is the
+      // non-destructive way to step back from owning the src.
+      const player = await fixture(`<mux-video
+        playback-id=""
+        src="https://stream.mux.com/DS00Spx1CV902MCtPj5WknGlR102V5HFkDe.m3u8?redundant_streams=true"
+        muted
+      ></mux-video>`);
+
+      assert.isNull(player.src, 'an empty playback-id clears the src');
+    });
+  });
+
   it('dispatches events properly', async function () {
     this.timeout(10000);
 


### PR DESCRIPTION
Closes https://github.com/muxinc/elements/issues/1351

`<mux-video>` should only derive its own src when it owns the playback-id. An externally supplied src is the source of truth and must not be rebuilt from attributes.

## Problem:

`attributeChangedCallback` recomputed `this.src = toMuxVideoURL(this)` for ten attributes since #1286. Of those, `custom-domain` is the only one mux-player actually forwards to `<mux-video>`, and it's destructive, because:

- mux-player computes the full `src` itself from `extraSourceParams` (which could include stuff like `redundant_streams: true` by default) and passes src, never playback-id.
- `get playbackId()` (mux-video) therefore falls back to `toPlaybackIdFromSrc(this.src)`, which splits on .m3u8 and discards the query string.
- mux-video has no access to `extraSourceParams` as these belong to mux player.
- So the recompute derives a bare playback id from the src it's about to overwrite, then rebuilds it with strictly less state than the template had. cast-src isn't in the recompute list, so it survives with the right value.

## Fix:
Added a guard in both mux-video and mux-audio to only re-derive src if not explicitly set, i.e., it has a playback id attribute.
Also added a bunch of tests 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core media URL update behavior on attribute changes; wrong guard logic could break playback-id-driven URLs or leave stale src, but scope is narrow and well covered by new tests.
> 
> **Overview**
> Fixes a regression where changing attributes like **`custom-domain`** on `<mux-video>` / `<mux-audio>` always recomputed `src` via `toMuxVideoURL()`, which stripped query params and could clear externally supplied URLs.
> 
> **`<mux-video>` and `<mux-audio>`** now only rebuild `src` when the element **owns** a `playback-id` attribute; if `src` was provided without `playback-id`, attribute updates leave it unchanged (including non-Mux playlists). Derivation from `playback-id` still runs for domain, clip, token, and related attrs.
> 
> This especially fixes **`<mux-player>`**, which builds the full playlist URL (e.g. `extra-source-params`, `redundant_streams`, clip times) on the inner media element but only forwards `custom-domain`—so a domain change no longer wipes those params or desyncs `src` from `cast-src`.
> 
> Adds regression tests for src derivation on mux-video/mux-audio and mux-player URL param preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57ab1e68e2fb1f38e605180a676792838982f9d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->