### PR TITLE
chore: update release please action to use node 24

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: .github/release-please/release-please-config.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install playwright browsers
         run: npx playwright install --with-deps
       # Retry the test command up to 3 times with a timeout of 10 minutes
-      - uses: nick-fields/retry@v3
+      - uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 6


### PR DESCRIPTION
`release` step is failing currently showing an error and a warning. This change fixes just the warning about node 20 deprecation. The error is likely unrelated, but upgrading in hopes that this fixes both.
<img width="1559" height="300" alt="image" src="https://github.com/user-attachments/assets/36f2f288-0d04-4f15-bd3d-4c25baee7e5f" />
 
https://github.com/muxinc/elements/actions/runs/34361034453

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only third-party action version bumps with no runtime or application logic changes.
> 
> **Overview**
> Bumps GitHub Actions in CI/CD workflows to newer major versions: **`googleapis/release-please-action`** from v4 to v5 in the production release job (intended to clear Node 20 deprecation warnings on the failing release step), and **`nick-fields/retry`** from v3 to v4 in the CI test job. No application or package code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce336d214004bd8a2cfdd11d29b783d3f0c4a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->